### PR TITLE
Refactor Integration Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ psalm:
 	$(PHP_BIN) vendor/bin/psalm --update-baseline
 
 .PHONY: test
-test: test-unit test-functional test-integration## Runs all test suites with phpunit/phpunit
+test: test-unit test-functional test-integration cleanup-tests## Runs all test suites with phpunit/phpunit
 
 .PHONY: test-unit
 test-unit: ## Runs unit tests with phpunit/phpunit
@@ -37,6 +37,10 @@ test-functional: ## Runs functional tests with phpunit/phpunit
 .PHONY: test-integration
 test-integration: ## Runs integration tests with phpunit/phpunit
 	$(PHP_BIN) vendor/bin/phpunit --testsuite=integration
+
+.PHONY: cleanup-tests
+cleanup-tests: ## Cleans up temp directories created by test-integration
+	$(PHP_BIN) find ./tests -type d -name 'temp' -exec rm -rf {} \;
 
 .PHONY: dependency-analysis
 dependency-analysis: vendor ## Runs a dependency analysis with maglnet/composer-require-checker

--- a/packages/guides/src/Renderer/DefaultTypeRendererFactory.php
+++ b/packages/guides/src/Renderer/DefaultTypeRendererFactory.php
@@ -13,6 +13,7 @@ class DefaultTypeRendererFactory implements TypeRendererFactory
     {
         $this->renderSets = [
             new HtmlTypeRenderer(),
+            new LatexTypeRenderer(),
             new IntersphinxTypeRenderer(),
         ];
     }

--- a/packages/guides/src/Renderer/LatexTypeRenderer.php
+++ b/packages/guides/src/Renderer/LatexTypeRenderer.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace phpDocumentor\Guides\Renderer;
+
+use phpDocumentor\Guides\Handlers\RenderCommand;
+use phpDocumentor\Guides\Handlers\RenderDocumentCommand;
+use phpDocumentor\Guides\Handlers\RenderDocumentHandler;
+use phpDocumentor\Guides\RenderContext;
+use phpDocumentor\Guides\Setup\QuickStart;
+use phpDocumentor\Guides\UrlGenerator;
+
+class LatexTypeRenderer implements TypeRenderer
+{
+    public const TYPE = 'tex';
+
+    public function supports(string $outputFormat): bool
+    {
+        return $outputFormat === self::TYPE;
+    }
+
+    public function render(RenderCommand $renderCommand): void
+    {
+        $renderer = QuickStart::createRenderer($renderCommand->getMetas());
+        $renderDocumentHandler = new RenderDocumentHandler($renderer);
+        foreach ($renderCommand->getDocuments() as $document) {
+            $renderDocumentHandler->handle(
+                new RenderDocumentCommand(
+                    $document,
+                    RenderContext::forDocument(
+                        $document,
+                        $renderCommand->getOrigin(),
+                        $renderCommand->getDestination(),
+                        '/',
+                        $renderCommand->getMetas(),
+                        new UrlGenerator(),
+                        self::TYPE
+                    )
+                )
+            );
+        }
+    }
+}

--- a/packages/guides/src/Setup/QuickStart.php
+++ b/packages/guides/src/Setup/QuickStart.php
@@ -76,7 +76,12 @@ final class QuickStart
         $renderer = new TwigRenderer(
             [
                 new OutputFormatRenderer(
-                    'html',
+                    Renderer\HtmlTypeRenderer::TYPE,
+                    new LazyNodeRendererFactory($nodeFactoryCallback),
+                    new TemplateRenderer($twigBuilder)
+                ),
+                new OutputFormatRenderer(
+                    Renderer\LatexTypeRenderer::TYPE,
                     new LazyNodeRendererFactory($nodeFactoryCallback),
                     new TemplateRenderer($twigBuilder)
                 ),

--- a/tests/Integration/tests/index/expected/index.html
+++ b/tests/Integration/tests/index/expected/index.html
@@ -6,7 +6,7 @@
 <body>
     <div class="section" id="document-title">
     <h1>Document Title</h1>
-            <p>Lorem Ipsum Dolor.</p>
+        <p>Lorem Ipsum Dolor.</p>
     </div>
 </body>
 </html>

--- a/tests/Integration/tests/sometest/index.rst
+++ b/tests/Integration/tests/sometest/index.rst
@@ -1,0 +1,5 @@
+==============
+Document Title
+==============
+
+Lorem Ipsum Dolor.


### PR DESCRIPTION
- clean up temp directories after general test runs
- introduce `make cleanup-tests` command
- ignore empty lines and trim lines before comparison