### PR TITLE
Add new compiler pass to move anchors

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/LiteralRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/LiteralRule.php
@@ -36,6 +36,6 @@ class LiteralRule extends AbstractInlineRule
     public function getPriority(): int
     {
         // Should be executed first as any other rules within may not be interpreted
-        return 10000;
+        return 10_000;
     }
 }

--- a/packages/guides/src/Compiler/CompilerContext.php
+++ b/packages/guides/src/Compiler/CompilerContext.php
@@ -16,11 +16,12 @@ namespace phpDocumentor\Guides\Compiler;
 use Exception;
 use phpDocumentor\Guides\Compiler\ShadowTree\TreeNode;
 use phpDocumentor\Guides\Nodes\DocumentNode;
+use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\ProjectNode;
 
 class CompilerContext
 {
-    /** @var TreeNode<DocumentNode> */
+    /** @var TreeNode<Node> */
     private TreeNode $shadowTree;
 
     public function __construct(
@@ -50,6 +51,7 @@ class CompilerContext
         return $that;
     }
 
+    /** @param TreeNode<Node> $shadowTree */
     public function withShadowTree(TreeNode $shadowTree): static
     {
         $that = clone $this;
@@ -58,7 +60,7 @@ class CompilerContext
         return $that;
     }
 
-    /** @return TreeNode<DocumentNode> */
+    /** @return TreeNode<Node> */
     public function getShadowTree(): TreeNode
     {
         if (!isset($this->shadowTree)) {

--- a/packages/guides/src/Compiler/CompilerContext.php
+++ b/packages/guides/src/Compiler/CompilerContext.php
@@ -42,10 +42,18 @@ class CompilerContext
         return $this->shadowTree->getRoot()->getNode();
     }
 
-    public function withShadowTree(DocumentNode $documentNode): static
+    public function withDocumentShadowTree(DocumentNode $documentNode): static
     {
         $that = clone $this;
         $that->shadowTree = TreeNode::createFromDocument($documentNode);
+
+        return $that;
+    }
+
+    public function withShadowTree(TreeNode $shadowTree): static
+    {
+        $that = clone $this;
+        $that->shadowTree = $shadowTree;
 
         return $that;
     }

--- a/packages/guides/src/Compiler/DocumentNodeTraverser.php
+++ b/packages/guides/src/Compiler/DocumentNodeTraverser.php
@@ -50,7 +50,7 @@ final class DocumentNodeTraverser
         }
 
         foreach ($shadowNode->getChildren() as $shadowChild) {
-            $this->traverseForTransformer($transformer, $shadowChild, $compilerContext->withShadowTree($shadowNode));
+            $this->traverseForTransformer($transformer, $shadowChild, $compilerContext->withShadowTree($shadowChild));
         }
 
         if (!$supports) {

--- a/packages/guides/src/Compiler/DocumentNodeTraverser.php
+++ b/packages/guides/src/Compiler/DocumentNodeTraverser.php
@@ -50,7 +50,7 @@ final class DocumentNodeTraverser
         }
 
         foreach ($shadowNode->getChildren() as $shadowChild) {
-            $this->traverseForTransformer($transformer, $shadowChild, $compilerContext);
+            $this->traverseForTransformer($transformer, $shadowChild, $compilerContext->withShadowTree($shadowNode));
         }
 
         if (!$supports) {

--- a/packages/guides/src/Compiler/NodeTransformers/CitationTargetTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/CitationTargetTransformer.php
@@ -40,6 +40,6 @@ class CitationTargetTransformer implements NodeTransformer
 
     public function getPriority(): int
     {
-        return 20000;
+        return 20_000;
     }
 }

--- a/packages/guides/src/Compiler/NodeTransformers/ClassNodeTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/ClassNodeTransformer.php
@@ -61,6 +61,6 @@ class ClassNodeTransformer implements NodeTransformer
 
     public function getPriority(): int
     {
-        return 40000;
+        return 40_000;
     }
 }

--- a/packages/guides/src/Compiler/NodeTransformers/CollectLinkTargetsTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/CollectLinkTargetsTransformer.php
@@ -14,6 +14,8 @@ use phpDocumentor\Guides\Nodes\SectionNode;
 use SplStack;
 use Webmozart\Assert\Assert;
 
+use function assert;
+
 /** @implements NodeTransformer<DocumentNode|AnchorNode> */
 final class CollectLinkTargetsTransformer implements NodeTransformer
 {
@@ -36,12 +38,16 @@ final class CollectLinkTargetsTransformer implements NodeTransformer
             $this->documentStack->push($node);
         } elseif ($node instanceof AnchorNode) {
             $currentDocument = $compilerContext->getDocumentNode();
-            $parentSection = $compilerContext->getShadowTree()->getParent()->getNode();
+            $parentSection = $compilerContext->getShadowTree()->getParent()?->getNode();
             assert($parentSection instanceof SectionNode);
 
             $compilerContext->getProjectNode()->addLinkTarget(
                 $node->toString(),
-                new InternalTarget($currentDocument->getFilePath(), $node->toString()),
+                new InternalTarget(
+                    $currentDocument->getFilePath(),
+                    $node->toString(),
+                    $parentSection->getTitle()->toString(),
+                ),
             );
         } elseif ($node instanceof SectionNode) {
             $currentDocument = $this->documentStack->top();

--- a/packages/guides/src/Compiler/NodeTransformers/CollectLinkTargetsTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/CollectLinkTargetsTransformer.php
@@ -35,8 +35,9 @@ final class CollectLinkTargetsTransformer implements NodeTransformer
         if ($node instanceof DocumentNode) {
             $this->documentStack->push($node);
         } elseif ($node instanceof AnchorNode) {
-            $currentDocument = $this->documentStack->top();
-            Assert::notNull($currentDocument);
+            $currentDocument = $compilerContext->getDocumentNode();
+            $parentSection = $compilerContext->getShadowTree()->getParent()->getNode();
+            assert($parentSection instanceof SectionNode);
 
             $compilerContext->getProjectNode()->addLinkTarget(
                 $node->toString(),

--- a/packages/guides/src/Compiler/NodeTransformers/FootNodeNamedTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/FootNodeNamedTransformer.php
@@ -41,6 +41,6 @@ class FootNodeNamedTransformer implements NodeTransformer
     public function getPriority(): int
     {
         // must be run *after* FootNodeNumberedTransformer
-        return 20000;
+        return 20_000;
     }
 }

--- a/packages/guides/src/Compiler/NodeTransformers/FootNodeNumberedTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/FootNodeNumberedTransformer.php
@@ -40,6 +40,6 @@ class FootNodeNumberedTransformer implements NodeTransformer
     public function getPriority(): int
     {
         // must be run *before* FootNodeNamedTransformer
-        return 30000;
+        return 30_000;
     }
 }

--- a/packages/guides/src/Compiler/NodeTransformers/MoveAnchorTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/MoveAnchorTransformer.php
@@ -27,7 +27,7 @@ final class MoveAnchorTransformer implements NodeTransformer
         }
 
         $this->seen[spl_object_hash($node)] = spl_object_hash($node);
