### PR TITLE
Some toctree improvements + add skipped test for non-titlesonly toctrees

### DIFF
--- a/packages/guides/resources/template/html/guides/body/toc/toc-item.html.twig
+++ b/packages/guides/resources/template/html/guides/body/toc/toc-item.html.twig
@@ -1,9 +1,8 @@
-<li class="toc-item">
-    <a href="{{ url }}">{{ renderNode(node.value.value) }}</a>
+<li class="toc-item"><a href="{{ url }}">{{ renderNode(node.value.value) }}</a>
 
-    {% if node.children|length %}
+    {%- if node.children|length %}
         {% include "body/toc/toc-level.html.twig" with {
             tocItems:tocItem.children
         } %}
-    {% endif %}
+    {%- endif -%}
 </li>

--- a/packages/guides/resources/template/html/guides/body/toc/toc-level.html.twig
+++ b/packages/guides/resources/template/html/guides/body/toc/toc-level.html.twig
@@ -1,7 +1,5 @@
-{% spaceless %}
-    <ul class="phpdocumentor-list">
-        {% for tocItem in node.entries %}
-            {{ renderNode(tocItem) }}
-        {% endfor %}
-    </ul>
-{% endspaceless %}
+<ul class="phpdocumentor-list">
+    {% for tocItem in node.entries -%}
+        {{ renderNode(tocItem) }}
+    {% endfor %}
+</ul>

--- a/packages/guides/resources/template/html/guides/body/toc/toc.html.twig
+++ b/packages/guides/resources/template/html/guides/body/toc/toc.html.twig
@@ -1,5 +1,3 @@
-{% spaceless %}
-    <div class="toc">
-        {% include "body/toc/toc-level.html.twig" %}
-    </div>
-{% endspaceless %}
+<div class="toc">
+    {% include "body/toc/toc-level.html.twig" %}
+</div>

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -77,7 +77,7 @@ class IntegrationTest extends ApplicationTestCase
 
         foreach ($compareFiles as $compareFile) {
             $outputFile = str_replace($expectedPath, $outputPath, $compareFile);
-            self::assertFileEqualsTrimmed($compareFile, $outputFile);
+            self::assertFileEqualsTrimmed($compareFile, $outputFile, 'Expected file path: ' . $compareFile);
         }
     }
 
@@ -148,7 +148,7 @@ class IntegrationTest extends ApplicationTestCase
                 $compareFiles[] = $file->getPathname();
             }
 
