### PR TITLE
Remove role from raw content with domain

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/TextRoleRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/TextRoleRule.php
@@ -34,7 +34,6 @@ class TextRoleRule extends AbstractInlineRule
 
         $initialPosition = $lexer->token?->position;
         $lexer->moveNext();
-
         while ($lexer->token !== null) {
             $token = $lexer->token;
             switch ($token->type) {
@@ -42,7 +41,7 @@ class TextRoleRule extends AbstractInlineRule
                     if ($role !== null) {
                         $domain = $role;
                         $role = $part;
-                        $part = '';
+                        $rawPart = $part = '';
                         break;
                     }
 

--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/InlineRules/TextRoleRuleTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/InlineRules/TextRoleRuleTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Parser\Productions\InlineRules;
+
+use Generator;
+use phpDocumentor\Guides\Nodes\Inline\InlineNode;
+use phpDocumentor\Guides\ParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules\TextRoleRule;
+use phpDocumentor\Guides\RestructuredText\TextRoles\TextRole;
+use phpDocumentor\Guides\RestructuredText\TextRoles\TextRoleFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class TextRoleRuleTest extends TestCase
+{
+    /** @return Generator<string, string[]> */
+    public static function roleFormatProvider(): Generator
+    {
+        yield 'simple role' => [
+            ':role:`content`',
+            'role',
+            'content',
+            'content',
+        ];
+
+        yield 'role with domain' => [
+            ':domain:role:`content`',
+            'domain:role',
+            'content',
+            'content',
+            'domain',
+        ];
+
+        yield 'role with escaped backticks' => [
+            ':role:`con\`tent`',
+            'role',
+            'con`tent',
+            'con`tent',
+        ];
+    }
+
+    #[DataProvider('roleFormatProvider')]
+    public function testApplyDoesPassTheRoleAndDomainToFactory(
+        string $input,
+        string $expectedRole,
+        string $expectedContent,
+        string $expectedRawContent,
+        string|null $expectedDomain = null,
+    ): void {
+        $textRoleFactory = $this->createMock(TextRoleFactory::class);
+
+        $collectingRole = new class implements TextRole {
+            public function getName(): string
+            {
+                return 'role';
+            }
+
+            /** @return string[] */
+            public function getAliases(): array
+            {
+                return [];
+            }
+
+            public function processNode(ParserContext $parserContext, string $role, string $content, string $rawContent): InlineNode
+            {
+                return new class ($role, $content, $rawContent) extends InlineNode {
+                    public function __construct(
+                        public string $role,
+                        public string $content,
+                        public string $rawContent,
+                    ) {
+                        parent::__construct('test', $this->content);
+                    }
+                };
+            }
+        };
+
+        $textRoleFactory->expects($this->once())
+            ->method('getTextRole')
+            ->with('role', $expectedDomain)
+            ->willReturn($collectingRole);
+
+        $lexer = new InlineLexer();
+        $lexer->setInput($input);
+        $lexer->moveNext();
+        $lexer->moveNext();
+
+        $textRoleRule = new TextRoleRule($textRoleFactory);
+        self::assertTrue($textRoleRule->applies($lexer));
+        $node = $textRoleRule->apply(
+            $this->createStub(ParserContext::class),
+            $lexer,
+        );
+
+        /**
+         * @psalm-suppress UndefinedPropertyFetch
+         * @phpstan-ignore-next-line
+         */
+        $this->assertSame($expectedRole, $node->role);
+        /**
+         * @psalm-suppress UndefinedPropertyFetch
+         * @phpstan-ignore-next-line
+         */
+        $this->assertSame($expectedContent, $node->content);
+        /**
+         * @psalm-suppress UndefinedPropertyFetch
+         * @phpstan-ignore-next-line
+         */
+        $this->assertSame($expectedRawContent, $node->rawContent);
+    }
+}


### PR DESCRIPTION
Added a unittest for the TextRoleRule to cover the use cases including the broken behavior that added the role when a role was defined with a domain. 