-        $parent = $compilerContext->getShadowTree();
+        $parent = $compilerContext->getShadowTree()->getParent();
         $position = $parent->findPosition($node);
         if ($position === null) {
             throw new LogicException('Node not found in shadow tree');

--- a/packages/guides/src/Compiler/NodeTransformers/MoveAnchorTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/MoveAnchorTransformer.php
@@ -12,14 +12,18 @@ use phpDocumentor\Guides\Compiler\ShadowTree\TreeNode;
 use phpDocumentor\Guides\Nodes\AnchorNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\SectionNode;
-
-use function spl_object_hash;
+use WeakMap;
 
 /** @implements NodeTransformer<AnchorNode> */
 final class MoveAnchorTransformer implements NodeTransformer
 {
-    /** @var array<string, string> */
-    private array $seen = [];
+    /** @var WeakMap<AnchorNode, true> */
+    private WeakMap $seen;
+
+    public function __construct()
+    {
+        $this->seen = new WeakMap();
+    }
 
     public function enterNode(Node $node, CompilerContext $compilerContext): Node
     {
@@ -29,11 +33,11 @@ final class MoveAnchorTransformer implements NodeTransformer
     public function leaveNode(Node $node, CompilerContext $compilerContext): Node|null
     {
         //When exists in seen, it means that the node has already been processed. Ignore it.
-        if (isset($this->seen[spl_object_hash($node)])) {
+        if (isset($this->seen[$node])) {
             return $node;
         }
 
-        $this->seen[spl_object_hash($node)] = spl_object_hash($node);
+        $this->seen[$node] = true;
         $parent = $compilerContext->getShadowTree()->getParent();
         if ($parent === null) {
             throw new LogicException('Node not found in shadow tree');

--- a/packages/guides/src/Compiler/NodeTransformers/MoveAnchorTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/MoveAnchorTransformer.php
@@ -58,7 +58,7 @@ final class MoveAnchorTransformer implements NodeTransformer
 
     public function getPriority(): int
     {
-        return 30000;
+        return 30_000;
     }
 
     /** @param TreeNode<Node> $parent */

--- a/packages/guides/src/Compiler/NodeTransformers/MoveAnchorTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/MoveAnchorTransformer.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace phpDocumentor\Guides\Compiler\NodeTransformers;
+
+use LogicException;
+use phpDocumentor\Guides\Compiler\CompilerContext;
+use phpDocumentor\Guides\Compiler\NodeTransformer;
+use phpDocumentor\Guides\Compiler\ShadowTree\TreeNode;
+use phpDocumentor\Guides\Nodes\AnchorNode;
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\Nodes\SectionNode;
+
+final class MoveAnchorTransformer implements NodeTransformer
+{
+    private array $seen = [];
+
+    public function enterNode(Node $node, CompilerContext $compilerContext): Node
+    {
+        return $node;
+    }
+
+    public function leaveNode(Node $node, CompilerContext $compilerContext): Node|null
+    {
+        //When exists in seen, it means that the node has already been processed. Ignore it.
+        if (isset($this->seen[spl_object_hash($node)])) {
+            return $node;
+        }
+
+        $this->seen[spl_object_hash($node)] = spl_object_hash($node);
+        $parent = $compilerContext->getShadowTree();
+        $position = $parent->findPosition($node);
+        if ($position === null) {
+            throw new LogicException('Node not found in shadow tree');
+        }
+
+        return $this->attemptMoveToNeighbour($parent, $position, $node);
+    }
+
+    public function supports(Node $node): bool
+    {
+        return $node instanceof AnchorNode;
+    }
+
+    public function getPriority(): int
+    {
+        return 30000;
+    }
+
+    private function attemptMoveToNeighbour(TreeNode $parent, int $position, Node $node): ?Node
+    {
+        $current = $this->findNextSection($parent, $position);
+        if ($current === null) {
+            if ($parent->getParent() === null) {
+                return $node;
+            }
+
+            $position = $parent->getParent()->findPosition($parent->getNode());
+            return $this->attemptMoveToNeighbour($parent->getParent(), $position, $node);
+        }
+
+        if ($current->getNode() instanceof SectionNode) {
+            $current->pushChild($node);
+            return null;
+        }
+
+        return $node;
+    }
+
+    private function findNextSection($parent, $position): TreeNode|null
+    {
+        $children = new \ArrayIterator($parent->getChildren());
+        if ($children->count() <= $position + 1) {
+            return null;
+        }
+
+        $children->seek($position + 1);
+        while ($children->valid() && $children->current()->getNode() instanceof AnchorNode) {
+            $children->next();
+        }
+
+        return $children->current();
+    }
+}

--- a/packages/guides/src/Compiler/NodeTransformers/MoveAnchorTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/MoveAnchorTransformer.php
@@ -35,6 +35,10 @@ final class MoveAnchorTransformer implements NodeTransformer
 
         $this->seen[spl_object_hash($node)] = spl_object_hash($node);
         $parent = $compilerContext->getShadowTree()->getParent();
+        if ($parent === null) {
+            throw new LogicException('Node not found in shadow tree');
+        }
+
         $position = $parent->findPosition($node);
         if ($position === null) {
             throw new LogicException('Node not found in shadow tree');

--- a/packages/guides/src/Compiler/NodeTransformers/TransformerPass.php
+++ b/packages/guides/src/Compiler/NodeTransformers/TransformerPass.php
@@ -34,7 +34,7 @@ final class TransformerPass implements CompilerPass
                 continue;
             }
 
-            $compilerContext = $compilerContext->withShadowTree($document);
+            $compilerContext = $compilerContext->withDocumentShadowTree($document);
             $documents[$key] = $this->documentNodeTraverser->traverse($document, $compilerContext);
         }
 

--- a/packages/guides/src/Compiler/NodeTransformers/VariableInlineNodeTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/VariableInlineNodeTransformer.php
@@ -59,6 +59,6 @@ class VariableInlineNodeTransformer implements NodeTransformer
     public function getPriority(): int
     {
         // Late, other replacements should already have happened
-        return 30000;
+        return 30_000;
     }
 }

--- a/packages/guides/src/Compiler/Passes/ImplicitHyperlinkTargetPass.php
+++ b/packages/guides/src/Compiler/Passes/ImplicitHyperlinkTargetPass.php
@@ -30,7 +30,7 @@ class ImplicitHyperlinkTargetPass implements CompilerPass
 {
     public function getPriority(): int
     {
-        return 20000; // must be run *before* MetasPass
+        return 20_000; // must be run *before* MetasPass
     }
 
     /** {@inheritDoc} */

--- a/packages/guides/src/Compiler/ShadowTree/TreeNode.php
+++ b/packages/guides/src/Compiler/ShadowTree/TreeNode.php
@@ -9,9 +9,10 @@ use phpDocumentor\Guides\Nodes\CompoundNode;
 use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\Nodes\Node;
 
+use function array_unshift;
 use function array_values;
 
-/** @template TNode of Node */
+/** @template-covariant TNode of Node */
 final class TreeNode
 {
     /** @var TreeNode<DocumentNode> */
@@ -178,7 +179,7 @@ final class TreeNode
         }
     }
 
-    public function findPosition(Node $node): ?int
+    public function findPosition(Node $node): int|null
     {
         foreach ($this->children as $key => $child) {
             if ($child->getNode() === $node) {

--- a/packages/guides/src/Compiler/ShadowTree/TreeNode.php
+++ b/packages/guides/src/Compiler/ShadowTree/TreeNode.php
@@ -123,6 +123,18 @@ final class TreeNode
         $this->node->addChildNode($child);
     }
 
+    public function pushChild(Node $child): void
+    {
+        if ($this->node instanceof CompoundNode === false) {
+            throw new LogicException('Cannot add a child to a non-compound node');
+        }
+
+        $shadowNode = self::createFromNode($child, $this);
+        $shadowNode->setRoot($this->root);
+        array_unshift($this->children, $shadowNode);
+        $this->node->pushChildNode($child);
+    }
+
     /** @return self<Node>|self<DocumentNode>|null */
     public function getParent(): TreeNode|null
     {
@@ -164,5 +176,16 @@ final class TreeNode
                 break;
             }
         }
+    }
+
+    public function findPosition(Node $node): ?int
+    {
+        foreach ($this->children as $key => $child) {
+            if ($child->getNode() === $node) {
+                return $key;
+            }
+        }
+
+        return null;
     }
 }

--- a/packages/guides/src/Nodes/CompoundNode.php
+++ b/packages/guides/src/Nodes/CompoundNode.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\Nodes;
 
+use function array_unshift;
 use function array_values;
 
 /**
@@ -38,7 +39,6 @@ abstract class CompoundNode extends AbstractNode
     {
         $this->value[] = $node;
     }
-
 
     public function pushChildNode(Node $node): void
     {

--- a/packages/guides/src/Nodes/CompoundNode.php
+++ b/packages/guides/src/Nodes/CompoundNode.php
@@ -40,6 +40,7 @@ abstract class CompoundNode extends AbstractNode
         $this->value[] = $node;
     }
 
+    /** @param TValue $node */
     public function pushChildNode(Node $node): void
     {
         array_unshift($this->value, $node);

--- a/packages/guides/src/Nodes/CompoundNode.php
+++ b/packages/guides/src/Nodes/CompoundNode.php
@@ -39,6 +39,12 @@ abstract class CompoundNode extends AbstractNode
         $this->value[] = $node;
     }
 
+
+    public function pushChildNode(Node $node): void
+    {
+        array_unshift($this->value, $node);
+    }
+
     /** @return $this<TValue> */
     public function removeNode(int $key): self
     {

--- a/packages/guides/tests/unit/Compiler/DocumentNodeTraverserTest.php
+++ b/packages/guides/tests/unit/Compiler/DocumentNodeTraverserTest.php
@@ -47,7 +47,7 @@ final class DocumentNodeTraverserTest extends TestCase
             },
         ]), 2000);
 