-            $tests[$dir->getPathname()] = [
+            $tests[$dir->getRelativePathname()] = [
                 $dir->getPathname() . '/input',
                 $dir->getPathname() . '/expected',
                 $dir->getPathname() . '/temp',

--- a/tests/Integration/tests/toctree-simple/expected/index.html
+++ b/tests/Integration/tests/toctree-simple/expected/index.html
@@ -4,11 +4,15 @@
 
 </head>
 <body>
-<div class="section" id="index">
-    <h1>index</h1>
+    <div class="section" id="index">
+        <h1>index</h1>
 
-    <div class="toc"><ul class="phpdocumentor-list"><li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li><li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li></ul></div>
-</div>
-
+        <div class="toc">
+            <ul class="phpdocumentor-list">
+                <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
+                <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
+            </ul>
+        </div>
+    </div>
 </body>
 </html>

--- a/tests/Integration/tests/toctree-titlesonly/expected/index.html
+++ b/tests/Integration/tests/toctree-titlesonly/expected/index.html
@@ -4,6 +4,11 @@
 
 </head>
 <body>
-<div class="toc"><ul class="phpdocumentor-list"><li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li><li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li></ul></div>
+    <div class="toc">
+        <ul class="phpdocumentor-list">
+            <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
+            <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
+        </ul>
+    </div>
 </body>
 </html>

--- a/tests/Integration/tests/toctree/expected/index.html
+++ b/tests/Integration/tests/toctree/expected/index.html
@@ -5,11 +5,17 @@
 </head>
 <body>
     <div class="section" id="document-title">
-    <h1>Document Title</h1>
+        <h1>Document Title</h1>
 
-            <p>Lorem Ipsum Dolor.</p>
-            <div class="toc"><ul class="phpdocumentor-list"><li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li><li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li><li class="toc-item"><a href="/subfolder/index.html#subfolder-index">Subfolder Index</a></li><li class="toc-item"><a href="/subfolder2/index.html#subfolder-index">Subfolder Index</a></li></ul></div>
+        <p>Lorem Ipsum Dolor.</p>
+        <div class="toc">
+           <ul class="phpdocumentor-list">
+              <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
+              <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
+              <li class="toc-item"><a href="/subfolder/index.html#subfolder-index">Subfolder Index</a></li>
+              <li class="toc-item"><a href="/subfolder2/index.html#subfolder-index">Subfolder Index</a></li>
+           </ul>
+        </div>
     </div>
-
 </body>
 </html>

--- a/tests/Integration/tests/toctree/expected/index.html
+++ b/tests/Integration/tests/toctree/expected/index.html
@@ -10,8 +10,32 @@
         <p>Lorem Ipsum Dolor.</p>
         <div class="toc">
            <ul class="phpdocumentor-list">
-              <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
-              <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
+              <li class="toc-item"><a href="/page1.html#page-1">Page 1</a>
+                  <ul class="phpdocumentor-list">
+                      <li class="toc-item"><a href="/page1.html#page-1-level-2">Page 1 Level 2</a>
+                          <ul class="phpdocumentor-list">
+                              <li class="toc-item"><a href="/page1.html#page-1-level-2">Page 1 Level 3</a>
+                                  <ul class="phpdocumentor-list">
+                                      <li class="toc-item"><a href="/page1.html#page-1-level-2">Page 1 Level 4</a></li>
+                                  </ul>
+                              </li>
+                          </ul>
+                      </li>
+                  </ul>
+              </li>
+              <li class="toc-item"><a href="/page2.html#page-2">Page 2</a>
+                  <ul class="phpdocumentor-list">
+                      <li class="toc-item"><a href="/page2.html#page-2-level-2">Page 2 Level 2</a>
+                          <ul class="phpdocumentor-list">
+                              <li class="toc-item"><a href="/page2.html#page-2-level-2">Page 2 Level 3</a>
+                                  <ul class="phpdocumentor-list">
+                                      <li class="toc-item"><a href="/page2.html#page-2-level-2">Page 2 Level 4</a></li>
+                                  </ul>
+                              </li>
+                          </ul>
+                      </li>
+                  </ul>
+              </li>
               <li class="toc-item"><a href="/subfolder/index.html#subfolder-index">Subfolder Index</a></li>
               <li class="toc-item"><a href="/subfolder2/index.html#subfolder-index">Subfolder Index</a></li>
            </ul>

--- a/tests/Integration/tests/toctree/expected/subfolder2/index.html
+++ b/tests/Integration/tests/toctree/expected/subfolder2/index.html
@@ -8,8 +8,12 @@
         <h1>Subfolder Index</h1>
         <p>A Toctree with multiple whitespaces in the directive:</p>
 
-            <div class="toc"><ul class="phpdocumentor-list"><li class="toc-item"><a href="/subfolder2/subpage1.html#subpage-1">Subpage 1</a></li><li class="toc-item"><a href="/subfolder2/subpage2.html#subpage-2">Subpage 2</a></li></ul></div>
+        <div class="toc">
+           <ul class="phpdocumentor-list">
+              <li class="toc-item"><a href="/subfolder2/subpage1.html#subpage-1">Subpage 1</a></li>
+              <li class="toc-item"><a href="/subfolder2/subpage2.html#subpage-2">Subpage 2</a></li>
+           </ul>
+        </div>
     </div>
-
 </body>
 </html>

--- a/tests/Integration/tests/toctree/input/page1.rst
+++ b/tests/Integration/tests/toctree/input/page1.rst
@@ -3,3 +3,12 @@ Page 1
 ======
 
 Lorem Ipsum Dolor.
+
+Page 1 Level 2
+--------------
+
+Page 1 Level 3
+~~~~~~~~~~~~~~
+
+Page 1 Level 4
+""""""""""""""

--- a/tests/Integration/tests/toctree/input/page2.rst
+++ b/tests/Integration/tests/toctree/input/page2.rst
@@ -3,3 +3,12 @@ Page 2
 ======
 
 Lorem Ipsum Dolor.
+
+Page 2 Level 2
+--------------
+
+Page 2 Level 3
+~~~~~~~~~~~~~~
+
+Page 2 Level 4
+""""""""""""""

--- a/tests/Integration/tests/toctree/input/skip
+++ b/tests/Integration/tests/toctree/input/skip
@@ -1,0 +1,1 @@
+toctrees only support (and imply) :titlesonly: currently


### PR DESCRIPTION
This library has the same issue as doctrine/rst-parser, where each toctree is assumed to be `:titlesonly:` and no sub-section titles are rendered. Although we are not using it in the Symfony documentation, we do have a test for this in our test suite somehow.

Lina has started a PR in the past to fix this for the Doctrine parser (https://github.com/doctrine/rst-parser/pull/199), we might reuse the logic from that PR to fix this test in the future.

Meanwhile, I've already made some minor improvements:

* Use relative paths as test name, this makes it easy to filter data sets (e.g. `./vendor/bin/phpunit tests/Integration/IntegrationTest.php --filter testHtmlIntegration@toctree`, currently "toctree" must be the full local path)
* Remove the `spaceless` tag from the template. This tag is deprecated in Twig as has quite some edge cases where meaningfull spaces are removed, instead we should rely solely on the [whitespace control characters](https://twig.symfony.com/doc/3.x/templates.html#whitespace-control). As a benefit, it makes the diff from failing toctree tests much easier to read (as each item is on its own line now)