### PR TITLE
Introduce ContainerFactory

### DIFF
--- a/packages/guides-cli/bin/guides
+++ b/packages/guides-cli/bin/guides
@@ -6,9 +6,8 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides;
 
 use phpDocumentor\Guides\Cli\Application;
-use phpDocumentor\Guides\DependencyInjection\Compiler\NodeRendererPass;
-use phpDocumentor\Guides\DependencyInjection\Compiler\ParserRulesPass;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
+use phpDocumentor\Guides\Cli\DependencyInjection\ApplicationExtension;
+use phpDocumentor\Guides\DependencyInjection\ContainerFactory;
 
 $vendorDir = dirname(__DIR__) . '/../../vendor';
 $autoloadDirectory = $vendorDir . '/autoload.php';
@@ -30,22 +29,8 @@ if (file_exists($autoloadDirectory)){
     require $vendorDir . '/autoload.php';
 }
 
-$container = new ContainerBuilder();
-
-// Load manual parameters
-$container->setParameter('vendor_dir', $vendorDir);
-$container->setParameter('working_directory', rtrim(getcwd(), '/'));
-
-// Load container configuration
-foreach (Application::getDefaultExtensions() as $extension) {
-    $container->registerExtension($extension);
-    $container->loadFromExtension($extension->getAlias());
-}
-
-$container->addCompilerPass(new NodeRendererPass());
-$container->addCompilerPass(new ParserRulesPass());
-
-// Compile container
-$container->compile(true);
-
-exit($container->get(Application::class)->run());
+/** @var Application $application */
+$application = (new ContainerFactory([new ApplicationExtension()]))
+    ->create($vendorDir)
+    ->get(Application::class);
+$application->run();

--- a/packages/guides-cli/src/Application.php
+++ b/packages/guides-cli/src/Application.php
@@ -4,12 +4,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\Cli;
 
-use phpDocumentor\Guides\Cli\DependencyInjection\ApplicationExtension;
-use phpDocumentor\Guides\DependencyInjection\GuidesExtension;
-use phpDocumentor\Guides\DependencyInjection\ReStructuredTextExtension;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\DependencyInjection\Extension\Extension;
 
 final class Application extends BaseApplication
 {
@@ -23,15 +19,5 @@ final class Application extends BaseApplication
         }
 
         $this->setDefaultCommand($defaultCommand, true);
-    }
-
-    /** @return Extension[] */
-    public static function getDefaultExtensions(): array
-    {
-        return [
-            new GuidesExtension(),
-            new ReStructuredTextExtension(),
-            new ApplicationExtension(),
-        ];
     }
 }

--- a/packages/guides-symfony/src/DependencyInjection/ContainerFactory.php
+++ b/packages/guides-symfony/src/DependencyInjection/ContainerFactory.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\DependencyInjection;
+
+use LogicException;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+
+use function array_merge;
+use function class_exists;
+use function explode;
+use function getcwd;
+use function implode;
+use function is_a;
+use function rtrim;
+
+final class ContainerFactory
+{
+    private ContainerBuilder $container;
+
+    /** @var array<string, string> */
+    private array $registeredExtensions = [];
+
+    /** @param list<ExtensionInterface> $defaultExtensions */
+    public function __construct(array $defaultExtensions = [])
+    {
+        $this->container = new ContainerBuilder();
+
+        foreach (array_merge([new GuidesExtension(), new ReStructuredTextExtension()], $defaultExtensions) as $extension) {
+            $this->registerExtension($extension);
+        }
+    }
+
+    /** @param array<mixed> $config */
+    public function loadExtensionConfig(string $extension, array $config): void
+    {
+        $extensionFqcn = $this->resolveExtensionClass($extension);
+
+        $extensionAlias = $this->registeredExtensions[$extensionFqcn] ?? false;
+        if (!$extensionAlias) {
+            $this->registerExtension(new $extensionFqcn(), $config);
+
+            return;
+        }
+
+        $this->container->loadFromExtension($extensionAlias, $config);
+    }
+
+    public function create(string $vendorDir): Container
+    {
+        $this->container->setParameter('vendor_dir', $vendorDir);
+        $this->container->setParameter('working_directory', $workingDirectory = rtrim(getcwd(), '/'));
+
+        $this->container->compile(true);
+
+        return $this->container;
+    }
+
+    /** @param array<mixed> $config */
+    private function registerExtension(ExtensionInterface $extension, array $config = []): void
+    {
+        $this->container->registerExtension($extension);
+        $this->container->loadFromExtension($extension->getAlias());
+
+        if ($extension instanceof CompilerPassInterface) {
+            $this->container->addCompilerPass($extension);
+        }
+
+        $this->registeredExtensions[$extension::class] = $extension->getAlias();
+    }
+
+    /** @return class-string<ExtensionInterface> */
+    private function resolveExtensionClass(string $name): string
+    {
+        $fqcn = $name;
+        if (!class_exists($fqcn)) {
+            [$namespace, $package] = explode('\\', $fqcn, 2);
+
+            $fqcn = implode('\\', [$namespace, 'DependencyInjection', $package . 'Extension']);
+            if (!class_exists($fqcn)) {
+                $fqcn = 'phpDocumentor\\' . $fqcn;
+
+                if (!class_exists($fqcn)) {
+                    throw new LogicException();
+                }
+            }
+        }
+
+        if (!is_a($fqcn, ExtensionInterface::class, true)) {
+            throw new LogicException();
+        }
+
+        return $fqcn;
+    }
+}

--- a/packages/guides-symfony/src/DependencyInjection/GuidesExtension.php
+++ b/packages/guides-symfony/src/DependencyInjection/GuidesExtension.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\DependencyInjection;
 
 use phpDocumentor\Guides\Configuration;