-        $actual = $traverser->traverse($document, (new CompilerContext(new ProjectNode()))->withShadowTree($document));
+        $actual = $traverser->traverse($document, (new CompilerContext(new ProjectNode()))->withDocumentShadowTree($document));
 
         self::assertInstanceOf(DocumentNode::class, $actual);
         self::assertEquals(
@@ -97,7 +97,7 @@ final class DocumentNodeTraverserTest extends TestCase
 
         $traverser = new DocumentNodeTraverser(new CustomNodeTransformerFactory($transformers), 2000);
 
-        $actual = $traverser->traverse($document, (new CompilerContext(new ProjectNode()))->withShadowTree($document));
+        $actual = $traverser->traverse($document, (new CompilerContext(new ProjectNode()))->withDocumentShadowTree($document));
 
         self::assertInstanceOf(DocumentNode::class, $actual);
         self::assertEquals(
@@ -150,7 +150,7 @@ final class DocumentNodeTraverserTest extends TestCase
 
         $traverser = new DocumentNodeTraverser(new CustomNodeTransformerFactory($transformers), 2000);
 
-        $actual = $traverser->traverse($document, (new CompilerContext(new ProjectNode()))->withShadowTree($document));
+        $actual = $traverser->traverse($document, (new CompilerContext(new ProjectNode()))->withDocumentShadowTree($document));
 
         self::assertInstanceOf(DocumentNode::class, $actual);
         self::assertEquals(

--- a/packages/guides/tests/unit/Compiler/NodeTransformers/ClassNodeTransformerTest.php
+++ b/packages/guides/tests/unit/Compiler/NodeTransformers/ClassNodeTransformerTest.php
@@ -20,7 +20,7 @@ final class ClassNodeTransformerTest extends TestCase
     {
         $context = new CompilerContext(new ProjectNode());
 
-        return $context->withShadowTree(new DocumentNode('123', $path));
+        return $context->withDocumentShadowTree(new DocumentNode('123', $path));
     }
 
     public function testLeaveNodeWillReturnNullWhenNodeIsClass(): void

--- a/packages/guides/tests/unit/Compiler/NodeTransformers/DocumentEntryRegistrationTransformerTest.php
+++ b/packages/guides/tests/unit/Compiler/NodeTransformers/DocumentEntryRegistrationTransformerTest.php
@@ -26,7 +26,7 @@ class DocumentEntryRegistrationTransformerTest extends TestCase
     {
         $context = new CompilerContext(new ProjectNode());
 
-        return $context->withShadowTree(new DocumentNode('123', $path));
+        return $context->withDocumentShadowTree(new DocumentNode('123', $path));
     }
 
     public function testLeaveNodeWillReturnDocumentNodeWithEntry(): void

--- a/packages/guides/tests/unit/Compiler/NodeTransformers/MoveAnchorTransformerTest.php
+++ b/packages/guides/tests/unit/Compiler/NodeTransformers/MoveAnchorTransformerTest.php
@@ -24,6 +24,7 @@ final class MoveAnchorTransformerTest extends TestCase
             /** @return iterable<MoveAnchorTransformer> */
             public function getTransformers(): iterable
             {
+                //phpstan:ignore-next-line
                 yield new MoveAnchorTransformer();
             }
 
@@ -98,12 +99,11 @@ final class MoveAnchorTransformerTest extends TestCase
 
         self::assertCount(1, $context->getDocumentNode()->getChildren());
         $updatedSection = $context->getDocumentNode()->getChildren()[0];
-
-        self::assertCount(2, $updatedSection->getChildren());
-        self::assertEquals([$node1, $subSection], $context->getDocumentNode()->getChildren()[0]->getChildren());
-
+        self::assertInstanceOf(SectionNode::class, $updatedSection);
+        self::assertEquals([$node1, $subSection], $updatedSection->getChildren());
         $updatedSubSection = $updatedSection->getChildren()[1];
-        self::assertCount(1, $updatedSubSection->getChildren());
+        self::assertInstanceOf(SectionNode::class, $updatedSubSection);
+        self::assertEquals([new AnchorNode('bar')], $updatedSubSection->getChildren());
     }
 
     public function testNoMoveWhenAnchorIsOnlyChild(): void
@@ -140,8 +140,11 @@ final class MoveAnchorTransformerTest extends TestCase
         $this->documentNodeTraverser->traverse($document, $context);
 
         self::assertCount(2, $context->getDocumentNode()->getChildren());
-        self::assertCount(0, $context->getDocumentNode()->getChildren()[0]->getChildren());
-        self::assertCount(2, $context->getDocumentNode()->getChildren()[1]->getChildren());
+        [$firstChild, $secondChild] = $context->getDocumentNode()->getChildren();
+        self::assertInstanceOf(SectionNode::class, $firstChild);
+        self::assertInstanceOf(SectionNode::class, $secondChild);
+        self::assertCount(0, $firstChild->getChildren());
+        self::assertCount(2, $secondChild->getChildren());
     }
 
     public function testMoveAnchorsAtTheEndOfSectionToNextParentNeighbourSection(): void
@@ -165,7 +168,10 @@ final class MoveAnchorTransformerTest extends TestCase
         $this->documentNodeTraverser->traverse($document, $context);
 
         self::assertCount(2, $context->getDocumentNode()->getChildren());
-        self::assertCount(1, $context->getDocumentNode()->getChildren()[0]->getChildren());
-        self::assertCount(2, $context->getDocumentNode()->getChildren()[1]->getChildren());
+        [$firstChild, $secondChild] = $context->getDocumentNode()->getChildren();
+        self::assertInstanceOf(SectionNode::class, $firstChild);
+        self::assertInstanceOf(SectionNode::class, $secondChild);
+        self::assertCount(1, $firstChild->getChildren());
+        self::assertCount(2, $secondChild->getChildren());
     }
 }

