### PR TITLE
Attach Anchor nodes to sections

### DIFF
--- a/packages/guides/resources/template/html/guides/inline/anchor.html.twig
+++ b/packages/guides/resources/template/html/guides/inline/anchor.html.twig
@@ -1,1 +1,1 @@
-<a id="{{ node.value }}"></a>
+{% if node.parentNode == null %}<a id="{{ node.value }}"></a>{% endif %}

--- a/packages/guides/resources/template/html/guides/structure/section.html.twig
+++ b/packages/guides/resources/template/html/guides/structure/section.html.twig
@@ -1,4 +1,9 @@
-<div class="section{% if node.classes %} {{ node.classesString }}{% endif %}" id="{{ node.title.id }}">
+{% for anchor in node.anchors %}
+    {% if anchor != node.identifier %}
+        <a id="{{ anchor }}"></a>
+    {% endif %}
+{% endfor %}
+<div class="section{% if node.classes %} {{ node.classesString }}{% endif %}" id="{{ node.identifier }}">
     {{ renderNode(node.title) }}
     {% for childNode in node.children %}
         {{ renderNode(childNode) }}

--- a/packages/guides/src/Compiler/NodeTransformers/AnchorNodeTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/AnchorNodeTransformer.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Compiler\NodeTransformers;
+
+use phpDocumentor\Guides\Compiler\NodeTransformer;
+use phpDocumentor\Guides\Nodes\AnchorNode;
+use phpDocumentor\Guides\Nodes\DocumentNode;
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\Nodes\TitledNode;
+
+/**
+ * @implements NodeTransformer<Node>
+ *
+ * A custom anchor, also called label, can be applied to sections if directly in front of a headline. It can be applied
+ * directly to a figure as well. In all other cases it is a standalone target rendered separately, which does not have
+ * a title.
+ *
+ * https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-ref
+ */
+class AnchorNodeTransformer implements NodeTransformer
+{
+    /** @var AnchorNode[] */
+    private array $anchorNodes = [];
+
+    public function enterNode(Node $node): Node
+    {
+        if ($node instanceof DocumentNode) {
+            // unset classes when entering the next document
+            $this->anchorNodes = [];
+        }
+
+        if ($node instanceof AnchorNode) {
+            // collect all anchors, multiple anchors can be applied to one section
+            $this->anchorNodes[] = $node;
+        } elseif ($node instanceof TitledNode) {
+            // Titled Nodes handle anchors themselves and provide a title to links
+            foreach ($this->anchorNodes as $anchorNode) {
+                $node->addAnchor((string) $anchorNode->getValue());
+                $anchorNode->setParentNode($node);
+                // reset the anchor nodes as they have already been added to a titled node
+                $this->anchorNodes = [];
+            }
+        }
+
+        return $node;
+    }
+
+    public function leaveNode(Node $node): Node|null
+    {
+        return $node;
+    }
+
+    public function supports(Node $node): bool
+    {
+        return true;
+    }
+}

--- a/packages/guides/src/Compiler/NodeTransformers/DefaultNodeTransformerFactory.php
+++ b/packages/guides/src/Compiler/NodeTransformers/DefaultNodeTransformerFactory.php
@@ -21,7 +21,7 @@ class DefaultNodeTransformerFactory implements NodeTransformerFactory
         $transformers = [
             new TocNodeTransformer($this->metas),
             new CollectLinkTargetsTransformer($this->metas),
-            new ClassNodeTransformer(),
+            new AnchorNodeTransformer(),
         ];
 
         return $transformers;

--- a/packages/guides/src/Compiler/Passes/ImplicitHyperlinkTargetPass.php
+++ b/packages/guides/src/Compiler/Passes/ImplicitHyperlinkTargetPass.php
@@ -15,9 +15,7 @@ use function array_map;
 use function array_merge;
 use function current;
 use function in_array;
-use function key;
 use function next;
