### PR TITLE
Ignore case in directive name

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
@@ -48,9 +48,9 @@ final class DirectiveRule implements Rule
 
     private function registerDirective(DirectiveHandler $directive): void
     {
-        $this->directives[$directive->getName()] = $directive;
+        $this->directives[strtolower($directive->getName())] = $directive;
         foreach ($directive->getAliases() as $alias) {
-            $this->directives[$alias] = $directive;
+            $this->directives[strtolower($alias)] = $directive;
         }
     }
 
@@ -134,7 +134,7 @@ final class DirectiveRule implements Rule
 
     private function getDirectiveHandler(Directive $directive): ?DirectiveHandler
     {
-        return $this->directives[$directive->getName()] ?? null;
+        return $this->directives[strtolower($directive->getName())] ?? null;
     }
 
     private function interpretDirectiveOptions(LinesIterator $documentIterator, Directive $directive): void

--- a/tests/tests/directive-ignore-case/directive-ignore-case.html
+++ b/tests/tests/directive-ignore-case/directive-ignore-case.html
@@ -1,21 +1,16 @@
-SKIP directives do not ignore case
-<div class="alert tip-admonition bg-success text-light border ">
-    <table width="100%">
-        <tr>
-            <td width="10" class="align-top" title="Tip"><i class="fas fa-question-circle mr-2"></i></td>
-            <td>
-                <p>This is a Tip</p>
-            </td>
-        </tr>
-    </table>
+<div class="phpdocumentor-admonition -tip">
+    <svg class="phpdocumentor-admonition__icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 5.636l-3.536 3.536m0 5.656l3.536 3.536M9.172 9.172L5.636 5.636m3.536 9.192l-3.536 3.536M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-5 0a4 4 0 11-8 0 4 4 0 018 0z"></path>
+    </svg>
+    <article>
+        <p>This is a Tip</p>
+    </article>
 </div>
-<div class="alert tip-admonition bg-success text-light border ">
-    <table width="100%">
-        <tr>
-            <td width="10" class="align-top" title="Tip"><i class="fas fa-question-circle mr-2"></i></td>
-            <td>
-                <p>This is a TIP</p>
-            </td>
-        </tr>
-    </table>
+<div class="phpdocumentor-admonition -tip">
+    <svg class="phpdocumentor-admonition__icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 5.636l-3.536 3.536m0 5.656l3.536 3.536M9.172 9.172L5.636 5.636m3.536 9.192l-3.536 3.536M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-5 0a4 4 0 11-8 0 4 4 0 018 0z"></path>
+    </svg>
+    <article>
+        <p>This is a TIP</p>
+    </article>
 </div>


### PR DESCRIPTION
"Directives are indicated by an explicit markup start (".. ") followed by the directive type, two colons, and whitespace (together called the "directive marker"). Directive types are **case-insensitive single words**" https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#directives