--- a/packages/guides/tests/unit/Compiler/NodeTransformers/MoveAnchorTransformerTest.php
+++ b/packages/guides/tests/unit/Compiler/NodeTransformers/MoveAnchorTransformerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace phpDocumentor\Guides\Compiler\NodeTransformers;
 
 use phpDocumentor\Guides\Compiler\CompilerContext;
@@ -19,13 +21,13 @@ final class MoveAnchorTransformerTest extends TestCase
     protected function setUp(): void
     {
         $this->documentNodeTraverser = new DocumentNodeTraverser(new class implements NodeTransformerFactory {
+            /** @return iterable<MoveAnchorTransformer> */
             public function getTransformers(): iterable
             {
-                return [
-                    new MoveAnchorTransformer()
-                ];
+                yield new MoveAnchorTransformer();
             }
 
+            /** @return array<string, int> */
             public function getPriorities(): array
             {
                 return [];
@@ -141,7 +143,6 @@ final class MoveAnchorTransformerTest extends TestCase
         self::assertCount(0, $context->getDocumentNode()->getChildren()[0]->getChildren());
         self::assertCount(2, $context->getDocumentNode()->getChildren()[1]->getChildren());
     }
-
 
     public function testMoveAnchorsAtTheEndOfSectionToNextParentNeighbourSection(): void
     {

--- a/packages/guides/tests/unit/Compiler/NodeTransformers/MoveAnchorTransformerTest.php
+++ b/packages/guides/tests/unit/Compiler/NodeTransformers/MoveAnchorTransformerTest.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace phpDocumentor\Guides\Compiler\NodeTransformers;
+
+use phpDocumentor\Guides\Compiler\CompilerContext;
+use phpDocumentor\Guides\Compiler\DocumentNodeTraverser;
+use phpDocumentor\Guides\Nodes\AnchorNode;
+use phpDocumentor\Guides\Nodes\DocumentNode;
+use phpDocumentor\Guides\Nodes\InlineCompoundNode;
+use phpDocumentor\Guides\Nodes\ProjectNode;
+use phpDocumentor\Guides\Nodes\SectionNode;
+use phpDocumentor\Guides\Nodes\TitleNode;
+use PHPUnit\Framework\TestCase;
+
+final class MoveAnchorTransformerTest extends TestCase
+{
+    private DocumentNodeTraverser $documentNodeTraverser;
+
+    protected function setUp(): void
+    {
+        $this->documentNodeTraverser = new DocumentNodeTraverser(new class implements NodeTransformerFactory {
+            public function getTransformers(): iterable
+            {
+                return [
+                    new MoveAnchorTransformer()
+                ];
+            }
+
+            public function getPriorities(): array
+            {
+                return [];
+            }
+        }, 30000);
+    }
+
+    public function testAnchorNodeShouldBeMovedToNextSectionNodeWhenPositionedAboveSection(): void
+    {
+        $node = new AnchorNode('foo');
+        $section = new SectionNode(new TitleNode(InlineCompoundNode::getPlainTextInlineNode('foo'), 1, 'id'));
+
+        $document = new DocumentNode('123', 'some/path');
+        $document->addChildNode($node);
+        $document->addChildNode($section);
+
+        $context = (new CompilerContext(new ProjectNode('test', 'test')))->withDocumentShadowTree($document);
+
+        $this->documentNodeTraverser->traverse($document, $context);
+
+        self::assertCount(1, $context->getDocumentNode()->getChildren());
+        self::assertCount(1, $section->getChildren());
+        self::assertSame($node, $section->getChildren()[0]);
+    }
+
+    public function testMultipleAnchorsShouldBeMovedToNextSectionNodeWhenPositionedAboveSection(): void
+    {
+        $node1 = new AnchorNode('foo');
+        $node2 = new AnchorNode('bar');
+        $node3 = new AnchorNode('bar2');
+        $node4 = new AnchorNode('bar3');
+        $section = new SectionNode(new TitleNode(InlineCompoundNode::getPlainTextInlineNode('foo'), 1, 'id'));
+
+        $document = new DocumentNode('123', 'some/path');
+        $document->addChildNode($node1);
+        $document->addChildNode($node2);
+        $document->addChildNode($node3);
+        $document->addChildNode($node4);
+        $document->addChildNode($section);
+
+        $context = (new CompilerContext(new ProjectNode('test', 'test')))->withDocumentShadowTree($document);
+
+        $this->documentNodeTraverser->traverse($document, $context);
+
+        self::assertCount(1, $context->getDocumentNode()->getChildren());
+        self::assertCount(4, $section->getChildren());
+        self::assertEquals($node4, $section->getChildren()[0]);
+        self::assertEquals($node3, $section->getChildren()[1]);
+        self::assertEquals($node2, $section->getChildren()[2]);
+        self::assertEquals($node1, $section->getChildren()[3]);
+    }
+
+    public function testAnchorShouldNotBeMovedTwice(): void
+    {
+        $node1 = new AnchorNode('foo');
+        $section = new SectionNode(new TitleNode(InlineCompoundNode::getPlainTextInlineNode('foo'), 1, 'id'));
+        $subSection = new SectionNode(new TitleNode(InlineCompoundNode::getPlainTextInlineNode('foo'), 1, 'id'));
+        $section->addChildNode(new AnchorNode('bar'));
+        $section->addChildNode($subSection);
+
+        $document = new DocumentNode('123', 'some/path');
+        $document->addChildNode($node1);
+        $document->addChildNode($section);
+
+        $context = (new CompilerContext(new ProjectNode('test', 'test')))->withDocumentShadowTree($document);
+
+        $this->documentNodeTraverser->traverse($document, $context);
+
+        self::assertCount(1, $context->getDocumentNode()->getChildren());
+        $updatedSection = $context->getDocumentNode()->getChildren()[0];
+
+        self::assertCount(2, $updatedSection->getChildren());
+        self::assertEquals([$node1, $subSection], $context->getDocumentNode()->getChildren()[0]->getChildren());
+
+        $updatedSubSection = $updatedSection->getChildren()[1];
+        self::assertCount(1, $updatedSubSection->getChildren());
+    }
+
+    public function testNoMoveWhenAnchorIsOnlyChild(): void
+    {
+        $node = new AnchorNode('foo');
+
+        $document = new DocumentNode('123', 'some/path');
+        $document->addChildNode($node);
+
+        $context = (new CompilerContext(new ProjectNode('test', 'test')))->withDocumentShadowTree($document);
+
+        $this->documentNodeTraverser->traverse($document, $context);
+
+        self::assertCount(1, $context->getDocumentNode()->getChildren());
+        self::assertSame($node, $context->getDocumentNode()->getChildren()[0]);
+    }
+
+    public function testMoveAnchorsAtTheEndOfSectionToNextSection(): void
+    {
+        $node1 = new AnchorNode('foo');
+        $node2 = new AnchorNode('bar');
+        $section1 = new SectionNode(new TitleNode(InlineCompoundNode::getPlainTextInlineNode('foo'), 1, 'id'));
+        $section1->addChildNode($node1);
+        $section1->addChildNode($node2);
+
+        $section2 = new SectionNode(new TitleNode(InlineCompoundNode::getPlainTextInlineNode('foo'), 1, 'id'));
+
+        $document = new DocumentNode('123', 'some/path');
+        $document->addChildNode($section1);
+        $document->addChildNode($section2);
+
+        $context = (new CompilerContext(new ProjectNode('test', 'test')))->withDocumentShadowTree($document);
+
+        $this->documentNodeTraverser->traverse($document, $context);
+
+        self::assertCount(2, $context->getDocumentNode()->getChildren());
+        self::assertCount(0, $context->getDocumentNode()->getChildren()[0]->getChildren());
+        self::assertCount(2, $context->getDocumentNode()->getChildren()[1]->getChildren());
+    }
+
+
+    public function testMoveAnchorsAtTheEndOfSectionToNextParentNeighbourSection(): void
+    {
+        $node1 = new AnchorNode('foo');
+        $node2 = new AnchorNode('bar');
+        $section1 = new SectionNode(new TitleNode(InlineCompoundNode::getPlainTextInlineNode('foo'), 1, 'id'));
+        $subSection = new SectionNode(new TitleNode(InlineCompoundNode::getPlainTextInlineNode('foo'), 2, 'id'));
+        $subSection->addChildNode($node1);
+        $subSection->addChildNode($node2);
+        $section1->addChildNode($subSection);
+
+        $section2 = new SectionNode(new TitleNode(InlineCompoundNode::getPlainTextInlineNode('foo'), 1, 'id'));
+
+        $document = new DocumentNode('123', 'some/path');
+        $document->addChildNode($section1);
+        $document->addChildNode($section2);
+
+        $context = (new CompilerContext(new ProjectNode('test', 'test')))->withDocumentShadowTree($document);
+
+        $this->documentNodeTraverser->traverse($document, $context);
+
+        self::assertCount(2, $context->getDocumentNode()->getChildren());
+        self::assertCount(1, $context->getDocumentNode()->getChildren()[0]->getChildren());
+        self::assertCount(2, $context->getDocumentNode()->getChildren()[1]->getChildren());
+    }
+}

--- a/packages/guides/tests/unit/Compiler/NodeTransformers/MoveAnchorTransformerTest.php
+++ b/packages/guides/tests/unit/Compiler/NodeTransformers/MoveAnchorTransformerTest.php
@@ -33,7 +33,7 @@ final class MoveAnchorTransformerTest extends TestCase
             {
                 return [];
             }
-        }, 30000);
+        }, 30_000);
     }
 
     public function testAnchorNodeShouldBeMovedToNextSectionNodeWhenPositionedAboveSection(): void

