### PR TITLE
Be stricter about what happens in tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,6 +8,11 @@
         beStrictAboutTestsThatDoNotTestAnything="true"
         beStrictAboutOutputDuringTests="true"
         beStrictAboutChangesToGlobalState="true"
+        failOnNotice="true"
+        failOnWarning="true"
+        displayDetailsOnTestsThatTriggerNotices="true"
+        displayDetailsOnTestsThatTriggerWarnings="true"
+        displayDetailsOnTestsThatTriggerErrors="true"
         cacheDirectory=".phpunit.cache"
         requireCoverageMetadata="false"
 >


### PR DESCRIPTION
This ensures we cannot have a PHP notice or warning in the test suite. Also, we display details when that happens, for easier debugging.