### PR TITLE
Add node visitor pattern + implement internal references (the `:ref:` role)

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/MarkupLanguageParser.php
+++ b/packages/guides-restructured-text/src/RestructuredText/MarkupLanguageParser.php
@@ -6,6 +6,7 @@ namespace phpDocumentor\Guides\RestructuredText;
 
 use phpDocumentor\Guides\MarkupLanguageParser as ParserInterface;
 use phpDocumentor\Guides\Nodes\DocumentNode;
+use phpDocumentor\Guides\NodeTransformer\NodeTransformer;
 use phpDocumentor\Guides\ParserContext;
 use phpDocumentor\Guides\RestructuredText\Directives\AdmonitionDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\BestPracticeDirective;
@@ -52,6 +53,9 @@ class MarkupLanguageParser implements ParserInterface
     /** @var Directive[] */
     private $directives = [];
 
+    /** @var iterable<NodeTransformer> */
+    private $transformers;
+
     /** @var string|null */
     private $filename = null;
 
@@ -60,10 +64,14 @@ class MarkupLanguageParser implements ParserInterface
 
     /**
      * @param iterable<Directive> $directives
+     * @param iterable<NodeTransformer> $transformers
      */
     public function __construct(
-        iterable $directives
+        iterable $directives,
+        iterable $transformers = []
     ) {
+        $this->transformers = $transformers;
+
         foreach ($directives as $directive) {
             $this->registerDirective($directive);
         }
@@ -169,6 +177,6 @@ class MarkupLanguageParser implements ParserInterface
 
     private function createDocumentParser(): DocumentParser
     {
-        return new DocumentParser($this, $this->directives);
+        return new DocumentParser($this, $this->directives, $this->transformers);
     }
 }

--- a/packages/guides/src/Metas.php
+++ b/packages/guides/src/Metas.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides;
 
 use phpDocumentor\Guides\Meta\Entry;
+use phpDocumentor\Guides\References\InternalTarget;
 
 final class Metas
 {
@@ -22,6 +23,9 @@ final class Metas
 
     /** @var string[] */
     private $parents = [];
+
+    /** @var array<string, InternalTarget> */
+    private $internalLinkTargets = [];
 
     /**
      * @param Entry[] $entries
@@ -97,5 +101,15 @@ final class Metas
     public function setMetaEntries(array $metaEntries): void
     {
         $this->entries = $metaEntries;
+    }
+
+    public function addLinkTarget(string $anchorName, InternalTarget $target): void
+    {
+        $this->internalLinkTargets[$anchorName] = $target;
+    }
+
+    public function getInternalTarget(string $anchorName): ?InternalTarget
+    {
+        return $this->internalLinkTargets[$anchorName] ?? null;
     }
 }

--- a/packages/guides/src/NodeTransformer/CollectLinkTargetsTransformer.php
+++ b/packages/guides/src/NodeTransformer/CollectLinkTargetsTransformer.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\NodeTransformer;
+
+use Webmozart\Assert\Assert;
+use phpDocumentor\Guides\Metas;
+use phpDocumentor\Guides\Nodes\AnchorNode;
+use phpDocumentor\Guides\Nodes\DocumentNode;
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\References\InternalTarget;
+
+class CollectLinkTargetsTransformer implements NodeTransformer
+{
+    /** @var Metas */
+    private $metas;
+
+    /** @var DocumentNode|null */
+    private $currentDocument = null;
+
+    public function __construct(Metas $metas)
+    {
+        $this->metas = $metas;
+    }
+
+    public function enterNode(Node $node): Node
+    {
+        if ($node instanceof DocumentNode) {
+            $this->currentDocument = $node;
+        } elseif ($node instanceof AnchorNode) {
+            Assert::notNull($this->currentDocument);
+
+            $this->metas->addLinkTarget(
+                $node->getValueString(),
+                new InternalTarget($this->currentDocument->getFilePath(), $node->getValueString())
+            );
+        }
+
+        return $node;
+    }
+
+    public function leaveNode(Node $node): Node
+    {
+        if ($node instanceof DocumentNode) {
+            $this->currentDocument = null;
+        }
+
+        return $node;
+    }
+
+    public function supports(Node $node): bool
+    {
+        return $node instanceof DocumentNode || $node instanceof AnchorNode;
+    }
+}

