### PR TITLE
Address deprecation of spaceless tag

### DIFF
--- a/packages/guides/resources/template/html/body/menu/content-menu.html.twig
+++ b/packages/guides/resources/template/html/body/menu/content-menu.html.twig
@@ -1,5 +1,5 @@
-{% spaceless %}
+{% apply spaceless %}
     <div class="contents">
         {% include "body/menu/menu-level.html.twig" %}
     </div>
-{% endspaceless %}
+{% endapply %}

--- a/packages/guides/resources/template/html/body/menu/menu.html.twig
+++ b/packages/guides/resources/template/html/body/menu/menu.html.twig
@@ -1,5 +1,5 @@
-{% spaceless %}
+{% apply spaceless %}
     <div class="menu">
         {% include "body/menu/menu-level.html.twig" %}
     </div>
-{% endspaceless %}
+{% endapply %}

--- a/packages/guides/resources/template/tex/guides/body/paragraph.tex.twig
+++ b/packages/guides/resources/template/tex/guides/body/paragraph.tex.twig
@@ -1,8 +1,8 @@
-{% spaceless %}
+{% apply spaceless %}
 {% set text = renderNode(node.value) %}
 
 {% if text|trim %}
 {{ text|raw }}
 
 {% endif %}
-{% endspaceless %}
+{% endapply %}


### PR DESCRIPTION
Since Twig 2.7, the `spaceless` tag is deprecated in favor of the `spaceless` filter, or the `apply` tag with a `spaceless` argument. I picked the latter so as to still benefit from syntax highlighting.

This is the only deprecation I found while running the test suite with `symfony/phpunit-bridge` locally.