### PR TITLE
Fix risky tests

### DIFF
--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/GridTableRuleTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/GridTableRuleTest.php
@@ -270,7 +270,7 @@ RST;
         $context = $this->createContext($input);
         $this->rule->apply($context);
 
-        $this->logger->hasError('Malformed table');
+        self::assertTrue($this->logger->hasErrorThatContains('Malformed table'));
     }
 
     public function testErrorMultipleHeaderRows(): void
@@ -290,7 +290,7 @@ RST;
         $context = $this->createContext($input);
         $this->rule->apply($context);
 
-        $this->logger->hasError('Malformed table: multiple "header rows" using "===" were found');
+        self::assertTrue($this->logger->hasErrorThatContains('Malformed table: multiple "header rows" using "===" were found'));
     }
 
     public function testNotEndingWithWhiteLine(): never
@@ -312,6 +312,6 @@ RST;
         $context = $this->createContext($input);
         $this->rule->apply($context);
 
-        $this->logger->hasError('Malformed table: multiple "header rows" using "===" were found');
+        self::assertTrue($this->logger->hasErrorThatContains('Malformed table: multiple "header rows" using "===" were found'));
     }
 }


### PR DESCRIPTION
When switching to the logger for error handling in https://github.com/phpDocumentor/guides/pull/472 these tests turned risky as logger->hasError returns a boolean that was not asserted until now