--- a/packages/guides/tests/unit/Compiler/NodeTransformers/SectionEntryRegistrationTransformerTest.php
+++ b/packages/guides/tests/unit/Compiler/NodeTransformers/SectionEntryRegistrationTransformerTest.php
@@ -28,7 +28,7 @@ class SectionEntryRegistrationTransformerTest extends TestCase
         $document = new DocumentNode('123', $path);
         $document = $document->setDocumentEntry(new DocumentEntryNode($path, TitleNode::emptyNode()));
 
-        return $context->withShadowTree($document);
+        return $context->withDocumentShadowTree($document);
     }
 
     public function testSectionGetsRegistered(): void

--- a/packages/guides/tests/unit/Compiler/NodeTransformers/TocNodeWithDocumentEntryTransformerTest.php
+++ b/packages/guides/tests/unit/Compiler/NodeTransformers/TocNodeWithDocumentEntryTransformerTest.php
@@ -31,7 +31,7 @@ class TocNodeWithDocumentEntryTransformerTest extends TestCase
         $documentNode = new DocumentNode('123', $currentPath);
         $documentNode->setDocumentEntry(new DocumentEntryNode($currentPath, TitleNode::emptyNode()));
 
-        return $context->withShadowTree($documentNode);
+        return $context->withDocumentShadowTree($documentNode);
     }
 
     /**

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -31,6 +31,12 @@
         <exclude-pattern>packages/guides/src/Setup/QuickStart.php</exclude-pattern>
     </rule>
 
+    <rule ref="SlevomatCodingStandard.Numbers.RequireNumericLiteralSeparator">
+        <properties>
+            <property name="minDigitsBeforeDecimalPoint" value="5"/>
+        </properties>
+    </rule>
+
     <rule ref="PSR2">
         <include-pattern>*\.php</include-pattern>
     </rule>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -24,6 +24,10 @@ parameters:
         - packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/TextRoleRule.php
         - packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/VariableInlineRule.php
 
+    -
+       message: '#^Return type \(iterable<phpDocumentor\\Guides\\Compiler\\NodeTransformers\\MoveAnchorTransformer>\) of method class@anonymous\/guides\/tests\/unit\/Compiler\/.*#'
+       paths:
+         - packages/guides/tests/unit/Compiler/NodeTransformers/MoveAnchorTransformerTest.php
   paths:
     - packages/guides/src
     - packages/guides-markdown/src

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -128,9 +128,7 @@ class IntegrationTest extends ApplicationTestCase
         static::assertFileExists($expected, $message);
         static::assertFileExists($actual, $message);
 
-        $constraint = new IsEqual(self::getTrimmedFileContent($expected));
-
-        static::assertThat(self::getTrimmedFileContent($actual), $constraint, $message);
+        static::assertEquals(self::getTrimmedFileContent($expected), self::getTrimmedFileContent($actual), $message);
     }
 
     public static function getTrimmedFileContent(string $file): string

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -7,7 +7,6 @@ namespace phpDocumentor\Guides\Integration;
 use phpDocumentor\Guides\ApplicationTestCase;
 use phpDocumentor\Guides\Cli\Command\Run;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Constraint\IsEqual;
 use PHPUnit\Framework\ExpectationFailedException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;

--- a/tests/Integration/tests/anchor-ref-title-equals-title/expected/overview.html
+++ b/tests/Integration/tests/anchor-ref-title-equals-title/expected/overview.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Overview</title>
+</head>
+<body>
+<div class="section" id="overview">
+    <h1>Overview</h1>
+    <div class="section" id="overview-1">
+        <h2>Overview 1</h2>
+        <a id="rst-overview"></a>
+        <p>RST Overview content</p>
+    </div>
+    <div class="section" id="overview-2">
+        <h2>Overview 2</h2>
+        <a id="sphinx-overview"></a>
+        <p>Sphinx Overview content</p>
+    </div>
+</div>
+</body>
+</html>

--- a/tests/Integration/tests/anchor-ref-title-equals-title/input/skip
+++ b/tests/Integration/tests/anchor-ref-title-equals-title/input/skip
@@ -1,1 +1,0 @@
-References to anchors do not work

--- a/tests/Integration/tests/anchor-title-overriden-by-ref-title/expected/index.html
+++ b/tests/Integration/tests/anchor-title-overriden-by-ref-title/expected/index.html
@@ -1,18 +1,18 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <meta charset="utf-8"/>
-
-
+    <title>Overview</title>
 </head>
 
 <body>
-<div class="section" id="rst-overview">
+<div class="section" id="overview">
     <h1>Overview</h1>
+    <a id="rst-overview"></a>
     <p>RST Overview content</p>
 </div>
-<div class="section" id="sphinx-overview">
+<div class="section" id="overview-1">
     <h1>Overview</h1>
+    <a id="sphinx-overview"></a>
     <p>Sphinx Overview content</p>
     <div class="section" id="somewhere-else">
         <h2>Somewhere else</h2>

--- a/tests/Integration/tests/anchor-title-overriden-by-ref-title/input/skip
+++ b/tests/Integration/tests/anchor-title-overriden-by-ref-title/input/skip
@@ -1,1 +1,0 @@
-References to anchors do not work

--- a/tests/Integration/tests/anchor-to-page/expected/objects.inv.json
+++ b/tests/Integration/tests/anchor-to-page/expected/objects.inv.json
@@ -26,6 +26,12 @@
             "index.html#page",
             "Page"
         ],
+        "overview": [
+        null,
+        null,
+        "sphinx-overview.html#overview",
+        "Overview"
+        ],
         "rst-overview": [
             null,
             null,

--- a/tests/Integration/tests/anchor-to-title-on-another-page/expected/index.html
+++ b/tests/Integration/tests/anchor-to-title-on-another-page/expected/index.html
@@ -1,9 +1,7 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <meta charset="utf-8"/>
-
-
+    <title>Anchors between pages</title>
 </head>
 
 <body>

--- a/tests/Integration/tests/anchor-to-title-on-another-page/input/skip
+++ b/tests/Integration/tests/anchor-to-title-on-another-page/input/skip
@@ -1,1 +1,0 @@
-References to anchors do not work

--- a/tests/Integration/tests/anchor-to-title/expected/index.html
+++ b/tests/Integration/tests/anchor-to-title/expected/index.html
@@ -1,18 +1,18 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <meta charset="utf-8"/>
-
-
+    <title>Overview</title>
 </head>
 
 <body>
-<div class="section" id="rst-overview">
+<div class="section" id="overview">
     <h1>Overview</h1>
+    <a id="rst-overview"></a>
     <p>RST Overview content</p>
 </div>
-<div class="section" id="sphinx-overview">
+<div class="section" id="overview">
     <h1>Overview</h1>
+    <a id="sphinx-overview"></a>
     <p>Sphinx Overview content</p>
     <div class="section" id="somewhere-else">
         <h2>Somewhere else</h2>

--- a/tests/Integration/tests/anchor-to-title/expected/index.html
+++ b/tests/Integration/tests/anchor-to-title/expected/index.html
@@ -10,7 +10,7 @@
     <a id="rst-overview"></a>
     <p>RST Overview content</p>
 </div>
-<div class="section" id="overview">
+<div class="section" id="overview-1">
     <h1>Overview</h1>
     <a id="sphinx-overview"></a>
     <p>Sphinx Overview content</p>

--- a/tests/Integration/tests/anchor-whitespace/expected/index.html
+++ b/tests/Integration/tests/anchor-whitespace/expected/index.html
@@ -1,18 +1,18 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <meta charset="utf-8"/>
-
-
+    <title>Overview</title>
 </head>
 
 <body>
-<div class="section" id="rst-overview">
+<div class="section" id="overview">
     <h1>Overview</h1>
+    <a id="rst-overview"></a>
     <p>RST Overview content</p>
 </div>
-<div class="section" id="sphinx-overview">
+<div class="section" id="overview-1">
     <h1>Overview</h1>
+    <a id="sphinx-overview"></a>
     <p>Sphinx Overview content</p>
     <div class="section" id="somewhere-else">
         <h2>Somewhere else</h2>

--- a/tests/Integration/tests/anchor-whitespace/input/index.rst
+++ b/tests/Integration/tests/anchor-whitespace/input/index.rst
@@ -16,6 +16,6 @@ Sphinx Overview content
 Somewhere else
 =============
 
-This is a link to the RST Overview :ref:`rst-overview`
+This is a link to the RST Overview: :ref:`rst-overview`
 
-This is a link to the Sphinx Overview :ref:`sphinx-overview`
+This is a link to the Sphinx Overview: :ref:`sphinx-overview`

--- a/tests/Integration/tests/anchor-whitespace/input/index.rst
+++ b/tests/Integration/tests/anchor-whitespace/input/index.rst
@@ -16,6 +16,6 @@ Sphinx Overview content
 Somewhere else
 =============
 
-This is a link to the RST Overview: :ref:`rst-overview`
+This is a link to the RST Overview :ref:`rst-overview`
 
-This is a link to the Sphinx Overview: :ref:`sphinx-overview`
+This is a link to the Sphinx Overview :ref:`sphinx-overview`

--- a/tests/Integration/tests/anchor-whitespace/input/skip
+++ b/tests/Integration/tests/anchor-whitespace/input/skip
@@ -1,1 +1,0 @@
-References to anchors do not work

--- a/tests/Integration/tests/inventory_ref_json/expected/objects.inv.json
+++ b/tests/Integration/tests/inventory_ref_json/expected/objects.inv.json
@@ -38,11 +38,23 @@
         ]
     },
     "std:label": {
+        "document-title": [
+            "My Project",
+            "3.1.4",
+            "index.html#document-title",
+            "Document Title"
+        ],
         "my_index": [
             "My Project",
             "3.1.4",
             "index.html#my_index",
             "Document Title"
+        ],
+        "page-1": [
+        "My Project",
+        "3.1.4",
+        "page1.html#page-1",
+        "Page 1"
         ],
         "my_cool_page": [
             "My Project",
@@ -61,6 +73,12 @@
             "3.1.4",
             "subfolder\/index.html#subfolder-index",
             "Subfolder Index"
+        ],
+        "subpage-1": [
+        "My Project",
+        "3.1.4",
+        "subfolder\/subpage1.html#subpage-1",
+        "Subpage 1"
         ],
         "another_cool_page": [
             "My Project",

--- a/tests/Integration/tests/references/expected/index.html
+++ b/tests/Integration/tests/references/expected/index.html
@@ -1,17 +1,17 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<title>index</title>
+<title>Overview</title>
 </head>
 <body>
-    <a id="RST Overview"></a>
 <div class="section" id="overview">
     <h1>Overview</h1>
+    <a id="RST Overview"></a>
             <p>RST Overview content</p>
-            <a id="Other Overview"></a>
     </div>
 <div class="section" id="overview">
     <h1>Overview</h1>
+    <a id="Other Overview"></a>
             <p>Other Overview content</p>
             <p>This is a link to the RST Overview<a href="/index.html#RST Overview">alternative</a></p>
             <p>This is a link to the Other Overview<a href="/index.html#Other Overview">Other Overview</a></p>

--- a/tests/Integration/tests/references/expected/index.html
+++ b/tests/Integration/tests/references/expected/index.html
@@ -14,7 +14,7 @@
     <a id="Other Overview"></a>
             <p>Other Overview content</p>
             <p>This is a link to the RST Overview: <a href="/index.html#RST Overview">alternative</a></p>
-            <p>This is a link to the Other Overview: <a href="/index.html#Other Overview">Other Overview</a></p>
+            <p>This is a link to the Other Overview: <a href="/index.html#Other Overview">Overview</a></p>
             <p>This is a link to <a href="/page.html">Page 1</a>
 This is a link to with alternative text <a href="/page.html">alternative</a></p>
     </div>

--- a/tests/Integration/tests/references/expected/index.html
+++ b/tests/Integration/tests/references/expected/index.html
@@ -9,12 +9,12 @@
     <a id="RST Overview"></a>
             <p>RST Overview content</p>
     </div>
-<div class="section" id="overview">
+<div class="section" id="overview-1">
     <h1>Overview</h1>
     <a id="Other Overview"></a>
             <p>Other Overview content</p>
-            <p>This is a link to the RST Overview<a href="/index.html#RST Overview">alternative</a></p>
-            <p>This is a link to the Other Overview<a href="/index.html#Other Overview">Other Overview</a></p>
+            <p>This is a link to the RST Overview: <a href="/index.html#RST Overview">alternative</a></p>
+            <p>This is a link to the Other Overview: <a href="/index.html#Other Overview">Other Overview</a></p>
             <p>This is a link to <a href="/page.html">Page 1</a>
 This is a link to with alternative text <a href="/page.html">alternative</a></p>
     </div>

--- a/tests/Integration/tests/references/expected/page.html
+++ b/tests/Integration/tests/references/expected/page.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<title>index</title>
+    <title>Page 1</title>
 </head>
+
 <body>
     <div class="section" id="page-1">
     <h1>Page 1</h1>

--- a/tests/Integration/tests/references/expected/subfolder/index.html
+++ b/tests/Integration/tests/references/expected/subfolder/index.html
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title></title>
+    <title>Subfolder index</title>
 
 </head>
 <body>
-    <p><a href="/page.html">Page 1</a></p>
+<div class="section" id="subfolder-index">
+<h1>Subfolder index</h1>
+<p><a href="/page.html">Page 1</a></p>
+</div>
 </body>
 </html>


### PR DESCRIPTION
Anchors should be part of the first compound node after their definition. Anchors at the end of a compound node are positioned wrong by the parser So they are moved to the next compoundnode.