### PR TITLE
Metas: Implement section target and conflict resolution

### DIFF
--- a/packages/guides/examples/render_docs.php
+++ b/packages/guides/examples/render_docs.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+use phpDocumentor\Guides\Compiler\Passes\TransformerPass;
 use phpDocumentor\Guides\Handlers\RenderDocumentHandler;
 use phpDocumentor\Guides\Handlers\RenderDocumentCommand;
 use phpDocumentor\Guides\RenderContext;
@@ -65,7 +66,7 @@ $parseDirCommand = new ParseDirectoryCommand(
 $documents = $parseDirectoryHandler->handle($parseDirCommand);
 $compliler = new phpDocumentor\Guides\Compiler\Compiler([
     new \phpDocumentor\Guides\Compiler\MetasPass($metas),
-    new \phpDocumentor\Guides\Compiler\TransformerPass(
+    new phpDocumentor\Guides\Compiler\Passes\TransformerPass(
         new \phpDocumentor\Guides\Compiler\DocumentNodeTraverser(
             [
                 new \phpDocumentor\Guides\Compiler\NodeTransformers\TocNodeTransformer($metas)

--- a/packages/guides/src/Compiler/NodeTransformers/TocNodeTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/TocNodeTransformer.php
@@ -64,7 +64,7 @@ final class TocNodeTransformer implements NodeTransformer
         //If Toctree is defined at level 2, and max is 3, only titles of the documents are added to the toctree.
 
         foreach ($document->getChildren() as $child) {
-            yield from $this->buildLevel($child, $document, $depth, $node);
+            yield from $this->buildLevel($child, $document, $depth, $node, true);
         }
     }
 
@@ -80,16 +80,16 @@ final class TocNodeTransformer implements NodeTransformer
         }
 
         foreach ($entry->getChildren() as $child) {
-            yield from $this->buildLevel($child, $document, $depth, $node);
+            yield from $this->buildLevel($child, $document, $depth, $node, false);
         }
     }
 
     /** @return Traversable<Entry> */
-    private function buildLevel(MetaEntry $child, DocumentEntry $document, int $depth, TocNode $node): Traversable
+    private function buildLevel(MetaEntry $child, DocumentEntry $document, int $depth, TocNode $node, bool $isDocumentRoot): Traversable
     {
         if ($child instanceof SectionEntry) {
             yield new Entry(
-                $document->getFile(),
+                $document->getFile().($isDocumentRoot ? '' : '#'.$child->getId()),
                 $child->getTitle(),
                 iterator_to_array($this->buildFromSection($document, $child, ++$depth, $node), false)
             );

--- a/packages/guides/src/Compiler/Passes/ImplicitHyperlinkTargetPass.php
+++ b/packages/guides/src/Compiler/Passes/ImplicitHyperlinkTargetPass.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Compiler\Passes;
+
+use phpDocumentor\Guides\Compiler\CompilerPass;
+use phpDocumentor\Guides\Nodes\AnchorNode;
+use phpDocumentor\Guides\Nodes\DocumentNode;
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\Nodes\SectionNode;
+
+/**
+ * Resolves the hyperlink target for each section in the document.
+ *
+ * This follows the reStructuredText rules as outlined in:
+ * https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#implicit-hyperlink-targets
+ */
+class ImplicitHyperlinkTargetPass implements CompilerPass
+{
+    public function getPriority(): int
+    {
+        return 20000; // must be run *before* MetasPass
+    }
+
+    public function run(array $documents): array
+    {
+        return array_map(function (DocumentNode $document) {
+            // implicit references must not conflict with explicit ones
+            $knownReferences = $explicitReferences = $this->fetchExplicitReferences($document);
+
+            $nodes = $document->getNodes();
+            $node = current($nodes);
+            do {
+                if ($node instanceof AnchorNode) {
+                    // override implicit section reference if an anchor precedes the section
+                    $key = key($nodes);
+                    $section = next($nodes);
+                    if (!$section instanceof SectionNode) {
+                        prev($nodes);
+                        continue;
+                    }
+
+                    $section->getTitle()->setId($node->getValueString());
+
+                    $document = $document->removeNode($key);
+
+                    continue;
+                }
+
+                if ($node instanceof SectionNode) {
+                    $realId = $sectionId = $node->getTitle()->getId();
+
+                    // resolve conflicting references by appending an increasing number
+                    $i = 1;
+                    while (\in_array($realId, $knownReferences, true)) {
+                        $realId = $sectionId . '-' . ($i++);
+                    }
+
+                    $node->getTitle()->setId($realId);
+                    $knownReferences[] = $realId;
+                }
+            } while ($node = next($nodes));
+
+            return $document;
+        }, $documents);
+    }
+
+    private function fetchExplicitReferences(Node $node): array
+    {
+        if ($node instanceof AnchorNode) {
+            return [$node->getValueString()];
+        }
+
+        $anchors = [];
+        foreach ($node->getChildren() as $child) {
+            $anchors[] = $this->fetchExplicitReferences($child);
+        }
+
+        return array_merge(...$anchors);
+    }
+}

--- a/packages/guides/src/Compiler/Passes/MetasPass.php
+++ b/packages/guides/src/Compiler/Passes/MetasPass.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace phpDocumentor\Guides\Compiler;
+namespace phpDocumentor\Guides\Compiler\Passes;
 
+use phpDocumentor\Guides\Compiler\CompilerPass;
 use phpDocumentor\Guides\Meta\DocumentEntry;
 use phpDocumentor\Guides\Meta\DocumentReferenceEntry;
 use phpDocumentor\Guides\Meta\Entry;

--- a/packages/guides/src/Compiler/Passes/TransformerPass.php
+++ b/packages/guides/src/Compiler/Passes/TransformerPass.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-namespace phpDocumentor\Guides\Compiler;
+namespace phpDocumentor\Guides\Compiler\Passes;
+
+use phpDocumentor\Guides\Compiler\DocumentNodeTraverser;
+use phpDocumentor\Guides\Compiler\CompilerPass;
 
 final class TransformerPass implements CompilerPass
 {

--- a/packages/guides/src/Meta/SectionEntry.php
+++ b/packages/guides/src/Meta/SectionEntry.php
@@ -18,6 +18,11 @@ class SectionEntry implements ChildEntry
         $this->title = $title;
     }
 
+    public function getId(): string
+    {
+        return $this->title->getId();
+    }
+
     public function getTitle(): TitleNode
     {
         return $this->title;

--- a/packages/guides/src/Nodes/TitleNode.php
+++ b/packages/guides/src/Nodes/TitleNode.php
@@ -56,6 +56,11 @@ class TitleNode extends Node
         return $this->target;
     }
 
+    public function setId(string $id): void
+    {
+        $this->id = $id;
+    }
+
     public function getId(): string
     {
         return $this->id;

--- a/packages/guides/tests/unit/Compiler/NodeTransformers/TocNodeTransformerTest.php
+++ b/packages/guides/tests/unit/Compiler/NodeTransformers/TocNodeTransformerTest.php
@@ -52,11 +52,11 @@ final class TocNodeTransformerTest extends TestCase
             new TitleNode(new SpanNode('Title 1', []), 1),
             [
                 new TocEntry(
-                    'index',
+                    'index#title-1-1',
                     new TitleNode(new SpanNode('Title 1.1', []), 2)
                 ),
                 new TocEntry(
-                    'index',
+                    'index#title-1-2',
                     new TitleNode(new SpanNode('Title 1.2', []), 2),
                 )
             ]
@@ -87,11 +87,11 @@ final class TocNodeTransformerTest extends TestCase
             new TitleNode(new SpanNode('Title 1', []), 1),
             [
                 new TocEntry(
-                    'index',
+                    'index#title-1-1',
                     new TitleNode(new SpanNode('Title 1.1', []), 2)
                 ),
                 new TocEntry(
-                    'index',
+                    'index#title-1-2',
                     new TitleNode(new SpanNode('Title 1.2', []), 2),
                 )
             ]

--- a/packages/guides/tests/unit/Compiler/Passes/ImplicitHyperlinkTargetPassTest.php
+++ b/packages/guides/tests/unit/Compiler/Passes/ImplicitHyperlinkTargetPassTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace phpDocumentor\Guides\Compiler\Passes;
+
+use PHPUnit\Framework\TestCase;
+use phpDocumentor\Guides\Nodes\AnchorNode;
+use phpDocumentor\Guides\Nodes\DocumentNode;
+use phpDocumentor\Guides\Nodes\SectionNode;
+use phpDocumentor\Guides\Nodes\SpanNode;
+use phpDocumentor\Guides\Nodes\TitleNode;
+
+class ImplicitHyperlinkTargetPassTest extends TestCase
+{
+    public function testAllImplicitUniqueSections(): void
+    {
+        $document = new DocumentNode('1', 'index');
+        $expected = new DocumentNode('1', 'index');
+        foreach (['Document 1', 'Section A', 'Section B'] as $titles) {
+            $document->addChildNode(new SectionNode(new TitleNode(new SpanNode($titles), 1)));
+            $expected->addChildNode(new SectionNode(new TitleNode(new SpanNode($titles), 1)));
+        }
+
+        $pass = new ImplicitHyperlinkTargetPass();
+        $resultDocuments = $pass->run([clone $document]);
+
+        self::assertEquals([$expected], $resultDocuments);
+    }
+
+    public function testImplicitWithConflict(): void
+    {
+        $document = new DocumentNode('1', 'index');
+        $expected = new DocumentNode('1', 'index');
+        foreach (['Document 1', 'Section A', 'Section A'] as $titles) {
+            $document->addChildNode(new SectionNode(new TitleNode(new SpanNode($titles), 1)));
+            $expected->addChildNode(new SectionNode(new TitleNode(new SpanNode($titles), 1)));
+        }
+
+        $pass = new ImplicitHyperlinkTargetPass();
+        $resultDocuments = $pass->run([$document]);
+
+        $expected->getNodes()[2]->getTitle()->setId('section-a-1');
+
+        self::assertEquals([$expected], $resultDocuments);
+    }
+
+    public function testExplicit(): void
+    {
+        $document = new DocumentNode('1', 'index');
+        $expected = new DocumentNode('1', 'index');
+
+        $document->addChildNode(new SectionNode(new TitleNode(new SpanNode('Document 1'), 1)));
+        $expected->addChildNode(new SectionNode(new TitleNode(new SpanNode('Document 1'), 1)));
+
+        $document->addChildNode(new AnchorNode('custom-anchor'));
+        $expected->addChildNode('removed');
+        $expected = $expected->removeNode(1);
+
+        $document->addChildNode(new SectionNode(new TitleNode(new SpanNode('Section A'), 1)));
+        $expectedTitle = new TitleNode(new SpanNode('Section A'), 1);
+        $expectedTitle->setId('custom-anchor');
+        $expected->addChildNode(new SectionNode($expectedTitle));
+
+        $pass = new ImplicitHyperlinkTargetPass();
+        $resultDocuments = $pass->run([$document]);
+
+        self::assertEquals([$expected], $resultDocuments);
+    }
+
+    public function testExplicitHasPriorityOverImplicit(): void
+    {
+        $document = new DocumentNode('1', 'index');
+        $expected = new DocumentNode('1', 'index');
+
+        $document->addChildNode(new SectionNode(new TitleNode(new SpanNode('Document 1'), 1)));
+        $expectedTitle = new TitleNode(new SpanNode('Document 1'), 1);
+        $expectedTitle->setId('document-1-1');
+        $expected->addChildNode(new SectionNode($expectedTitle));
+
+        $document->addChildNode(new AnchorNode('document-1'));
+        $expected->addChildNode('removed');
+        $expected = $expected->removeNode(1);
+
+        $document->addChildNode(new SectionNode(new TitleNode(new SpanNode('Section A'), 1)));
+        $expectedTitle = new TitleNode(new SpanNode('Section A'), 1);
+        $expectedTitle->setId('document-1');
+        $expected->addChildNode(new SectionNode($expectedTitle));
+
+        $pass = new ImplicitHyperlinkTargetPass();
+        $resultDocuments = $pass->run([$document]);
+
+        self::assertEquals([$expected], $resultDocuments);
+    }
+}

--- a/packages/guides/tests/unit/Compiler/Passes/MetasPassTest.php
+++ b/packages/guides/tests/unit/Compiler/Passes/MetasPassTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace phpDocumentor\Guides\Compiler;
+namespace phpDocumentor\Guides\Compiler\Passes;
 
 use phpDocumentor\Guides\Meta\DocumentEntry;
 use phpDocumentor\Guides\Meta\DocumentReferenceEntry;
@@ -33,15 +33,15 @@ final class MetasPassTest extends TestCase
 
         $entries = $metas->getAll();
 
-        $exprected = new DocumentEntry('index');
+        $expected = new DocumentEntry('index');
         $s1 = new SectionEntry(new TitleNode(new SpanNode('index-title 1'), 1));
         $s1->addChild(new DocumentReferenceEntry('getting-started'));
         $s1->addChild(new SectionEntry(new TitleNode(new SpanNode('index-title 1.1'), 2)));
-        $exprected->addChild($s1);
+        $expected->addChild($s1);
 
         self::assertEquals(
             [
-                'index' => $exprected
+                'index' => $expected
             ],
             $entries
         );


### PR DESCRIPTION
This builds on top of the Metas refactor in #132 

Each section in a document should have its own "hyperlink target", which is used to focus the specific section ones the user clicks on the link in the TOC.

Section hyperlink targets are either implicit (based on the title) or explicit (set by using an anchor node). This PR implements a new compiler pass to resolve conflicting implicit references (which is currently missing in the Doctrine parser, ref doctrine/rst-parser#175).

