### PR TITLE
Add attributes to ignore directories for export

### DIFF
--- a/packages/guides-cli/.gitattributes
+++ b/packages/guides-cli/.gitattributes
@@ -1,0 +1,4 @@
+/.gitattributes export-ignore
+/docs export-ignore
+/tests export-ignore
+/.gitignore export-ignore

--- a/packages/guides-graphs/.gitattributes
+++ b/packages/guides-graphs/.gitattributes
@@ -1,0 +1,4 @@
+/.gitattributes export-ignore
+/docs export-ignore
+/tests export-ignore
+/.gitignore export-ignore

--- a/packages/guides-markdown/.gitattributes
+++ b/packages/guides-markdown/.gitattributes
@@ -1,0 +1,4 @@
+/.gitattributes export-ignore
+/docs export-ignore
+/tests export-ignore
+/.gitignore export-ignore

--- a/packages/guides-restructured-text/.gitattributes
+++ b/packages/guides-restructured-text/.gitattributes
@@ -1,0 +1,4 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/docs export-ignore
+/tests export-ignore

--- a/packages/guides/.gitattributes
+++ b/packages/guides/.gitattributes
@@ -1,0 +1,5 @@
+/.gitattributes export-ignore
+/docs export-ignore
+/examples export-ignore
+/tests export-ignore
+/.gitignore export-ignore


### PR DESCRIPTION
To make the composer packages a bit smaller, we should not export tests, docs etc. 