### PR TITLE
Run compiler passes in functional tests

### DIFF
--- a/packages/guides/src/DependencyInjection/TestExtension.php
+++ b/packages/guides/src/DependencyInjection/TestExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\DependencyInjection;
 
+use phpDocumentor\Guides\Compiler\Compiler;
 use phpDocumentor\Guides\NodeRenderers\DelegatingNodeRenderer;
 use phpDocumentor\Guides\Parser;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -20,6 +21,7 @@ class TestExtension extends Extension implements CompilerPassInterface
     public function process(ContainerBuilder $container): void
     {
         $container->getDefinition(Parser::class)->setPublic(true);
+        $container->getDefinition(Compiler::class)->setPublic(true);
         $container->getDefinition(DelegatingNodeRenderer::class)->setPublic(true);
     }
 }

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -9,6 +9,7 @@ use Gajus\Dindent\Indenter;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Memory\MemoryAdapter;
 use phpDocumentor\Guides\ApplicationTestCase;
+use phpDocumentor\Guides\Compiler\Compiler;
 use phpDocumentor\Guides\Metas;
 use phpDocumentor\Guides\NodeRenderers\DelegatingNodeRenderer;
 use phpDocumentor\Guides\Parser;
@@ -77,6 +78,10 @@ class FunctionalTest extends ApplicationTestCase
 
             $parser = $this->getContainer()->get(Parser::class);
             $document = $parser->parse($rst);
+
+
+            $compiler = $this->getContainer()->get(Compiler::class);
+            $compiler->run([$document]);
 
             $renderer = $this->getContainer()->get(DelegatingNodeRenderer::class);
             $context = RenderContext::forDocument(

--- a/tests/Functional/tests/citation/citation.html
+++ b/tests/Functional/tests/citation/citation.html
@@ -1,0 +1,5 @@
+<p>Lorem ipsum [Ref] dolor sit amet.</p>
+<div class="citation " id="citation-ref">
+    <div class="citation-label">[Ref]</div>
+    <div class="citation-content">Book or article reference, URL or whatever.</div>
+</div>

--- a/tests/Functional/tests/citation/citation.rst
+++ b/tests/Functional/tests/citation/citation.rst
@@ -1,0 +1,3 @@
+Lorem ipsum [Ref]_ dolor sit amet.
+
+.. [Ref] Book or article reference, URL or whatever.


### PR DESCRIPTION
This enables us to run functional tests on some topics that rely on node transformers and passes as long as they don't rely the project structure