### PR TITLE
Removed all dependencies from the phpdocumentor/guides-theme-bootstrap package

### DIFF
--- a/packages/guides-theme-bootstrap/composer.json
+++ b/packages/guides-theme-bootstrap/composer.json
@@ -1,24 +1,7 @@
 {
     "name": "phpdocumentor/guides-theme-bootstrap",
+    "description": "A theme for phpdocumentor/guides based on Bootstrap",
     "type": "library",
     "license": "MIT",
-    "homepage": "https://www.phpdoc.org",
-    "autoload": {
-        "psr-4": {
-            "phpDocumentor\\Guides\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "phpDocumentor\\Guides\\": [
-                "tests/unit/"
-            ]
-        }
-    },
-    "minimum-stability": "stable",
-    "require": {
-        "php": "^7.4||^8.0",
-        "doctrine/lexer": "^2.1",
-        "webmozart/assert": "^1.11"
-    }
+    "homepage": "https://www.phpdoc.org"
 }


### PR DESCRIPTION
In its current state, the package does not contain any source code, so it does not really depend on a certain PHP version or specific packages. Also, autoloading does not make sense without code that could be autoloaded.