### PR TITLE
Directive ends on complete unindent

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Directives/CodeBlock.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/CodeBlock.php
@@ -43,8 +43,8 @@ class CodeBlock extends Directive
         $node->setLanguage(trim($data));
         $this->setStartingLineNumberBasedOnOptions($options, $node);
 
-        $document = $documentParserContext->getDocument();
         if ($variable !== '') {
+            $document = $documentParserContext->getDocument();
             $document->addVariable($variable, $node);
             return null;
         }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Buffer.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Buffer.php
@@ -84,4 +84,13 @@ class Buffer
     {
         $this->lines = [];
     }
+
+    public function unIndent(int $indentation): void
+    {
+        array_walk($this->lines, function (&$value) use ($indentation) {
+            if (strlen($value) >= $indentation) {
+                $value = substr($value, $indentation);
+            }
+        });
+    }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/DocumentParserContext.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/DocumentParserContext.php
@@ -106,4 +106,17 @@ class DocumentParserContext
 
         return $that;
     }
+
+    /**
+     * can be used to set the content to the document iterator while preserving space
+     * code-block directives have to preserve space
+    */
+    public function withContentsPreserveSpace(string $contents): self
+    {
+        $that = clone $this;
+        $that->documentIterator = new LinesIterator();
+        $that->documentIterator->load($contents, true);
+
+        return $that;
+    }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/LinesIterator.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/LinesIterator.php
@@ -18,6 +18,7 @@ use OutOfBoundsException;
 
 use function chr;
 use function explode;
+use function PHPUnit\Framework\assertInstanceOf;
 use function sprintf;
 use function str_replace;
 use function trim;
@@ -33,10 +34,16 @@ class LinesIterator implements Iterator
     private int $position = 0;
     private int $peek = 1;
 
-    public function load(string $document): void
+    public function load(string $document, bool $preserveSpace = false): void
     {
-        $document = trim($this->prepareDocument($document));
-        $this->lines = explode("\n", $document);
+        if (!$preserveSpace) {
+            $document = trim($this->prepareDocument($document));
+        } else {
+            // only remove empty lines at start and end
+            $document = preg_replace('/^\n+/', '', $document);
+            $document = preg_replace('/\n+$/', '', (string) $document);
+        }
+        $this->lines = explode("\n", (string) $document);
         $this->rewind();
     }
 

--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/DirectiveRuleTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/DirectiveRuleTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions;
 
+use phpDocumentor\Guides\Nodes\CodeNode;
+use phpDocumentor\Guides\RestructuredText\Directives\CodeBlock;
 use phpDocumentor\Guides\RestructuredText\Directives\Directive as DirectiveHandler;
 use phpDocumentor\Guides\RestructuredText\Parser\DummyDirective;
 use phpDocumentor\Guides\RestructuredText\Parser\DummyNode;
@@ -87,6 +89,42 @@ NOWDOC
             'some very long option in multiple, very long, lines',
             array_values($node->getDirectiveOptions())[0]->getValue()
         );
+    }
+
+    /** @dataProvider codeBlockValueProvider */
+    public function testCodeBlockValue(string $input, string $expectedValue): void
+    {
+        $this->rule = new DirectiveRule([$this->directiveHandler, new CodeBlock()]);
+        $context = $this->createContext($input);
+        $node = $this->rule->apply($context);
+        self::assertInstanceOf(CodeNode::class, $node);
+        self::assertEquals($expectedValue, $node->getValue());
+    }
+
+
+    /** @return array<int, array<int, string>> */
+    public function codeBlockValueProvider(): array
+    {
+        return [
+            [
+                <<<'INPUT'
+.. code-block::
+
+    Whitespace, newlines, blank lines, and all kinds of markup
+      (like *this* or \this) is preserved by literal blocks.
+  Lookie here, I've dropped an indentation level
+  (but not far enough)
+
+This is outside the code-block
+INPUT,
+                <<<'EXPECTED'
+  Whitespace, newlines, blank lines, and all kinds of markup
+    (like *this* or \this) is preserved by literal blocks.
+Lookie here, I've dropped an indentation level
+(but not far enough)
+EXPECTED
+                ],
+        ];
     }
 
 

--- a/packages/guides/src/Nodes/CodeNode.php
+++ b/packages/guides/src/Nodes/CodeNode.php
@@ -25,7 +25,7 @@ class CodeNode extends TextNode
      */
     public function __construct(array $lines)
     {
-        parent::__construct(self::normalizeLines($lines));
+        parent::__construct(implode("\n", $lines));
     }
 
     public function setLanguage(?string $language = null): void

