### PR TITLE
[BUGFIX] Fix the DefaultNodeRenderer for array values

### DIFF
--- a/packages/guides/resources/config/guides.php
+++ b/packages/guides/resources/config/guides.php
@@ -153,6 +153,8 @@ return static function (ContainerConfigurator $container): void {
         ->set(MenuEntryRenderer::class)
         ->tag('phpdoc.guides.noderenderer.html')
 
+        ->set(DefaultNodeRenderer::class)
+
         ->set(InMemoryNodeRendererFactory::class)
         ->args([
             '$nodeRenderers' => tagged_iterator('phpdoc.guides.noderenderer.html'),

--- a/packages/guides/resources/template/html/inline/variable.html.twig
+++ b/packages/guides/resources/template/html/inline/variable.html.twig
@@ -1,1 +1,2 @@
-{{ renderNode(node.child) }}
+{% apply spaceless %}{{ renderNode(node.child) }}
+{% endapply %}

--- a/tests/Integration/tests/variables-from-project/expected/index.html
+++ b/tests/Integration/tests/variables-from-project/expected/index.html
@@ -8,9 +8,7 @@
     <div class="section" id="some-document">
     <h1>Some Document</h1>
 
-            <p>Project My Project
- in version 3.14
-</p>
+            <p>Project My Project in version 3.14</p>
     </div>
 
 </body>

--- a/tests/Integration/tests/variables-replace/expected/index.html
+++ b/tests/Integration/tests/variables-replace/expected/index.html
@@ -8,8 +8,7 @@
     <div class="section" id="document-title">
     <h1>Document Title</h1>
 
-            <p>We are using ReStructuredText
- here.</p>
+            <p>We are using ReStructuredText here.</p>
     </div>
 
 </body>


### PR DESCRIPTION
Up to now when the value of a node was an array (as for nodes replace and compound) there was an empty string returned in rendering. Added handling of array values (which fixes rendering of the replace directive) and added errrors in case a node that cannot be handled by the defaultnoderenderer is passed to it.

Additionally I removed the superflous new lines in rendering of inline variables

resolves https://github.com/phpDocumentor/guides/issues/509