### PR TITLE
Correct title / section tests

### DIFF
--- a/tests/tests/titles-auto/titles-auto.rst
+++ b/tests/tests/titles-auto/titles-auto.rst
@@ -15,9 +15,11 @@ Second subsubtitle
 ------------------
 
 Lorem ipsum
+
 Second subtitle
 ~~~~~~~~~~~~~~~
 Blha blha
+
 Third subsubtitle
 -----------------
 Text again

--- a/tests/tests/titles/titles.rst
+++ b/tests/tests/titles/titles.rst
@@ -17,9 +17,11 @@ Second subsubtitle
 ~~~~~~~~~~~~~~~~~~
 
 Lorem ipsum
+
 Second subtitle
 ---------------
 Blha blha
+
 Third subsubtitle
 ~~~~~~~~~~~~~~~~~
 Text again


### PR DESCRIPTION
"A blank line after a title is optional. All text blocks up to the next title of the same or higher level are included in a section (or subsection, etc.)."

The tests where the blank line before the title was missing are not correct in my eyes. At least in our files we do not have such titles.

https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#sections