-use function prev;
 
 /**
  * Resolves the hyperlink target for each section in the document.
@@ -42,23 +40,6 @@ class ImplicitHyperlinkTargetPass implements CompilerPass
             $nodes = $document->getNodes();
             $node = current($nodes);
             do {
-                if ($node instanceof AnchorNode) {
-                    // override implicit section reference if an anchor precedes the section
-                    $key = key($nodes);
-                    $section = next($nodes);
-                    if (!$section instanceof SectionNode) {
-                        prev($nodes);
-                        continue;
-                    }
-
-                    $section->getTitle()->setId($node->getValue());
-                    if ($key !== null) {
-                        $document = $document->removeNode($key);
-                    }
-
-                    continue;
-                }
-
                 if (!($node instanceof SectionNode)) {
                     continue;
                 }

--- a/packages/guides/src/Nodes/AnchorNode.php
+++ b/packages/guides/src/Nodes/AnchorNode.php
@@ -15,4 +15,15 @@ namespace phpDocumentor\Guides\Nodes;
 
 final class AnchorNode extends TextNode
 {
+    private Node|null $parentNode = null;
+
+    public function getParentNode(): Node|null
+    {
+        return $this->parentNode;
+    }
+
+    public function setParentNode(Node|null $parentNode): void
+    {
+        $this->parentNode = $parentNode;
+    }
 }

--- a/packages/guides/src/Nodes/SectionNode.php
+++ b/packages/guides/src/Nodes/SectionNode.php
@@ -5,13 +5,26 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\Nodes;
 
 use function array_merge;
+use function array_unique;
+use function trim;
 
 /** @extends CompoundNode<Node> */
-final class SectionNode extends CompoundNode
+final class SectionNode extends CompoundNode implements TitledNode
 {
+    private string $identifier;
+    /** @var string[] */
+    private array $anchors = [];
+
     public function __construct(private readonly TitleNode $title)
     {
+        $this->identifier = $title->getId();
+
         parent::__construct();
+    }
+
+    public function getTitlePlaintext(): string
+    {
+        return $this->getTitle()->getTitle();
     }
 
     public function getTitle(): TitleNode
@@ -32,5 +45,23 @@ final class SectionNode extends CompoundNode
         }
 
         return $titles;
+    }
+
+    public function addAnchor(string $anchor): void
+    {
+        $this->identifier = trim($anchor);
+        $this->anchors[] = trim($anchor);
+        $this->anchors = array_unique($this->anchors);
+    }
+
+    /** @return string[] */
+    public function getAnchors(): array
+    {
+        return $this->anchors;
+    }
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
     }
 }

--- a/packages/guides/src/Nodes/TitleNode.php
+++ b/packages/guides/src/Nodes/TitleNode.php
@@ -17,10 +17,18 @@ namespace phpDocumentor\Guides\Nodes;
 class TitleNode extends CompoundNode
 {
     protected string $target = '';
+    private string $title;
 
     public function __construct(SpanNode $value, protected int $level, protected string $id)
     {
+        $this->title = (string) $value->getValue();
+
         parent::__construct([$value]);
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
     }
 
     public static function emptyNode(): self

--- a/packages/guides/src/Nodes/TitledNode.php
+++ b/packages/guides/src/Nodes/TitledNode.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Nodes;
+
+/**
+ * Titled Nodes handle anchors and provide a title to links. Therefore, a reference not supplying a title to them yields
+ * in a link with a link text equaling this nodes title.
+ */
+interface TitledNode
+{
+    public function getTitlePlaintext(): string;
+
+    public function addAnchor(string $anchor): void;
+
+    /** @return string[] */
+    public function getAnchors(): array;
+}

--- a/packages/guides/tests/unit/Compiler/Passes/ImplicitHyperlinkTargetPassTest.php
+++ b/packages/guides/tests/unit/Compiler/Passes/ImplicitHyperlinkTargetPassTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\Compiler\Passes;
 
-use phpDocumentor\Guides\Nodes\AnchorNode;
 use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\Nodes\SectionNode;
 use phpDocumentor\Guides\Nodes\SpanNode;
@@ -63,64 +62,6 @@ class ImplicitHyperlinkTargetPassTest extends TestCase
         $section = $expected->getNodes()[2];
         self::assertInstanceOf(SectionNode::class, $section);
         $section->getTitle()->setId('section-a-1');
-
-        self::assertEquals([$expected], $resultDocuments);
-    }
-
-    public function testExplicit(): void
-    {
-        $document = new DocumentNode('1', 'index');
-        $expected = new DocumentNode('1', 'index');
-
-        $document->addChildNode(new SectionNode(
-            new TitleNode(new SpanNode('Document 1'), 1, 'document-1'),
-        ));
-        $expected->addChildNode(new SectionNode(
-            new TitleNode(new SpanNode('Document 1'), 1, 'document-1'),
-        ));
-
-        $document->addChildNode(new AnchorNode('custom-anchor'));
-        $expected->addChildNode(new AnchorNode('removed'));
-        $expected = $expected->removeNode(1);
-
-        $document->addChildNode(
-            new SectionNode(new TitleNode(new SpanNode('Section A'), 1, 'section-a')),
-        );
-        $expectedTitle = new TitleNode(new SpanNode('Section A'), 1, 'section-a');
-        $expectedTitle->setId('custom-anchor');
-        $expected->addChildNode(new SectionNode($expectedTitle));
-
-        $pass = new ImplicitHyperlinkTargetPass();
-        $resultDocuments = $pass->run([$document]);
-
-        self::assertEquals([$expected], $resultDocuments);
-    }
-
-    public function testExplicitHasPriorityOverImplicit(): void
-    {
-        $document = new DocumentNode('1', 'index');
-        $expected = new DocumentNode('1', 'index');
-
-        $document->addChildNode(
-            new SectionNode(new TitleNode(new SpanNode('Document 1'), 1, 'document-1')),
-        );
-        $expectedTitle = new TitleNode(new SpanNode('Document 1'), 1, 'document-1');
-        $expectedTitle->setId('document-1-1');
-        $expected->addChildNode(new SectionNode($expectedTitle));
-
-        $document->addChildNode(new AnchorNode('document-1'));
-        $expected->addChildNode(new AnchorNode('removed'));
-        $expected = $expected->removeNode(1);
-
-        $document->addChildNode(
-            new SectionNode(new TitleNode(new SpanNode('Section A'), 1, 'section-a')),
-        );
-        $expectedTitle = new TitleNode(new SpanNode('Section A'), 1, 'section-a');
-        $expectedTitle->setId('document-1');
-        $expected->addChildNode(new SectionNode($expectedTitle));
-
-        $pass = new ImplicitHyperlinkTargetPass();
-        $resultDocuments = $pass->run([$document]);
 
         self::assertEquals([$expected], $resultDocuments);
     }

