### PR TITLE
Fail on log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "autoload-dev": {
         "psr-4": {
             "phpDocumentor\\Guides\\": ["packages/guides/tests/unit/", "tests/"],
+            "phpDocumentor\\Guides\\Cli\\": "packages/guides-cli/tests/unit",
             "phpDocumentor\\Guides\\Graphs\\": "packages/guides-graphs/tests/unit",
             "phpDocumentor\\Guides\\RestructuredText\\": "packages/guides-restructured-text/tests/unit",
             "phpDocumentor\\Guides\\Markdown\\": "packages/guides-markdown/tests/unit"

--- a/composer.lock
+++ b/composer.lock
@@ -1076,7 +1076,7 @@
             "dist": {
                 "type": "path",
                 "url": "./packages/guides-cli",
-                "reference": "0307a5b03b8ee13c16e1d71a255de9f5768c2a1d"
+                "reference": "24c7a491aaf842817b71ad94edab6be9a276860c"
             },
             "require": {
                 "monolog/monolog": "^2.9",
@@ -1095,6 +1095,13 @@
             "autoload": {
                 "psr-4": {
                     "phpDocumentor\\Guides\\Cli\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "phpDocumentor\\Guides\\": [
+                        "tests/unit/"
+                    ]
                 }
             },
             "license": [

--- a/packages/guides-cli/composer.json
+++ b/packages/guides-cli/composer.json
@@ -11,6 +11,13 @@
             "phpDocumentor\\Guides\\Cli\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "phpDocumentor\\Guides\\": [
+                "tests/unit/"
+            ]
+        }
+    },
     "authors": [
         {
             "name": "jaapio",

--- a/packages/guides-cli/src/Logger/SpyProcessor.php
+++ b/packages/guides-cli/src/Logger/SpyProcessor.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Cli\Logger;
+
+use Monolog\Processor\ProcessorInterface;
+
+/**
+ * This decorator has an extra method to check whether anything was logged
+ *
+ * @internal
+ */
+final class SpyProcessor implements ProcessorInterface
+{
+    private bool $hasBeenCalled = false;
+
+    public function hasBeenCalled(): bool
+    {
+        return $this->hasBeenCalled;
+    }
+
+    /** @inheritDoc */
+    public function __invoke(array $record): array
+    {
+        $this->hasBeenCalled = true;
+
+        return $record;
+    }
+}

--- a/packages/guides-cli/tests/unit/Logger/SpyProcessorTest.php
+++ b/packages/guides-cli/tests/unit/Logger/SpyProcessorTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Cli\Logger;
+
+use PHPUnit\Framework\TestCase;
+
+class SpyProcessorTest extends TestCase
+{
+    public function testHasBeenCalledReturnsFalseByDefault(): void
+    {
+        $spyProcessor = new SpyProcessor();
+
+        $this->assertFalse($spyProcessor->hasBeenCalled());
+    }
+
+    public function testItKnowsWhenALogIsEmitted(): void
+    {
+        $process = new SpyProcessor();
+        $process(['channel' => 'test']);
+        self::assertTrue($process->hasBeenCalled());
+    }
+}


### PR DESCRIPTION
Currently, when all is well, nothing should be logged at all. We can leverage this to use the CLI tool as a linter, and create CI jobs with it.
Here, a new option called `--fail-on-log` is introduced, and it will use a failure exit code as soon as any log is emitted.
This is based on the assumption that the logger is never and will never be called for anything that should not result in a change in the documentation being processed.