### PR TITLE
Introduce GitPod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,21 @@
+# Example
+# https://gitpod.io/#https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-TSconfig/tree/main
+
+image: gitpod/workspace-full
+
+tasks:
+  - name: RenderRstGuides
+    init: |
+      git clone git@github.com:linawolf/guides.git guides
+    command: |
+      echo "Run 'bash ./render.sh' to generate all docs."
+
+# gp open ./Documentation-GENERATED-temp/Result/project/0.0.0/_buildinfo/warnings.txt
+# cd ./Documentation-GENERATED-temp/Result/project/0.0.0/
+# nohup php -S localhost:8001 &
+# gp preview "$(gp url 8001)/Index.html" --external
+
+ports:
+  - port: 8001
+    name: t3docspreview
+    onOpen: ignore

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,7 +6,7 @@ image: gitpod/workspace-full
 tasks:
   - name: RenderRstGuides
     init: |
-      git clone git@github.com:linawolf/guides.git guides
+      git clone git@github.com:phpDocumentor/guides.git guides
     command: |
       echo "Run 'bash ./render.sh' to generate all docs."
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,10 +1,10 @@
 # Example
 # https://gitpod.io/#https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-TSconfig/tree/main
 
-image: gitpod/workspace-full
+image: "gitpod/workspace-full"
 
 tasks:
-  - name: RenderRstGuides
+  - name: "RenderRstGuides"
     init: |
       git clone git@github.com:phpDocumentor/guides.git guides
     command: |
@@ -17,5 +17,5 @@ tasks:
 
 ports:
   - port: 8001
-    name: t3docspreview
-    onOpen: ignore
+    name: "guidespreview"
+    onOpen: "ignore"

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ such as Restructured Text, and output formats, such as HTML.
 
 You can try out this reposistory convieniently in GitPod by clicking this button:
 
-..  image::https://gitpod.io/button/open-in-gitpod.svg
+..  image:: https://gitpod.io/button/open-in-gitpod.svg
     :alt: Try out in GitPod
     :target: http://gitpod.io/#/https://github.com/phpDocumentor/guides
 

--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,12 @@ such as Restructured Text, and output formats, such as HTML.
 :Documentation:     https://github.com/phpDocumentor/guides/tree/main/docs/index.rst
 :Packagist:         https://packagist.org/packages/phpdocumentor/guides
 
+You can try out this reposistory convieniently in GitPod by clicking this button:
+
+..  image::https://gitpod.io/button/open-in-gitpod.svg
+    :alt: Try out in GitPod
+    :target: http://gitpod.io/#/https://github.com/phpDocumentor/guides
+
 Attribution
 ===========
 


### PR DESCRIPTION
GitPot is a fast and easy way to try out the guides without installing them on your local system. You can even use it for development with only using a browser.

Attention: Please squash on merging!