### PR TITLE
Fix Paths in Menus

### DIFF
--- a/packages/guides-theme-bootstrap/resources/template/body/menu/mainmenu/menu-level.html.twig
+++ b/packages/guides-theme-bootstrap/resources/template/body/menu/mainmenu/menu-level.html.twig
@@ -1,6 +1,6 @@
 <div class="level-x">
     {% for entry in node.entries -%}
-        <a href="{{ entry.url }}"
+        <a href="{{ renderLink(entry.url) }}"
            class="nav-link {% if entry.options.active %} active {% endif %}"
                 {% if entry.options.active %}  aria-current="page" {% endif %} >
             {{ renderNode(entry.value.value) }}

--- a/packages/guides-theme-bootstrap/resources/template/body/menu/mainmenu/table-of-content.html.twig
+++ b/packages/guides-theme-bootstrap/resources/template/body/menu/mainmenu/table-of-content.html.twig
@@ -1,7 +1,7 @@
 
 <nav class="nav flex-column">
     {% for entry in node.entries -%}
-        <a href="{{ entry.url }}"
+        <a href="{{ renderLink(entry.url) }}"
            class="nav-link {% if entry.options.active %} active {% endif %}"
                 {% if entry.options.active %}  aria-current="page" {% endif %} >
             {{ renderNode(entry.value.value) }}

--- a/packages/guides-theme-bootstrap/resources/template/body/menu/navbar/menu-level.html.twig
+++ b/packages/guides-theme-bootstrap/resources/template/body/menu/navbar/menu-level.html.twig
@@ -2,7 +2,7 @@
     {% for entry in node.entries -%}
 
         <li class="nav-item">
-            <a href="{{ entry.url }}"
+            <a href="{{ renderLink(entry.url) }}"
                class="nav-link {% if entry.options.active %} active {% endif %}"
                     {% if entry.options.active %}  aria-current="page" {% endif %} >
                 {{ renderNode(entry.value.value) }}

--- a/packages/guides-theme-bootstrap/resources/template/body/menu/navbar/table-of-content.html.twig
+++ b/packages/guides-theme-bootstrap/resources/template/body/menu/navbar/table-of-content.html.twig
@@ -2,7 +2,7 @@
 <ul class="navbar-nav me-auto mb-2 mb-lg-0">
     {% for entry in node.entries -%}
         <li class="nav-item">
-                <a href="{{ entry.url }}"
+                <a href="{{ renderLink(entry.url) }}"
            class="nav-link {% if entry.options.active %} active {% endif %}"
                 {% if entry.options.active %}  aria-current="page" {% endif %} >
             {{ renderNode(entry.value.value) }}

--- a/packages/guides/src/Twig/AssetsExtension.php
+++ b/packages/guides/src/Twig/AssetsExtension.php
@@ -45,6 +45,7 @@ final class AssetsExtension extends AbstractExtension
         return [
             new TwigFunction('asset', $this->asset(...), ['is_safe' => ['html'], 'needs_context' => true]),
             new TwigFunction('renderNode', $this->renderNode(...), ['is_safe' => ['html'], 'needs_context' => true]),
+            new TwigFunction('renderLink', $this->renderLink(...), ['is_safe' => ['html'], 'needs_context' => true]),
         ];
     }
 
@@ -102,6 +103,12 @@ final class AssetsExtension extends AbstractExtension
         }
 
         return $text;
+    }
+
+    /** @param array{env: RenderContext} $context */
+    public function renderLink(array $context, string $url): string
+    {
+        return $this->urlGenerator->createFileUrl($url);
     }
 
     private function copyAsset(

--- a/tests/Integration/tests-bootstrap/index/expected/index.html
+++ b/tests/Integration/tests-bootstrap/index/expected/index.html
@@ -23,13 +23,13 @@
                 
 <ul class="navbar-nav me-auto mb-2 mb-lg-0">
     <li class="nav-item">
-                <a href="index"
+                <a href="index.html"
            class="nav-link  active "
                   aria-current="page"  >
             Document Title
         </a>
         </li><li class="nav-item">
-                <a href="somePage"
+                <a href="somePage.html"
            class="nav-link "
                  >
             Some Page
@@ -49,11 +49,11 @@
 
     
 <nav class="nav flex-column">
-    <a href="index"
+    <a href="index.html"
            class="nav-link  active "
                   aria-current="page"  >
             Document Title
-        </a><a href="somePage"
+        </a><a href="somePage.html"
            class="nav-link "
                  >
             Some Page

--- a/tests/Integration/tests-bootstrap/index/expected/somePage.html
+++ b/tests/Integration/tests-bootstrap/index/expected/somePage.html
@@ -23,13 +23,13 @@
                 
 <ul class="navbar-nav me-auto mb-2 mb-lg-0">
     <li class="nav-item">
-                <a href="index"
+                <a href="index.html"
            class="nav-link "
                  >
             Document Title
         </a>
         </li><li class="nav-item">
-                <a href="somePage"
+                <a href="somePage.html"
            class="nav-link  active "
                   aria-current="page"  >
             Some Page
@@ -49,11 +49,11 @@
 
     
 <nav class="nav flex-column">
-    <a href="index"
+    <a href="index.html"
            class="nav-link "
                  >
             Document Title
-        </a><a href="somePage"
+        </a><a href="somePage.html"
            class="nav-link  active "
                   aria-current="page"  >
             Some Page


### PR DESCRIPTION
The paths need to have the file ending of the current format, which is not stored in the node. Therefore I introduce a Twig function "renderLink"