+use phpDocumentor\Guides\DependencyInjection\Compiler\NodeRendererPass;
+use phpDocumentor\Guides\DependencyInjection\Compiler\ParserRulesPass;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
@@ -13,7 +16,7 @@ use Twig\Loader\FilesystemLoader;
 
 use function dirname;
 
-class GuidesExtension extends Extension
+class GuidesExtension extends Extension implements CompilerPassInterface
 {
     /** @param string[] $configs */
     public function load(array $configs, ContainerBuilder $container): void
@@ -35,5 +38,11 @@ class GuidesExtension extends Extension
             $container->getDefinition(FilesystemLoader::class)
                 ->setArgument('$paths', $config->getTemplatePaths());
         }
+    }
+
+    public function process(ContainerBuilder $container): void
+    {
+        (new NodeRendererPass())->process($container);
+        (new ParserRulesPass())->process($container);
     }
 }

--- a/packages/guides-symfony/src/DependencyInjection/TestExtension.php
+++ b/packages/guides-symfony/src/DependencyInjection/TestExtension.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\DependencyInjection;
+
+use phpDocumentor\Guides\NodeRenderers\DelegatingNodeRenderer;
+use phpDocumentor\Guides\Parser;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+
+class TestExtension extends Extension implements CompilerPassInterface
+{
+    /** @param array<mixed> $configs */
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+    }
+
+    public function process(ContainerBuilder $container): void
+    {
+        $container->getDefinition(Parser::class)->setPublic(true);
+        $container->getDefinition(DelegatingNodeRenderer::class)->setPublic(true);
+    }
+}

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -9,7 +9,6 @@ use Gajus\Dindent\Indenter;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Memory\MemoryAdapter;
 use phpDocumentor\Guides\ApplicationTestCase;
-use phpDocumentor\Guides\Configuration;
 use phpDocumentor\Guides\Metas;
 use phpDocumentor\Guides\NodeRenderers\DelegatingNodeRenderer;
 use phpDocumentor\Guides\Parser;
@@ -39,12 +38,10 @@ use const LC_ALL;
 
 class FunctionalTest extends ApplicationTestCase
 {
-    private const RENDER_DOCUMENT_FILES = ['main-directive'];
     private const SKIP_INDENTER_FILES = ['code-block-diff'];
 
     protected function setUp(): void
     {
-        self::prepareContainer(new Configuration());
         setlocale(LC_ALL, 'en_US.utf8');
     }
 

--- a/tests/Integration/IntegrationBootstrapTest.php
+++ b/tests/Integration/IntegrationBootstrapTest.php
@@ -6,7 +6,6 @@ namespace phpDocumentor\Guides\Integration;
 
 use phpDocumentor\Guides\ApplicationTestCase;
 use phpDocumentor\Guides\Cli\Command\Run;
-use phpDocumentor\Guides\Configuration;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Constraint\IsEqual;
 use PHPUnit\Framework\ExpectationFailedException;
@@ -34,7 +33,6 @@ class IntegrationBootstrapTest extends ApplicationTestCase
 {
     protected function setUp(): void
     {
-        self::prepareContainer(new Configuration());
         setlocale(LC_ALL, 'en_US.utf8');
     }
 

--- a/tests/Integration/IntegrationLatexTest.php
+++ b/tests/Integration/IntegrationLatexTest.php
@@ -6,7 +6,6 @@ namespace phpDocumentor\Guides\Integration;
 
 use phpDocumentor\Guides\ApplicationTestCase;
 use phpDocumentor\Guides\Cli\Command\Run;
-use phpDocumentor\Guides\Configuration;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Constraint\IsEqual;
 use PHPUnit\Framework\ExpectationFailedException;
@@ -34,7 +33,6 @@ class IntegrationLatexTest extends ApplicationTestCase
 {
     protected function setUp(): void
     {
-        self::prepareContainer(new Configuration());
         setlocale(LC_ALL, 'en_US.utf8');
     }
 

--- a/tests/Integration/IntegrationPhpDocumentorTest.php
+++ b/tests/Integration/IntegrationPhpDocumentorTest.php
@@ -6,7 +6,6 @@ namespace phpDocumentor\Guides\Integration;
 
 use phpDocumentor\Guides\ApplicationTestCase;
 use phpDocumentor\Guides\Cli\Command\Run;
-use phpDocumentor\Guides\Configuration;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Constraint\IsEqual;
 use PHPUnit\Framework\ExpectationFailedException;
@@ -34,7 +33,6 @@ class IntegrationPhpDocumentorTest extends ApplicationTestCase
 {
     protected function setUp(): void
     {
-        self::prepareContainer(new Configuration());
         setlocale(LC_ALL, 'en_US.utf8');
     }
 

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -6,7 +6,6 @@ namespace phpDocumentor\Guides\Integration;
 
 use phpDocumentor\Guides\ApplicationTestCase;
 use phpDocumentor\Guides\Cli\Command\Run;
-use phpDocumentor\Guides\Configuration;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Constraint\IsEqual;
 use PHPUnit\Framework\ExpectationFailedException;
@@ -34,7 +33,6 @@ class IntegrationTest extends ApplicationTestCase
 {
     protected function setUp(): void
     {
-        self::prepareContainer(new Configuration());
         setlocale(LC_ALL, 'en_US.utf8');
     }
 


### PR DESCRIPTION
This is a split from #333 to try to make smaller steps more quickly :)

Goals of this feature from that PR description:

> * **Centralize the code building the container into a factory.** This makes it easier to change the build process (instead of having to update both the tests and guides "binary"), and allows to add some custom layer for DI extensions.
> * **Give extensions full control** by allowing them to add compiler passes, create configuration trees and load services. This means the container initialization no longer has to register compiler passes that actually belong to a specific package.