--- a/tests/Integration/tests/anchor-title-overriden-by-ref-title/expected/index.html
+++ b/tests/Integration/tests/anchor-title-overriden-by-ref-title/expected/index.html
@@ -1,16 +1,14 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <meta charset="utf-8"/>
-
 
 </head>
-
 <body>
 <div class="section" id="rst-overview">
     <h1>Overview</h1>
     <p>RST Overview content</p>
 </div>
+<a id="overview-2"></a>
 <div class="section" id="sphinx-overview">
     <h1>Overview</h1>
     <p>Sphinx Overview content</p>

--- a/tests/Integration/tests/anchor-title-overriden-by-ref-title/input/index.rst
+++ b/tests/Integration/tests/anchor-title-overriden-by-ref-title/input/index.rst
@@ -6,6 +6,7 @@ Overview
 RST Overview content
 
 
+.. _overview-2:
 .. _sphinx-overview:
 
 Overview

--- a/tests/Integration/tests/anchor-to-title/expected/index.html
+++ b/tests/Integration/tests/anchor-to-title/expected/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <meta charset="utf-8"/>
 
 
 </head>
@@ -14,11 +13,6 @@
 <div class="section" id="sphinx-overview">
     <h1>Overview</h1>
     <p>Sphinx Overview content</p>
-    <div class="section" id="somewhere-else">
-        <h2>Somewhere else</h2>
-        <p>This is a link to the RST Overview: <a href="index.html#rst-overview">Overview</a></p>
-        <p>This is a link to the Sphinx Overview: <a href="index.html#sphinx-overview">Overview</a></p>
-    </div>
 </div>
 
 </body>

--- a/tests/Integration/tests/anchor-to-title/input/index.rst
+++ b/tests/Integration/tests/anchor-to-title/input/index.rst
@@ -12,10 +12,3 @@ Overview
 *********
 
 Sphinx Overview content
-
-Somewhere else
-=============
-
-This is a link to the RST Overview: :ref:`rst-overview`
-
-This is a link to the Sphinx Overview: :ref:`sphinx-overview`

--- a/tests/Integration/tests/anchor-to-title/input/skip
+++ b/tests/Integration/tests/anchor-to-title/input/skip
@@ -1,1 +1,0 @@
-References to anchors do not work


### PR DESCRIPTION
I solved this in a way that anchor nodes can also be attached to other kind of nodes In rst anchors can be attached to figure notes as well, where the caption of the figure is treated as title. This is not implemented yet. Compare https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-ref

resolves https://github.com/phpDocumentor/guides/issues/307