--- a/packages/guides/src/NodeTransformer/DocumentNodeTraverser.php
+++ b/packages/guides/src/NodeTransformer/DocumentNodeTraverser.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\NodeTransformer;
+
+use phpDocumentor\Guides\Nodes\DocumentNode;
+use phpDocumentor\Guides\Nodes\Node;
+
+class DocumentNodeTraverser
+{
+    /** @var iterable<NodeTransformer> */
+    private $transformers;
+
+    /**
+     * @param iterable<NodeTransformer> $transformers
+     */
+    public function __construct(iterable $transformers)
+    {
+        $this->transformers = $transformers;
+    }
+
+    public function traverse(DocumentNode $node): Node
+    {
+        foreach ($this->transformers as $transformer) {
+            $node = $this->traverseForTransformer($transformer, $node);
+        }
+
+        return $node;
+    }
+
+    private function traverseForTransformer(NodeTransformer $transformer, Node $node): Node
+    {
+        if ($supports = $transformer->supports($node)) {
+            $node = $transformer->enterNode($node);
+        }
+
+        foreach ($node->getChildren() as $childNode) {
+            $node = $this->traverseForTransformer($transformer, $childNode);
+        }
+
+        if ($supports) {
+            $node = $transformer->leaveNode($node);
+        }
+
+        return $node;
+    }
+}

--- a/packages/guides/src/NodeTransformer/NodeTransformer.php
+++ b/packages/guides/src/NodeTransformer/NodeTransformer.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\NodeTransformer;
+
+use phpDocumentor\Guides\Nodes\Node;
+
+interface NodeTransformer
+{
+    /**
+     * @template T of Node
+     * @param T $node
+     * @return T
+     */
+    public function enterNode(Node $node): Node;
+
+    /**
+     * @template T of Node
+     * @param T $node
+     * @return T
+     */
+    public function leaveNode(Node $node): Node;
+
+    public function supports(Node $node): bool;
+}

--- a/packages/guides/src/Nodes/DocumentNode.php
+++ b/packages/guides/src/Nodes/DocumentNode.php
@@ -84,6 +84,11 @@ final class DocumentNode extends Node
         return array_filter($this->nodes, $function);
     }
 
