### PR TITLE
Unify Directive Naming

### DIFF
--- a/deptrac.packages.yaml
+++ b/deptrac.packages.yaml
@@ -1,6 +1,6 @@
 deptrac:
   skip_violations:
-    phpDocumentor\Guides\RestructuredText\Directives\Uml:
+    phpDocumentor\Guides\RestructuredText\Directives\UmlDirective:
       - phpDocumentor\Guides\Graphs\Nodes\UmlNode # yamllint disable-line rule:quoted-strings
   paths:
     - "./packages"

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/CodeBlockDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/CodeBlockDirective.php
@@ -23,7 +23,7 @@ use function trim;
  *
  * @link https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block
  */
-class CodeBlock extends BaseDirective
+class CodeBlockDirective extends BaseDirective
 {
     public function __construct(private readonly CodeNodeOptionMapper $codeNodeOptionMapper)
     {

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/FigureDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/FigureDirective.php
@@ -21,7 +21,7 @@ use phpDocumentor\Guides\UrlGeneratorInterface;
  *
  *      Here is an awesome caption
  */
-class Figure extends SubDirective
+class FigureDirective extends SubDirective
 {
     public function __construct(private readonly UrlGeneratorInterface $urlGenerator)
     {

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ImageDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ImageDirective.php
@@ -19,7 +19,7 @@ use function dirname;
  *      :width: 100
  *      :title: An image
  */
-class Image extends BaseDirective
+class ImageDirective extends BaseDirective
 {
     public function __construct(private readonly UrlGeneratorInterface $urlGenerator)
     {

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/MetaDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/MetaDirective.php
@@ -15,7 +15,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
  * .. meta::
  *      :key: value
  */
-class Meta extends BaseDirective
+class MetaDirective extends BaseDirective
 {
     public function getName(): string
     {

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ReplaceDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ReplaceDirective.php
@@ -14,7 +14,7 @@ use phpDocumentor\Guides\RestructuredText\Span\SpanParser;
  *
  * .. |test| replace:: The Test String!
  */
-class Replace extends BaseDirective
+class ReplaceDirective extends BaseDirective
 {
     public function __construct(private readonly SpanParser $spanParser)
     {

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/TitleDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/TitleDirective.php
@@ -14,7 +14,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
  *
  * .. title:: Page title
  */
-class Title extends BaseDirective
+class TitleDirective extends BaseDirective
 {
     public function getName(): string
     {

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ToctreeDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ToctreeDirective.php
@@ -19,7 +19,7 @@ use phpDocumentor\Guides\RestructuredText\Toc\ToctreeBuilder;
  *
  * @link https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#table-of-contents
  */
-class Toctree extends BaseDirective
+class ToctreeDirective extends BaseDirective
 {
     public function __construct(private readonly ToctreeBuilder $toctreeBuilder)
     {

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/UmlDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/UmlDirective.php
@@ -31,7 +31,7 @@ use function str_replace;
  *    :Transform AST into artifacts;
  *    stop
  */
-final class Uml extends BaseDirective
+final class UmlDirective extends BaseDirective
 {
     public function getName(): string
     {

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/WrapDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/WrapDirective.php
@@ -12,7 +12,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 /**
  * Wraps a sub document in a div with a given class
  */
-class Wrap extends SubDirective
+class WrapDirective extends SubDirective
 {
     public function getName(): string
     {

--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/DirectiveRuleTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/DirectiveRuleTest.php
@@ -6,7 +6,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions;
 
 use phpDocumentor\Guides\Nodes\CodeNode;
 use phpDocumentor\Guides\RestructuredText\Directives\BaseDirective as DirectiveHandler;
-use phpDocumentor\Guides\RestructuredText\Directives\CodeBlock;
+use phpDocumentor\Guides\RestructuredText\Directives\CodeBlockDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\OptionMapper\CodeNodeOptionMapper;
 use phpDocumentor\Guides\RestructuredText\Parser\DummyBaseDirective;
 use phpDocumentor\Guides\RestructuredText\Parser\DummyNode;
@@ -92,7 +92,7 @@ NOWDOC);
     #[DataProvider('codeBlockValueProvider')]
     public function testCodeBlockValue(string $input, string $expectedValue): void
     {
-        $this->rule = new DirectiveRule([$this->directiveHandler, new CodeBlock(new CodeNodeOptionMapper())]);
+        $this->rule = new DirectiveRule([$this->directiveHandler, new CodeBlockDirective(new CodeNodeOptionMapper())]);
         $context = $this->createContext($input);
         $node = $this->rule->apply($context);
         self::assertInstanceOf(CodeNode::class, $node);

--- a/packages/guides-symfony/resources/config/guides-restructured-text.php
+++ b/packages/guides-symfony/resources/config/guides-restructured-text.php
@@ -6,37 +6,37 @@ use phpDocumentor\Guides\RestructuredText\Directives\AdmonitionDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\AttentionDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\CautionDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\ClassDirective;
-use phpDocumentor\Guides\RestructuredText\Directives\CodeBlock;
+use phpDocumentor\Guides\RestructuredText\Directives\CodeBlockDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\ContainerDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\DangerDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\DeprecatedDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\ErrorDirective;
-use phpDocumentor\Guides\RestructuredText\Directives\Figure;
+use phpDocumentor\Guides\RestructuredText\Directives\FigureDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\HintDirective;
-use phpDocumentor\Guides\RestructuredText\Directives\Image;
+use phpDocumentor\Guides\RestructuredText\Directives\ImageDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\ImportantDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\IncludeDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\IndexDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\LaTeXMain;
 use phpDocumentor\Guides\RestructuredText\Directives\LiteralincludeDirective;
-use phpDocumentor\Guides\RestructuredText\Directives\Meta;
+use phpDocumentor\Guides\RestructuredText\Directives\MetaDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\NoteDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\RawDirective;
-use phpDocumentor\Guides\RestructuredText\Directives\Replace;
+use phpDocumentor\Guides\RestructuredText\Directives\ReplaceDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\RoleDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\RubricDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\SeeAlsoDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\SidebarDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\TipDirective;
-use phpDocumentor\Guides\RestructuredText\Directives\Title;
-use phpDocumentor\Guides\RestructuredText\Directives\Toctree;
+use phpDocumentor\Guides\RestructuredText\Directives\TitleDirective;
+use phpDocumentor\Guides\RestructuredText\Directives\ToctreeDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\TodoDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\TopicDirective;
-use phpDocumentor\Guides\RestructuredText\Directives\Uml;
+use phpDocumentor\Guides\RestructuredText\Directives\UmlDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\VersionAddedDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\VersionChangedDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\WarningDirective;
-use phpDocumentor\Guides\RestructuredText\Directives\Wrap;
+use phpDocumentor\Guides\RestructuredText\Directives\WrapDirective;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\BlockQuoteRule;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\CommentRule;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\DefinitionListRule;
@@ -82,7 +82,7 @@ return static function (ContainerConfigurator $container): void {
         ->set(AttentionDirective::class)
         ->set(CautionDirective::class)
         ->set(ClassDirective::class)
-        ->set(CodeBlock::class)
+        ->set(CodeBlockDirective::class)
         ->args([
             '$codeNodeOptionMapper' => service(
                 phpDocumentor\Guides\RestructuredText\Directives\OptionMapper\CodeNodeOptionMapper::class,
@@ -92,9 +92,9 @@ return static function (ContainerConfigurator $container): void {
         ->set(DangerDirective::class)
         ->set(DeprecatedDirective::class)
         ->set(ErrorDirective::class)
-        ->set(Figure::class)
+        ->set(FigureDirective::class)
         ->set(HintDirective::class)
-        ->set(Image::class)
+        ->set(ImageDirective::class)
         ->set(ImportantDirective::class)
         ->set(IncludeDirective::class)
         ->set(IndexDirective::class)
@@ -105,24 +105,24 @@ return static function (ContainerConfigurator $container): void {
                 phpDocumentor\Guides\RestructuredText\Directives\OptionMapper\CodeNodeOptionMapper::class,
             ),
         ])
-        ->set(Meta::class)
+        ->set(MetaDirective::class)
         ->set(NoteDirective::class)
         ->set(RawDirective::class)
-        ->set(Replace::class)
+        ->set(ReplaceDirective::class)
         ->set(RoleDirective::class)
         ->set(RubricDirective::class)
         ->set(SeeAlsoDirective::class)
         ->set(SidebarDirective::class)
         ->set(TipDirective::class)
-        ->set(Title::class)
-        ->set(Toctree::class)
+        ->set(TitleDirective::class)
+        ->set(ToctreeDirective::class)
         ->set(TodoDirective::class)
         ->set(TopicDirective::class)
-        ->set(Uml::class)
+        ->set(UmlDirective::class)
         ->set(VersionAddedDirective::class)
         ->set(VersionChangedDirective::class)
         ->set(WarningDirective::class)
-        ->set(Wrap::class)
+        ->set(WrapDirective::class)
 
         ->set('phpdoc.guides.parser.rst.body_elements', RuleContainer::class)
         ->set('phpdoc.guides.parser.rst.structural_elements', RuleContainer::class)


### PR DESCRIPTION
All Directives should end on "Directive" as we discussed in the code sprint