### PR TITLE
Fix intersection type spacing

### DIFF
--- a/packages/guides-restructured-text/tests/unit/Parser/SpanParserTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/SpanParserTest.php
@@ -20,7 +20,7 @@ use function current;
 final class SpanParserTest extends TestCase
 {
     public Generator $faker;
-    private ParserContext & MockObject $parserContext;
+    private ParserContext&MockObject $parserContext;
     private SpanParser $spanProcessor;
 
     public function setUp(): void


### PR DESCRIPTION
This was changed because of a bug in the old coding standard. Let's change it back.