### PR TITLE
Nest overlined or framed titles different from underlined ones

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Parser/DocumentParserContext.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/DocumentParserContext.php
@@ -83,8 +83,9 @@ class DocumentParserContext
         return $this->documentIterator;
     }
 
-    public function getLevel(string $letter): int
+    public function getLevel(string $overlineLetter, string $underlineLetter): int
     {
+        $letter = $overlineLetter.':'.$underlineLetter;
         foreach ($this->titleLetters as $level => $titleLetter) {
             if ($letter === $titleLetter) {
                 return $level;

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/TitleRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/TitleRule.php
@@ -109,7 +109,7 @@ class TitleRule implements Rule
         $context = $documentParserContext->getContext();
 
         $letter = $overlineLetter ?: $underlineLetter;
-        $level = $documentParserContext->getLevel($letter);
+        $level = $documentParserContext->getLevel($overlineLetter, $underlineLetter);
 
         return new TitleNode(
             $this->spanParser->parse($title, $context),

--- a/tests/tests/titles-overlined/titles-overlined.html
+++ b/tests/tests/titles-overlined/titles-overlined.html
@@ -1,4 +1,3 @@
-SKIP overlined / framed headlines are not nested correctly
 <div class="section" id="document-title">
     <h1>
         Document title


### PR DESCRIPTION
TYPO3 docs usually have the Document title between two lines of `=` each