### PR TITLE
Fix grid table end condition

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/GridTableRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/GridTableRule.php
@@ -93,7 +93,7 @@ final class GridTableRule implements Rule
                 $separatorLineConfig = $this->tableLineConfig($documentIterator->current(), '-');
                 $context->pushSeparatorLine($separatorLineConfig);
                 // if an empty line follows a separator line, then it is the end of the table
-                if (LinesIterator::isEmptyLine($documentIterator->current())) {
+                if (LinesIterator::isEmptyLine($documentIterator->peek())) {
                     break;
                 }
 

--- a/tests/Functional/tests/table-grid/table-grid.html
+++ b/tests/Functional/tests/table-grid/table-grid.html
@@ -20,3 +20,4 @@
         </tr>
     </tbody>
 </table>
+<p>Paragraph after the table.</p>

--- a/tests/Functional/tests/table-grid/table-grid.rst
+++ b/tests/Functional/tests/table-grid/table-grid.rst
@@ -7,3 +7,5 @@
 +--------+--------+
 | Cell 5 | item 3 |
 +--------+--------+
+
+Paragraph after the table.


### PR DESCRIPTION
A minor typo meant grid tables didn't end correctly, causing many subsequent lines to be considered as part of the table. This caused 646 random errors while rendering the Symfony documentation (as the first 2 characters of each subsequent line was stripped, this created weird reSt syntax for the rest of the parser to parse).

Fixes #253 