### PR TITLE
Enable multiline directive options

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Directives/Directive.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/Directive.php
@@ -11,7 +11,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 
 /**
  * A directive is like a function you can call or apply to a block
- * Il looks like:
+ * It looks like:
  *
  * .. function:: main
  *     :arg1: value

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Directive.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Directive.php
@@ -4,6 +4,17 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Parser;
 
+/**
+ * Represents the data contained in an arbitrary directive
+ *
+ * .. name:: data
+ *    :option: value
+ *    :option2: value 2
+ *
+ * A directive can be saved into a variable, the data can be empty:
+ *
+ * .. |variable| name::
+ */
 class Directive
 {
     private string $variable;

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/DirectiveOption.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/DirectiveOption.php
@@ -32,4 +32,9 @@ class DirectiveOption
     {
         return $this->value;
     }
+
+    public function appendValue(string $append): void
+    {
+        $this->value = ((string) $this->value) . $append;
+    }
 }

--- a/packages/guides-restructured-text/tests/unit/Parser/DummyDirective.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/DummyDirective.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace phpDocumentor\Guides\RestructuredText\Parser;
+
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Directives\Directive as DirectiveHandler;
+
+class DummyDirective extends DirectiveHandler
+{
+    private string $name = 'dummy';
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param DirectiveOption[] $options the array of options for this directive
+     */
+    public function process(
+        DocumentParserContext $documentParserContext,
+        string                $variable,
+        string                $data,
+        array                 $options
+    ): ?Node {
+        return new DummyNode($variable, $data, $options);
+    }
+}

--- a/packages/guides-restructured-text/tests/unit/Parser/DummyNode.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/DummyNode.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\RestructuredText\Parser;
+
+use phpDocumentor\Guides\Nodes\Node;
+
+class DummyNode implements Node
+{
+    private string $name;
+    private string $data;
+
+    /**
+     * @var DirectiveOption[] $directiveOptions the array of options for this directive
+     */
+    private array $directiveOptions;
+
+    /**
+     * @param DirectiveOption[] $directiveOptions
+     */
+    public function __construct(string $name, string $data, array $directiveOptions)
+    {
+        $this->name = $name;
+        $this->data = $data;
+        $this->directiveOptions = $directiveOptions;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return DirectiveOption[]
+     */
+    public function getDirectiveOptions(): array
+    {
+        return $this->directiveOptions;
+    }
+
+    /**
+     * @return array<string, scalar|null>
+     */
+    public function getOptions(): array
+    {
+        return [];
+    }
+
+    public function withOptions(array $options): Node
+    {
+        return $this;
+    }
+
+    public function hasOption(string $name): bool
+    {
+        return false;
+    }
+
+    public function setValue($value): void
+    {
+    }
+
+    public function getValue()
+    {
+        return $this->data;
+    }
+
+    public function getClasses(): array
+    {
+        return [];
+    }
+
+    public function setClasses(array $classes): void
+    {
+    }
+
+    public function getClassesString(): string
+    {
+        return '';
+    }
+}

--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/DirectiveRuleTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/DirectiveRuleTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\RestructuredText\Parser\Productions;
+
+use phpDocumentor\Guides\RestructuredText\Directives\Directive as DirectiveHandler;
+use phpDocumentor\Guides\RestructuredText\Parser\DummyDirective;
+use phpDocumentor\Guides\RestructuredText\Parser\DummyNode;
+
+final class DirectiveRuleTest extends AbstractRuleTest
+{
+    private DirectiveRule $rule;
+    private DirectiveHandler $directiveHandler;
+
+    public function setUp(): void
+    {
+        $this->directiveHandler = new DummyDirective();
+        $this->rule = new DirectiveRule([$this->directiveHandler]);
+    }
+
+    /** @dataProvider simpleDirectiveProvider */
+    public function testApplies(string $input): void
+    {
+        $context = $this->createContext($input);
+        self::assertTrue($this->rule->applies($context));
+    }
+
+
+    /** @dataProvider simpleNonDirectiveProvider */
+    public function testNotApplies(string $input): void
+    {
+        $context = $this->createContext($input);
+        self::assertFalse($this->rule->applies($context));
+    }
+
+    public function testApply(): void
+    {
+        $context = $this->createContext('.. dummy:: data');
+        self::assertInstanceOf(DummyNode::class, $this->rule->apply($context));
+    }
+
+
+    public function testApplySetsEmptyOptionTrue(): void
+    {
+        $context = $this->createContext(<<<'NOWDOC'
+.. dummy:: data
+    :option: 
+NOWDOC
+        );
+        $node = $this->rule->apply($context);
+        self::assertInstanceOf(DummyNode::class, $node);
+        self::assertCount(1, $node->getDirectiveOptions());
+        self::assertEquals('option', array_values($node->getDirectiveOptions())[0]->getName());
+        self::assertTrue(array_values($node->getDirectiveOptions())[0]->getValue());
+    }
+
+    public function testApplySetsOptionValue(): void
+    {
+        $context = $this->createContext(<<<'NOWDOC'
+.. dummy:: data
+    :option: value
+NOWDOC
+        );
+        $node = $this->rule->apply($context);
+        self::assertInstanceOf(DummyNode::class, $node);
+        self::assertCount(1, $node->getDirectiveOptions());
+        self::assertEquals('option', array_values($node->getDirectiveOptions())[0]->getName());
+        self::assertEquals('value', array_values($node->getDirectiveOptions())[0]->getValue());
+    }
+
+
+    public function testApplySetsOptionValueMultipleLines(): void
+    {
+        $context = $this->createContext(<<<'NOWDOC'
+.. dummy:: data
+    :option: some very long option
+      in multiple, very long,
+      lines
+NOWDOC
+        );
+        $node = $this->rule->apply($context);
+        self::assertInstanceOf(DummyNode::class, $node);
+        self::assertCount(1, $node->getDirectiveOptions());
+        self::assertEquals('option', array_values($node->getDirectiveOptions())[0]->getName());
+        self::assertEquals(
+            'some very long option in multiple, very long, lines',
+            array_values($node->getDirectiveOptions())[0]->getValue()
+        );
+    }
+
+
+    /** @return array<array<string>> */
+    public function simpleDirectiveProvider(): array
+    {
+        return [
+            ['.. name::'],
+            ['.. name:: data'],
+            ['.. multi:part:name:: data'],
+            ['.. abc123-b_c+d:e.f:: data'],
+            ['.. |variable| name:: data'],
+        ];
+    }
+
+    /** @return array<array<string>> */
+    public function simpleNonDirectiveProvider(): array
+    {
+        return [
+            [''],
+            [':field-option:'],
+            ['... name:: data'],
+            ['.. name: data'],
+            ['.. multi part name:: data'],
+        ];
+    }
+}

--- a/tests/tests/figure-multiline-alt/figure-multiline-alt.html
+++ b/tests/tests/figure-multiline-alt/figure-multiline-alt.html
@@ -1,4 +1,3 @@
-SKIP Multiple lines in directive options don't work yet
 <figure>
     <img src="foo.jpg" width="100" alt="Field options might use more than one line" />
     <figcaption>


### PR DESCRIPTION
directive options are basically field lists:

https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#directives 'Directive options are indicated using field lists; the field names and contents are directive-specific.'

Field list options can have multiple lines:
https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#field-lists