### PR TITLE
Fix image handling

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Directives/Image.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/Image.php
@@ -37,6 +37,11 @@ class Image extends Directive
         string                $data,
         array                 $options
     ): Node {
-        return new ImageNode($this->urlGenerator->relativeUrl($data));
+        return new ImageNode(
+            $this->urlGenerator->absoluteUrl(
+                dirname($documentParserContext->getContext()->getCurrentAbsolutePath()),
+                $data
+            )
+        );
     }
 }

--- a/packages/guides/src/RenderContext.php
+++ b/packages/guides/src/RenderContext.php
@@ -35,8 +35,6 @@ class RenderContext
 
     private string $destinationPath;
 
-    private string $currentAbsolutePath = '';
-
     private string $outputFormat;
     private DocumentNode $document;
     private FilesystemInterface $destination;
@@ -167,11 +165,6 @@ class RenderContext
     public function getMetaEntry(): ?DocumentEntry
     {
         return $this->metas->findDocument($this->currentFileName);
-    }
-
-    public function getSourcePath(): string
-    {
-        return $this->currentAbsolutePath;
     }
 
     public function getOutputFormat(): string

--- a/packages/guides/src/Twig/AssetsExtension.php
+++ b/packages/guides/src/Twig/AssetsExtension.php
@@ -114,17 +114,16 @@ final class AssetsExtension extends AbstractExtension
 
     private function copyAsset(
         ?RenderContext $environment,
-        string $path
+        string $sourcePath
     ): string {
         if (!$environment instanceof RenderContext) {
-            return $path;
+            return $sourcePath;
         }
 
-        $canonicalUrl = $environment->canonicalUrl($path);
+        $canonicalUrl = $environment->canonicalUrl($sourcePath);
         Assert::string($canonicalUrl);
-        $sourcePath = $environment->getSourcePath() . '/' . $path;
         $outputPath = $this->urlGenerator->absoluteUrl(
-            dirname($environment->getDestinationPath()),
+            $environment->getDestinationPath(),
             $canonicalUrl
         );
 


### PR DESCRIPTION
The image path set in the directive is transformed into the absolute path on disk. This will help to locate it in the origin filesystem during rendering.

fixes #234 