### PR TITLE
Introduce the rubric directive

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Directives/RubricDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/RubricDirective.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\RestructuredText\Directives;
+
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\Nodes\RubricNode;
+use phpDocumentor\Guides\RestructuredText\Parser\Directive;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+
+/**
+ * The "rubric" directive inserts a "rubric" node into the document tree. A rubric is like an informal heading
+ * that does not correspond to the document's structure.
+ *
+ * @see https://docutils.sourceforge.io/docs/ref/rst/directives.html#rubric
+ */
+class RubricDirective extends BaseDirective
+{
+    public function getName(): string
+    {
+        return 'rubric';
+    }
+
+    public function processNode(
+        DocumentParserContext $documentParserContext,
+        Directive $directive,
+    ): Node {
+        return new RubricNode($directive->getData());
+    }
+}

--- a/packages/guides-symfony/resources/config/guides-restructured-text.php
+++ b/packages/guides-symfony/resources/config/guides-restructured-text.php
@@ -23,6 +23,7 @@ use phpDocumentor\Guides\RestructuredText\Directives\NoteDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\RawDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\Replace;
 use phpDocumentor\Guides\RestructuredText\Directives\RoleDirective;
+use phpDocumentor\Guides\RestructuredText\Directives\RubricDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\SeeAlsoDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\SidebarDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\TipDirective;
@@ -96,6 +97,7 @@ return static function (ContainerConfigurator $container): void {
         ->set(RawDirective::class)
         ->set(Replace::class)
         ->set(RoleDirective::class)
+        ->set(RubricDirective::class)
         ->set(SeeAlsoDirective::class)
         ->set(SidebarDirective::class)
         ->set(TipDirective::class)

--- a/packages/guides-symfony/src/DependencyInjection/Compiler/NodeRendererPass.php
+++ b/packages/guides-symfony/src/DependencyInjection/Compiler/NodeRendererPass.php
@@ -20,6 +20,7 @@ use phpDocumentor\Guides\Nodes\LiteralBlockNode;
 use phpDocumentor\Guides\Nodes\Metadata\MetaNode;
 use phpDocumentor\Guides\Nodes\ParagraphNode;
 use phpDocumentor\Guides\Nodes\QuoteNode;
+use phpDocumentor\Guides\Nodes\RubricNode;
 use phpDocumentor\Guides\Nodes\SectionNode;
 use phpDocumentor\Guides\Nodes\SeparatorNode;
 use phpDocumentor\Guides\Nodes\TitleNode;
@@ -49,6 +50,7 @@ final class NodeRendererPass implements CompilerPassInterface
         ListNode::class => 'body/list/list.html.twig',
         ListItemNode::class => 'body/list/list-item.html.twig',
         LiteralBlockNode::class => 'body/literal-block.html.twig',
+        RubricNode::class => 'body/rubric.html.twig',
     ];
 
     public function process(ContainerBuilder $container): void

--- a/packages/guides/resources/template/html/guides/body/rubric.html.twig
+++ b/packages/guides/resources/template/html/guides/body/rubric.html.twig
@@ -1,0 +1,1 @@
+<div class="rubric{% if node.classes %} {{ node.classesString }}{% endif %}">{{ node.value }}</div>

--- a/packages/guides/src/Nodes/RubricNode.php
+++ b/packages/guides/src/Nodes/RubricNode.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\Nodes;
+
+/**
+ * A rubric is like an informal heading that does not correspond to the document's structure.
+ *
+ * For example the rubric directive in rst::
+ *
+ *     .. rubric:: Some text displayed like a headline
+ */
+final class RubricNode extends TextNode
+{
+}

--- a/tests/Functional/tests/rubric/rubric.html
+++ b/tests/Functional/tests/rubric/rubric.html
@@ -1,19 +1,8 @@
-SKIP rubric does not work
 <div class="row m-0 p-0">
     <div class="col-md-6 pl-0 pr-3 py-3 m-0">
-        <h6 class="rubric">
-            Test
-        </h6>
+        <div class="rubric">Test</div>
         <p>Some Content</p>
     </div>
 </div>
-<h6 class="rubric">
-    Test
-</h6>
-<h6 class="rubric">
-    The data
-    </h6>
-<h6 class="rubric">
-    The content is just a normal node
-</h6>
-Some content, treated as normal node.
+<div class="rubric">Test</div>
+<div class="rubric">The data</div>

--- a/tests/Functional/tests/rubric/rubric.rst
+++ b/tests/Functional/tests/rubric/rubric.rst
@@ -10,7 +10,3 @@
 
 .. rubric:: The data
     :Argument 1: The argument is ignored
-
-.. rubric:: The content is just a normal node
-
-    Some content, treated as normal node.


### PR DESCRIPTION
The general structure of directives can - in most cases - be saved into a general node type. 

A directive consists of a type, an argument, one or several options and content. the content can be in the form of nodes or plain text (for example code nodes)

I demonstrate usage of a DirectiveNode by introducing the rubric directive that was still missing. We can possibly replace many of the other nodes for directives with a general directive node.

In Sphinx there are rules for each directive what and how many of each kind of data it accepts. We might want to model that in future. Right now non-expected content is ignored.

The `:class:` option is one that can be added to all directives and it has the same effect like setting the class with the class directive. So I saved the class option in the same variable.