### PR TITLE
Allow multiple whitespace in directive

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
@@ -69,7 +69,7 @@ final class DirectiveRule implements Rule
 
     private function isDirective(string $line): bool
     {
-        return preg_match('/^\.\. (\|(.+)\| |)([^\s]+)::( (.*)|)$/mUsi', $line) > 0;
+        return preg_match('/^\.\.\s+(\|(.+)\| |)([^\s]+)::( (.*)|)$/mUsi', $line) > 0;
     }
 
     public function apply(DocumentParserContext $documentParserContext, ?CompoundNode $on = null): ?Node
@@ -129,7 +129,7 @@ final class DirectiveRule implements Rule
 
     private function parseDirective(string $line): ?Directive
     {
-        if (preg_match('/^\.\. (\|(.+)\| |)([^\s]+)::( (.*)|)$/mUsi', $line, $match) > 0) {
+        if (preg_match('/^\.\.\s+(\|(.+)\| |)([^\s]+)::( (.*)|)$/mUsi', $line, $match) > 0) {
             return new Directive(
                 $match[2],
                 $match[3],

--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/DirectiveRuleTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/DirectiveRuleTest.php
@@ -130,6 +130,7 @@ EXPECTED,
     {
         return [
             ['.. name::'],
+            ['..  name::'],
             ['.. name:: data'],
             ['.. multi:part:name:: data'],
             ['.. abc123-b_c+d:e.f:: data'],
@@ -142,6 +143,7 @@ EXPECTED,
     {
         return [
             [''],
+            ['..name::'],
             [':field-option:'],
             ['... name:: data'],
             ['.. name: data'],

--- a/tests/Integration/tests/toctree/expected/index.html
+++ b/tests/Integration/tests/toctree/expected/index.html
@@ -8,7 +8,7 @@
     <h1>Document Title</h1>
 
             <p>Lorem Ipsum Dolor.</p>
-            <div class="toc"><ul class="phpdocumentor-list"><li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li><li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li><li class="toc-item"><a href="/subfolder/index.html#subfolder-index">Subfolder Index</a></li></ul></div>
+            <div class="toc"><ul class="phpdocumentor-list"><li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li><li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li><li class="toc-item"><a href="/subfolder/index.html#subfolder-index">Subfolder Index</a></li><li class="toc-item"><a href="/subfolder2/index.html#subfolder-index">Subfolder Index</a></li></ul></div>
     </div>
 
 </body>

--- a/tests/Integration/tests/toctree/expected/subfolder2/index.html
+++ b/tests/Integration/tests/toctree/expected/subfolder2/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+
+</head>
+<body>
+    <div class="section" id="subfolder-index">
+        <h1>Subfolder Index</h1>
+        <p>A Toctree with multiple whitespaces in the directive:</p>
+
+            <div class="toc"><ul class="phpdocumentor-list"><li class="toc-item"><a href="/subfolder2/subpage1.html#subpage-1">Subpage 1</a></li><li class="toc-item"><a href="/subfolder2/subpage2.html#subpage-2">Subpage 2</a></li></ul></div>
+    </div>
+
+</body>
+</html>

--- a/tests/Integration/tests/toctree/input/index.rst
+++ b/tests/Integration/tests/toctree/input/index.rst
@@ -8,3 +8,4 @@ Lorem Ipsum Dolor.
     page1
     page2
     subfolder/index
+    subfolder2/index

--- a/tests/Integration/tests/toctree/input/subfolder2/index.rst
+++ b/tests/Integration/tests/toctree/input/subfolder2/index.rst
@@ -1,0 +1,9 @@
+===============
+Subfolder Index
+===============
+
+A Toctree with multiple whitespaces in the directive:
+
+..  toctree::
+    subpage1
+    subpage2

--- a/tests/Integration/tests/toctree/input/subfolder2/subpage1.rst
+++ b/tests/Integration/tests/toctree/input/subfolder2/subpage1.rst
@@ -1,0 +1,5 @@
+=========
+Subpage 1
+=========
+
+Lorem Ipsum Dolor.

--- a/tests/Integration/tests/toctree/input/subfolder2/subpage2.rst
+++ b/tests/Integration/tests/toctree/input/subfolder2/subpage2.rst
@@ -1,0 +1,5 @@
+=========
+Subpage 2
+=========
+
+Lorem Ipsum Dolor.


### PR DESCRIPTION
TYPO3 Documentation uses this to allign a directive and its content, Sphinx allows it:

```
..  toctree::
    subpage1
    subpage2

vs

.. toctree::
    subpage1
    subpage2
 ```