### PR TITLE
[BUGFIX] make horizontal rules work in document body

### DIFF
--- a/packages/guides-restructured-text/resources/config/guides-restructured-text.php
+++ b/packages/guides-restructured-text/resources/config/guides-restructured-text.php
@@ -229,6 +229,8 @@ return static function (ContainerConfigurator $container): void {
         ->tag('phpdoc.guides.parser.rst.body_element', ['priority' => FieldListRule::PRIORITY])
         ->set(ParagraphRule::class)
         ->tag('phpdoc.guides.parser.rst.body_element', ['priority' => ParagraphRule::PRIORITY])
+        ->set(TransitionRule::class)
+        ->tag('phpdoc.guides.parser.rst.body_element', ['priority' => TransitionRule::PRIORITY])
         ->set(InlineMarkupRule::class)
         ->set(TitleRule::class)
 
@@ -287,8 +289,6 @@ return static function (ContainerConfigurator $container): void {
         ])
         ->tag('phpdoc.guides.parser.rst.fieldlist')
 
-        ->set(TransitionRule::class)
-        ->tag('phpdoc.guides.parser.rst.structural_element', ['priority' => TransitionRule::PRIORITY])
         ->set(SectionRule::class)
         ->tag('phpdoc.guides.parser.rst.structural_element', ['priority' => SectionRule::PRIORITY])
 

--- a/tests/Integration/tests/horizontal-line/expected/index.html
+++ b/tests/Integration/tests/horizontal-line/expected/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Some Document</title>
+
+</head>
+<body>
+<div class="section" id="some-document">
+    <h1>Some Document</h1>
+
+    <p>Testing separator</p>
+    <hr />
+
+    <p>Hey!</p>
+</div>
+
+</body>
+</html>

--- a/tests/Integration/tests/horizontal-line/input/index.rst
+++ b/tests/Integration/tests/horizontal-line/input/index.rst
@@ -1,0 +1,9 @@
+
+Some Document
+=============
+
+Testing separator
+
+-------
+
+Hey!


### PR DESCRIPTION
They only worked before the first headline