### PR TITLE
Specify cache directory for Psalm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /.build
 .phpunit.cache
 .deptrac.cache
+/.psalm
 /**/temp
 /output/

--- a/psalm.xml
+++ b/psalm.xml
@@ -2,6 +2,7 @@
 <psalm
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
+    cacheDirectory=".psalm/cache"
     errorLevel="5"
     errorBaseline="psalm-baseline.xml"
     findUnusedBaselineEntry="true"


### PR DESCRIPTION
Before 90fb333, the Psalm cache directory was presumably created in the home directory of the root user.

After that commit, Psalm attempts to create that directory in /, and that fails because of permission issues.

Specifying a cache directory:
- fixes that particular issue;
- more importantly, allows the cache directory to be reused.

Note that `--update-baseline` does not seem to benefit from the cache, so this is really beneficial only when running `vendor/bin/psalm` (no option).

This fixes `make psalm`