### PR TITLE
Add CompileDocumentsCommand

### DIFF
--- a/packages/guides/src/Handlers/CompileDocumentsCommand.php
+++ b/packages/guides/src/Handlers/CompileDocumentsCommand.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Handlers;
+
+use phpDocumentor\Guides\Nodes\DocumentNode;
+
+final class CompileDocumentsCommand
+{
+    /** @var DocumentNode[] */
+    private array $documents;
+
+    /** @param DocumentNode[] $documents */
+    public function __construct(array $documents)
+    {
+        $this->documents = $documents;
+    }
+
+    /** @return DocumentNode[] */
+    public function getDocuments(): array
+    {
+        return $this->documents;
+    }
+}

--- a/packages/guides/src/Handlers/CompileDocumentsHandler.php
+++ b/packages/guides/src/Handlers/CompileDocumentsHandler.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Handlers;
+
+use phpDocumentor\Guides\Compiler\Compiler;
+use phpDocumentor\Guides\Nodes\DocumentNode;
+
+final class CompileDocumentsHandler
+{
+    private Compiler $compiler;
+
+    public function __construct(Compiler $compiler)
+    {
+        $this->compiler = $compiler;
+    }
+
+    /** @return DocumentNode[] */
+    public function handle(CompileDocumentsCommand $command): array
+    {
+        return $this->compiler->run($command->getDocuments());
+    }
+}


### PR DESCRIPTION
The command and handler are extremely simple, but makes the usage API of this library a bit more tidy (the service generating the docs now only needs the `CommandBus`, instead of `CommandBus`+`Compiler`).