### PR TITLE
Add progress bar to the run command

### DIFF
--- a/packages/guides/src/Handlers/RenderCommand.php
+++ b/packages/guides/src/Handlers/RenderCommand.php
@@ -10,10 +10,10 @@ use phpDocumentor\Guides\Nodes\ProjectNode;
 
 final class RenderCommand
 {
-    /** @param DocumentNode[] $documents */
+    /** @param iterable<DocumentNode> $documents */
     public function __construct(
         private readonly string $outputFormat,
-        private readonly array $documents,
+        private readonly iterable $documents,
         private readonly FilesystemInterface $origin,
         private readonly FilesystemInterface $destination,
         private readonly ProjectNode $projectNode,
@@ -26,8 +26,8 @@ final class RenderCommand
         return $this->outputFormat;
     }
 
-    /** @return DocumentNode[] */
-    public function getDocuments(): array
+    /** @return iterable<DocumentNode> */
+    public function getDocuments(): iterable
     {
         return $this->documents;
     }


### PR DESCRIPTION
This adds a progress bar based on how many documents are being processed.

This is not always possible depending on the capabilities of the current `OutputInterface` interface implementation, which it is conditionally created.

For instance, when running tests, you get a `BufferedOutput`, which does not have the section capability.


Closes https://github.com/phpDocumentor/guides/issues/297