--- a/packages/guides/tests/unit/Nodes/CodeNodeTest.php
+++ b/packages/guides/tests/unit/Nodes/CodeNodeTest.php
@@ -51,7 +51,7 @@ final class CodeNodeTest extends TestCase
             "\t\t\tline4",
         ]);
 
-        self::assertSame("line1\n  line2\n    line3\n\tline4", $node->getValue());
+        self::assertSame("  line1\n    line2\n      line3\n\t\t\tline4", $node->getValue());
     }
 
     public function test_that_normalizing_keeps_spaces_intact_when_the_first_line_has_no_spaces(): void

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,12 +27,4 @@
             <directory suffix=".php">packages/**/src</directory>
         </whitelist>
     </filter>
-    <logging>
-        <log type="coverage-html"
-             target="build/coverage"
-             lowUpperBound="35"
-             highLowerBound="70" />
-        <log type="coverage-clover" target=".build/logs/clover.xml"/>
-        <log type="junit" target=".build/logs/junit.xml" />
-    </logging>
 </phpunit>

--- a/tests/tests/code-block-diff/code-block-diff.html
+++ b/tests/tests/code-block-diff/code-block-diff.html
@@ -1,15 +1,10 @@
-SKIP directives should not strip beginning from a string based on the first line
 <pre><code class="language-diff">+ Added line
 - Removed line
   Normal line
 - Removed line
-+ Added line
-
-</code></pre>
-<pre><code class="language-diff">  Normal line
++ Added line</code></pre><pre><code class="language-diff">  Normal line
 + Added line
 - Removed line
   Normal line
 - Removed line
-+ Added line
-</code></pre>
++ Added line</code></pre>

--- a/tests/tests/code-block-indented-in-admonition/code-block-indented-in-admonition.html
+++ b/tests/tests/code-block-indented-in-admonition/code-block-indented-in-admonition.html
@@ -1,0 +1,12 @@
+<div class="phpdocumentor-admonition -note">
+    <svg class="phpdocumentor-admonition__icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z"></path>
+    </svg>
+    <article>
+        <pre><code class="language-"> Whitespace, newlines, blank lines, and all kinds of markup (like *this* or \this) is preserved by literal blocks.
+Lookie here, I&#039;ve dropped an indentation level
+(but not far enough)</code></pre>
+        <p>This is outside the code-block inside the admonition.</p>
+    </article>
+</div>
+<p>This is outside the admonition</p>

--- a/tests/tests/code-block-indented-in-admonition/code-block-indented-in-admonition.rst
+++ b/tests/tests/code-block-indented-in-admonition/code-block-indented-in-admonition.rst
@@ -1,0 +1,11 @@
+.. note::
+    .. code-block::
+
+        Whitespace, newlines, blank lines, and all kinds of markup
+          (like *this* or \this) is preserved by literal blocks.
+      Lookie here, I've dropped an indentation level
+      (but not far enough)
+
+    This is outside the code-block inside the admonition.
+
+This is outside the admonition

--- a/tests/tests/code-block-indented/code-block-indented.html
+++ b/tests/tests/code-block-indented/code-block-indented.html
@@ -1,0 +1,4 @@
+<pre><code class="language-"> Whitespace, newlines, blank lines, and all kinds of markup (like *this* or \this) is preserved by literal blocks.
+Lookie here, I&#039;ve dropped an indentation level
+(but not far enough)</code></pre>
+<p>This is outside the code-block</p>

--- a/tests/tests/code-block-indented/code-block-indented.rst
+++ b/tests/tests/code-block-indented/code-block-indented.rst
@@ -1,0 +1,8 @@
+.. code-block::
+
+    Whitespace, newlines, blank lines, and all kinds of markup
+      (like *this* or \this) is preserved by literal blocks.
+  Lookie here, I've dropped an indentation level
+  (but not far enough)
+
+This is outside the code-block

--- a/tests/tests/code/code.html
+++ b/tests/tests/code/code.html
@@ -1,2 +1,2 @@
 <p>Code block:</p>
-<pre><code class="language-">This is a code block You hou!</code></pre>
+<pre><code class="language-"> This is a code block You hou!</code></pre>


### PR DESCRIPTION
Expecially in code blocks the first line of the directive content can have more indentation then the following ones. Overall this is true for all directives.

The general rule is that a directive ends when the indentation level of the directive declaration is found or when the file ends.