### PR TITLE
[BUGFIX] Prevent Duplicates in toctree and menu

### DIFF
--- a/packages/guides/src/Compiler/NodeTransformers/MenuNodeAddEntryTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/MenuNodeAddEntryTransformer.php
@@ -16,6 +16,7 @@ use phpDocumentor\Guides\Nodes\Node;
 use Psr\Log\LoggerInterface;
 
 use function array_pop;
+use function array_unique;
 use function assert;
 use function explode;
 use function implode;
@@ -84,6 +85,8 @@ class MenuNodeAddEntryTransformer implements NodeTransformer
                 }
             }
         }
+
+        $menuEntries = array_unique($menuEntries);
 
         $node = $node->withMenuEntries($menuEntries);
 

--- a/packages/guides/src/Nodes/Menu/MenuEntryNode.php
+++ b/packages/guides/src/Nodes/Menu/MenuEntryNode.php
@@ -72,4 +72,9 @@ final class MenuEntryNode extends AbstractNode
     {
         $this->sections[] = $section;
     }
+
+    public function __toString(): string
+    {
+        return $this->url . '#' . $this->anchor;
+    }
 }

--- a/packages/guides/tests/unit/Compiler/NodeTransformers/MenuNodeAddSubDocumentsTransformerTest.php
+++ b/packages/guides/tests/unit/Compiler/NodeTransformers/MenuNodeAddSubDocumentsTransformerTest.php
@@ -79,8 +79,14 @@ class MenuNodeAddSubDocumentsTransformerTest extends TestCase
             'testRelativeTocUrlInSubdir' => [
                 'current' => 'doc1/index',
                 'paths' =>  ['index', 'doc1', 'doc2','doc1/index' , 'doc1/subdoc1', 'doc1/subdoc2', 'doc1/subdoc3', 'doc3/index'],
-                'tocFiles' => ['subdoc1', 'subdoc1'],
+                'tocFiles' => ['subdoc1', 'subdoc2'],
                 'expectedCount' => 2,
+            ],
+            'testMultipleGetRemoved' => [
+                'current' => 'doc1/index',
+                'paths' =>  ['index', 'doc1', 'doc2','doc1/index' , 'doc1/subdoc1', 'doc1/subdoc2', 'doc1/subdoc3', 'doc3/index'],
+                'tocFiles' => ['subdoc1', 'subdoc1'],
+                'expectedCount' => 1,
             ],
             'testTocTreeAbsoluteGlobDoesNotAddIndex' => [
                 'current' => 'index',
@@ -100,6 +106,13 @@ class MenuNodeAddSubDocumentsTransformerTest extends TestCase
                 'current' => 'index',
                 'paths' =>  ['index', 'doc1', 'doc2', 'doc1/subdoc', 'doc3/doc1'],
                 'tocFiles' => ['*'],
+                'expectedCount' => 2,
+                'glob' => true,
+            ],
+            'testRelativeGlobDoesNotAddDuplicates' => [
+                'current' => 'index',
+                'paths' =>  ['index', 'doc1', 'doc2', 'doc1/subdoc', 'doc3/doc1'],
+                'tocFiles' => ['doc1','*'],
                 'expectedCount' => 2,
                 'glob' => true,
             ],

--- a/tests/Integration/tests/toctree-no-duplicates/expected/index.html
+++ b/tests/Integration/tests/toctree-no-duplicates/expected/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>index</title>
+
+</head>
+<body>
+    <div class="section" id="index">
+    <h1>index</h1>
+
+            <div class="toc">
+    <ul class="phpdocumentor-list">
+    <li class="toc-item"><a href="/overview.html#overview">Overview</a></li>
+
+    <li class="toc-item"><a href="/apple.html#apple">Apple</a></li>
+
+    <li class="toc-item"><a href="/banana.html#banana">Banana</a></li>
+
+    <li class="toc-item"><a href="/cherry.html#cherry">Cherry</a></li>
+
+    </ul>
+</div>
+
+    </div>
+
+</body>
+</html>

--- a/tests/Integration/tests/toctree-no-duplicates/expected/overview.html
+++ b/tests/Integration/tests/toctree-no-duplicates/expected/overview.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Overview</title>
+
+</head>
+<body>
+    <div class="section" id="overview">
+    <h1>Overview</h1>
+
+            <p>Lorem Ipsum Dolor</p>
+            <div class="menu"><ul class="phpdocumentor-list"><li class="toc-item"><a href="/overview.html#overview">Overview</a></li><li class="toc-item"><a href="/apple.html#apple">Apple</a></li><li class="toc-item"><a href="/banana.html#banana">Banana</a></li><li class="toc-item"><a href="/cherry.html#cherry">Cherry</a></li></ul></div>
+    </div>
+
+</body>
+</html>

--- a/tests/Integration/tests/toctree-no-duplicates/input/apple.rst
+++ b/tests/Integration/tests/toctree-no-duplicates/input/apple.rst
@@ -1,0 +1,4 @@
+Apple
+=====
+
+Lorem Ipsum Dolor

--- a/tests/Integration/tests/toctree-no-duplicates/input/banana.rst
+++ b/tests/Integration/tests/toctree-no-duplicates/input/banana.rst
@@ -1,0 +1,4 @@
+Banana
+======
+
+Lorem Ipsum Dolor

--- a/tests/Integration/tests/toctree-no-duplicates/input/cherry.rst
+++ b/tests/Integration/tests/toctree-no-duplicates/input/cherry.rst
@@ -1,0 +1,4 @@
+Cherry
+======
+
+Lorem Ipsum Dolor

--- a/tests/Integration/tests/toctree-no-duplicates/input/index.rst
+++ b/tests/Integration/tests/toctree-no-duplicates/input/index.rst
@@ -1,0 +1,9 @@
+index
+=====
+
+..  toctree::
+    :titlesonly:
+    :glob:
+
+    overview
+    *

--- a/tests/Integration/tests/toctree-no-duplicates/input/overview.rst
+++ b/tests/Integration/tests/toctree-no-duplicates/input/overview.rst
@@ -1,0 +1,9 @@
+Overview
+========
+
+Lorem Ipsum Dolor
+
+..  menu::
+
+    overview
+    *


### PR DESCRIPTION
A page that has already been explicitely added to a toctree does not get added by the glob directive once more. As having multiple occurences of the same page within one toctree or menu does not make sense in general, I applied array_unique to the menu_items of one level of the toctree or menu.

@wouterj, @greg0ire is this behaviour also wanted in the doctrine and symfony docs?