### PR TITLE
Fail incomplete tests that pass

### DIFF
--- a/tests/Functional/tests/titles-auto/titles-auto.html
+++ b/tests/Functional/tests/titles-auto/titles-auto.html
@@ -1,4 +1,3 @@
-SKIP titles without empty line do not work correctly
 <div class="section" id="main-title">
     <h1>
         Main title


### PR DESCRIPTION
As we're using incomplete tests as a living todo list, I think it's good to also check whether such tests still fail.

This PR changes the functional and integration test to always run the tests and mark as incomplete only if there are errors. If there are no errors, but the test is skipped, it marks the test as failed.

As you see, this already discovered one skipped test that we have fixed in the past months :)