### PR TITLE
Create files with host user ids

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PHP_BIN = docker run -it --rm -v${PWD}:/opt/project -w /opt/project php:8.2-cli php -d memory_limit=1024M
+PHP_BIN = docker run -it --rm --user $$(id -u):$$(id -g) -v${PWD}:/opt/project -w /opt/project php:8.2-cli php -d memory_limit=1024M
 
 .PHONY: help
 help: ## Displays this list of targets with descriptions


### PR DESCRIPTION
When running docker with the php image, any command is run as root, unless. It is possible to specify another user to run as with the `--user` option though.
Note that creating the user and group on the docker image does not seem to be required for this to work, so let us just not do it. This spares us from creating a custom entrypoint file.