+    public function getChildren(): array
+    {
+        return $this->nodes;
+    }
+
     public function getTitle(): ?TitleNode
     {
         foreach ($this->nodes as $node) {

--- a/packages/guides/src/Nodes/ListNode.php
+++ b/packages/guides/src/Nodes/ListNode.php
@@ -40,6 +40,11 @@ final class ListNode extends Node
         return $this->items;
     }
 
+    public function getChildren(): array
+    {
+        return $this->items;
+    }
+
     public function isOrdered(): bool
     {
         return $this->ordered;

--- a/packages/guides/src/Nodes/Node.php
+++ b/packages/guides/src/Nodes/Node.php
@@ -131,6 +131,15 @@ abstract class Node
         return isset($this->options[$name]);
     }
 
+    public function getChildren(): array
+    {
+        if ($this->value instanceof Node && !$this->value instanceof SpanNode) {
+            return [$this->value];
+        }
+
+        return [];
+    }
+
     /**
      * @param string[] $lines
      */

--- a/packages/guides/src/Parser.php
+++ b/packages/guides/src/Parser.php
@@ -27,10 +27,10 @@ use function getcwd;
  */
 final class Parser
 {
-    /** @var ?ParserContext */
+    /** @var ParserContext|null */
     private $parserContext = null;
 
-    /** @var ?Metas */
+    /** @var Metas|null */
     private $metas = null;
 
 

--- a/packages/guides/src/References/InternalTarget.php
+++ b/packages/guides/src/References/InternalTarget.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\References;
+
+class InternalTarget
+{
+    /** @var string */
+    private $documentPath;
+
+    /** @var string */
+    private $anchorName;
+
+    public function __construct(string $documentPath, string $anchorName)
+    {
+        $this->documentPath = $documentPath;
+        $this->anchorName = $anchorName;
+    }
+
+    public function getDocumentPath(): string
+    {
+        return $this->documentPath;
+    }
+
+    public function getAnchor(): string
+    {
+        return $this->anchorName;
+    }
+}

--- a/packages/guides/src/References/Resolver/DocResolver.php
+++ b/packages/guides/src/References/Resolver/DocResolver.php
@@ -13,7 +13,7 @@ final class DocResolver implements Resolver
 {
     public function supports(CrossReferenceNode $node, RenderContext $context): bool
     {
-        return $node->getRole() === 'doc' || $node->getRole() === 'ref';
+        return $node->getRole() === 'doc';
     }
 
     public function resolve(CrossReferenceNode $node, RenderContext $context): ?ResolvedReference

--- a/packages/guides/src/References/Resolver/RefResolver.php
+++ b/packages/guides/src/References/Resolver/RefResolver.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\References\Resolver;
+
+use phpDocumentor\Guides\Meta\Entry;
+use phpDocumentor\Guides\References\ResolvedReference;
+use phpDocumentor\Guides\RenderContext;
+use phpDocumentor\Guides\Span\CrossReferenceNode;
+
+final class RefResolver implements Resolver
+{
+    public function supports(CrossReferenceNode $node, RenderContext $context): bool
+    {
+        return $node->getRole() === 'ref';
+    }
+
+    public function resolve(CrossReferenceNode $node, RenderContext $context): ?ResolvedReference
+    {
+        $url = $node->getUrl();
+
+        $target = $context->getMetas()->getInternalTarget($url);
+        if ($target === null) {
+            return null;
+        }
+
+        $filePath = $context->canonicalUrl($target->getDocumentPath());
+        if ($filePath === null) {
+            return null;
+        }
+
+        return new ResolvedReference($url, $node->getText(), $context->relativeDocUrl($filePath, $target->getAnchor()));
+    }
+}


### PR DESCRIPTION
Fixes #16 

As promised, this PR fixes the `:ref:` role implementation. It is used to link to internal hyperlink targets *within the project* (i.e. can also be used for explicit hyperlink targets in other documents).

Node transformers (visitor pattern)
---

I also added the concept of a "node transformer" (or node visitor), which makes it easy to collect all `AnchorNodes` - so it can be used by the `RefResolver`.

Node transformers is a pattern that Python Sphinx & docutils (rst parser) use a lot: https://github.com/docutils-mirror/docutils/tree/e88c5fb08d5cdfa8b4ac1020dd6f7177778d5990/docutils/transforms They allow to remove more state awareness from the parser/nodes to visitors, e.g. the whole generation of `Metas`/meta entries can be removed from `Parser`  and the nodes into a visitor in the future.
Transformers also allow to add or "collapse" nodes (e.g. create the section nodes based on title nodes, or apply `.. class::` directives on the adjacent node). You can see some more ideas in https://github.com/doctrine/rst-parser/issues/145

For the implementation, I've used Twig's node visitor as a base, as this is a proven pattern in Twig.

Metas
---

I'm not so sure about the role of the `Metas` object in the current guides, and I see there also is a "TODO" item about this in `DocResolver`. In my test project, I've defined `Metas` as a service, which allowed me to directly inject it in the `RefResolver`. This works great in the test project of the Symfony docs. However, the `Parser` somehow resets and creates a new `Metas` instance in some circumstances, breaking this implementation.

Maybe it is a good idea to discuss how `Metas` have to work (also in relation to node transformers) and refactor this part of the Parser as well. cc @jaapio @mvriel 