### PR TITLE
[FEATURE] Make DocumentParserContext Availible in InlineRules

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Parser/InlineParser.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/InlineParser.php
@@ -7,7 +7,6 @@ namespace phpDocumentor\Guides\RestructuredText\Parser;
 use Exception;
 use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 use phpDocumentor\Guides\Nodes\InlineCompoundNode;
-use phpDocumentor\Guides\ParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules\InlineRule;
 
 use function usort;
@@ -26,7 +25,7 @@ class InlineParser
         });
     }
 
-    public function parse(string $content, ParserContext $parserContext): InlineCompoundNode
+    public function parse(string $content, DocumentParserContext $documentParserContext): InlineCompoundNode
     {
         $lexer = new InlineLexer();
         $lexer->setInput($content);
@@ -38,7 +37,7 @@ class InlineParser
             foreach ($this->rules as $inlineRule) {
                 $node = null;
                 if ($inlineRule->applies($lexer)) {
-                    $node = $inlineRule->apply($parserContext, $lexer);
+                    $node = $inlineRule->apply($documentParserContext, $lexer);
                 }
 
                 if ($node === null) {

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineMarkupRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineMarkupRule.php
@@ -63,7 +63,7 @@ final class InlineMarkupRule implements Rule
         $documentIterator = $documentParserContext->getDocumentIterator();
         $buffer = $this->collectContent($documentIterator);
 
-        $node = $this->inlineTokenParser->parse($buffer->getLinesString(), $documentParserContext->getContext());
+        $node = $this->inlineTokenParser->parse($buffer->getLinesString(), $documentParserContext);
 
         if ($on !== null) {
             $on->setValue([$node]);

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/AnnotationRoleRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/AnnotationRoleRule.php
@@ -7,8 +7,8 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 use phpDocumentor\Guides\Nodes\Inline\CitationInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\FootnoteInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
-use phpDocumentor\Guides\ParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\AnnotationUtility;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 /**
@@ -21,7 +21,7 @@ class AnnotationRoleRule extends AbstractInlineRule
         return $lexer->token?->type === InlineLexer::ANNOTATION_START;
     }
 
-    public function apply(ParserContext $parserContext, InlineLexer $lexer): InlineNode|null
+    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): InlineNode|null
     {
         $startPosition = $lexer->token?->position;
         $annotationName = '';

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/AnonymousPhraseRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/AnonymousPhraseRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\HyperLinkNode;
-use phpDocumentor\Guides\ParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 /**
@@ -25,7 +25,7 @@ class AnonymousPhraseRule extends ReferenceRule
         return $lexer->token?->type === InlineLexer::BACKTICK;
     }
 
-    public function apply(ParserContext $parserContext, InlineLexer $lexer): HyperLinkNode|null
+    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): HyperLinkNode|null
     {
         $text = '';
         $embeddedUrl = null;
@@ -36,7 +36,7 @@ class AnonymousPhraseRule extends ReferenceRule
                 case InlineLexer::PHRASE_ANONYMOUS_END:
                     $lexer->moveNext();
 
-                    return $this->createAnonymousReference($parserContext, $text, $embeddedUrl);
+                    return $this->createAnonymousReference($documentParserContext, $text, $embeddedUrl);
 
                 case InlineLexer::EMBEDED_URL_START:
                     $embeddedUrl = $this->parseEmbeddedUrl($lexer);
@@ -57,11 +57,11 @@ class AnonymousPhraseRule extends ReferenceRule
         return null;
     }
 
-    private function createAnonymousReference(ParserContext $parserContext, string $link, string|null $embeddedUrl): HyperLinkNode
+    private function createAnonymousReference(DocumentParserContext $documentParserContext, string $link, string|null $embeddedUrl): HyperLinkNode
     {
-        $parserContext->resetAnonymousStack();
-        $node = $this->createReference($parserContext, $link, $embeddedUrl, false);
-        $parserContext->pushAnonymous($link);
+        $documentParserContext->getContext()->resetAnonymousStack();
+        $node = $this->createReference($documentParserContext, $link, $embeddedUrl, false);
+        $documentParserContext->getContext()->pushAnonymous($link);
 
         return $node;
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/AnonymousReferenceRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/AnonymousReferenceRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\HyperLinkNode;
-use phpDocumentor\Guides\ParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 use function trim;
@@ -26,10 +26,10 @@ class AnonymousReferenceRule extends ReferenceRule
         return $lexer->token?->type === InlineLexer::ANONYMOUSE_REFERENCE;
     }
 
-    public function apply(ParserContext $parserContext, InlineLexer $lexer): HyperLinkNode|null
+    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): HyperLinkNode|null
     {
         $node = $this->createAnonymousReference(
-            $parserContext,
+            $documentParserContext,
             trim((string) $lexer->token?->value, '_'),
         );
         $lexer->moveNext();
@@ -37,11 +37,11 @@ class AnonymousReferenceRule extends ReferenceRule
         return $node;
     }
 
-    private function createAnonymousReference(ParserContext $parserContext, string $link): HyperLinkNode
+    private function createAnonymousReference(DocumentParserContext $documentParserContext, string $link): HyperLinkNode
     {
-        $parserContext->resetAnonymousStack();
-        $node = $this->createReference($parserContext, $link, null, false);
-        $parserContext->pushAnonymous($link);
+        $documentParserContext->getContext()->resetAnonymousStack();
+        $node = $this->createReference($documentParserContext, $link, null, false);
+        $documentParserContext->getContext()->pushAnonymous($link);
 
         return $node;
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/DefaultTextRoleRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/DefaultTextRoleRule.php
@@ -6,7 +6,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
 use phpDocumentor\Guides\Nodes\Inline\LiteralInlineNode;
-use phpDocumentor\Guides\ParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 /**
@@ -19,7 +19,7 @@ class DefaultTextRoleRule extends AbstractInlineRule
         return $lexer->token?->type === InlineLexer::BACKTICK;
     }
 
-    public function apply(ParserContext $parserContext, InlineLexer $lexer): InlineNode|null
+    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): InlineNode|null
     {
         $text = '';
 

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/EmphasisRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/EmphasisRule.php
@@ -6,7 +6,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\EmphasisInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
-use phpDocumentor\Guides\ParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 /**
@@ -19,7 +19,7 @@ class EmphasisRule extends AbstractInlineRule
         return $lexer->token?->type === InlineLexer::EMPHASIS_DELIMITER;
     }
 
-    public function apply(ParserContext $parserContext, InlineLexer $lexer): InlineNode|null
+    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): InlineNode|null
     {
         $text = '';
 

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/EscapeRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/EscapeRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
-use phpDocumentor\Guides\ParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 use function preg_match;
@@ -21,7 +21,7 @@ class EscapeRule extends ReferenceRule
         return $lexer->token?->type === InlineLexer::ESCAPED_SIGN;
     }
 
-    public function apply(ParserContext $parserContext, InlineLexer $lexer): PlainTextInlineNode|null
+    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): PlainTextInlineNode|null
     {
         $char = $lexer->token?->value ?? '';
         $char = substr($char, 1);

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/InlineRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/InlineRule.php
@@ -14,14 +14,14 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
-use phpDocumentor\Guides\ParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 interface InlineRule
 {
     public function applies(InlineLexer $lexer): bool;
 
-    public function apply(ParserContext $parserContext, InlineLexer $lexer): InlineNode|null;
+    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): InlineNode|null;
 
     public function getPriority(): int;
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/InternalReferenceRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/InternalReferenceRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
-use phpDocumentor\Guides\ParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 class InternalReferenceRule extends ReferenceRule
@@ -15,7 +15,7 @@ class InternalReferenceRule extends ReferenceRule
         return $lexer->token?->type === InlineLexer::INTERNAL_REFERENCE_START;
     }
 
-    public function apply(ParserContext $parserContext, InlineLexer $lexer): InlineNode|null
+    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): InlineNode|null
     {
         $text = '';
         $initialPosition = $lexer->token?->position;
@@ -25,7 +25,7 @@ class InternalReferenceRule extends ReferenceRule
                 case InlineLexer::BACKTICK:
                     $lexer->moveNext();
 
-                    return $this->createReference($parserContext, $text);
+                    return $this->createReference($documentParserContext, $text);
 
                 default:
                     $text .= $lexer->token->value;

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/LiteralRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/LiteralRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\LiteralInlineNode;
-use phpDocumentor\Guides\ParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 use function strlen;
@@ -21,7 +21,7 @@ class LiteralRule extends AbstractInlineRule
         return $lexer->token?->type === InlineLexer::LITERAL;
     }
 
-    public function apply(ParserContext $parserContext, InlineLexer $lexer): LiteralInlineNode
+    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): LiteralInlineNode
     {
         $literal = $lexer->token?->value ?? '';
         if (strlen($literal) > 4) {

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/NamedPhraseRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/NamedPhraseRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
-use phpDocumentor\Guides\ParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 /**
@@ -25,7 +25,7 @@ class NamedPhraseRule extends ReferenceRule
         return $lexer->token?->type === InlineLexer::BACKTICK;
     }
 
-    public function apply(ParserContext $parserContext, InlineLexer $lexer): InlineNode|null
+    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): InlineNode|null
     {
         $text = '';
         $embeddedUrl = null;
@@ -39,7 +39,7 @@ class NamedPhraseRule extends ReferenceRule
                         $text = $embeddedUrl ?? '';
                     }
 
-                    return $this->createReference($parserContext, $text, $embeddedUrl);
+                    return $this->createReference($documentParserContext, $text, $embeddedUrl);
 
                 case InlineLexer::EMBEDED_URL_START:
                     $embeddedUrl = $this->parseEmbeddedUrl($lexer);

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/NamedReferenceRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/NamedReferenceRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
-use phpDocumentor\Guides\ParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 use function rtrim;
@@ -26,10 +26,10 @@ class NamedReferenceRule extends ReferenceRule
         return $lexer->token?->type === InlineLexer::NAMED_REFERENCE;
     }
 
-    public function apply(ParserContext $parserContext, InlineLexer $lexer): InlineNode|null
+    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): InlineNode|null
     {
         $value = rtrim($lexer->token?->value ?? '', '_');
-        $node = $this->createReference($parserContext, $value);
+        $node = $this->createReference($documentParserContext, $value);
 
         $lexer->moveNext();
 

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/NbspRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/NbspRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\WhitespaceInlineNode;
-use phpDocumentor\Guides\ParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 /**
@@ -18,7 +18,7 @@ class NbspRule extends ReferenceRule
         return $lexer->token?->type === InlineLexer::NBSP;
     }
 
-    public function apply(ParserContext $parserContext, InlineLexer $lexer): WhitespaceInlineNode
+    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): WhitespaceInlineNode
     {
         $lexer->moveNext();
 

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/PlainTextRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/PlainTextRule.php
@@ -6,7 +6,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
 use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
-use phpDocumentor\Guides\ParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 class PlainTextRule implements InlineRule
@@ -16,7 +16,7 @@ class PlainTextRule implements InlineRule
         return true;
     }
 
-    public function apply(ParserContext $parserContext, InlineLexer $lexer): InlineNode|null
+    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): InlineNode|null
     {
         $node = new PlainTextInlineNode($lexer->token?->value ?? '');
         $lexer->moveNext();

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/ReferenceRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/ReferenceRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\HyperLinkNode;
-use phpDocumentor\Guides\ParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 use function preg_replace;
@@ -14,7 +14,7 @@ use function trim;
 
 abstract class ReferenceRule extends AbstractInlineRule
 {
-    protected function createReference(ParserContext $parserContext, string $link, string|null $embeddedUrl = null, bool $registerLink = true): HyperLinkNode
+    protected function createReference(DocumentParserContext $documentParserContext, string $link, string|null $embeddedUrl = null, bool $registerLink = true): HyperLinkNode
     {
         // the link may have a new line in it, so we need to strip it
         // before setting the link and adding a token to be replaced
@@ -22,7 +22,7 @@ abstract class ReferenceRule extends AbstractInlineRule
         $link = trim(preg_replace('/\s+/', ' ', $link) ?? '');
 
         if ($registerLink && $embeddedUrl !== null) {
-            $parserContext->setLink($link, $embeddedUrl);
+            $documentParserContext->getContext()->setLink($link, $embeddedUrl);
         }
 
         return new HyperLinkNode($link, $embeddedUrl ?? $link);

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/StandaloneEmailRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/StandaloneEmailRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\HyperLinkNode;
-use phpDocumentor\Guides\ParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 /**
@@ -24,10 +24,10 @@ class StandaloneEmailRule extends ReferenceRule
         return $lexer->token?->type === InlineLexer::EMAIL;
     }
 
-    public function apply(ParserContext $parserContext, InlineLexer $lexer): HyperLinkNode|null
+    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): HyperLinkNode|null
     {
         $value = $lexer->token?->value ?? '';
-        $node = $this->createReference($parserContext, $value, $value, false);
+        $node = $this->createReference($documentParserContext, $value, $value, false);
 
         $lexer->moveNext();
 

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/StandaloneHyperlinkRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/StandaloneHyperlinkRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\HyperLinkNode;
-use phpDocumentor\Guides\ParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 /**
@@ -24,10 +24,10 @@ class StandaloneHyperlinkRule extends ReferenceRule
         return $lexer->token?->type === InlineLexer::HYPERLINK;
     }
 
-    public function apply(ParserContext $parserContext, InlineLexer $lexer): HyperLinkNode|null
+    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): HyperLinkNode|null
     {
         $value = $lexer->token?->value ?? '';
-        $node = $this->createReference($parserContext, $value, $value, false);
+        $node = $this->createReference($documentParserContext, $value, $value, false);
 
         $lexer->moveNext();
 

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/StrongRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/StrongRule.php
@@ -6,7 +6,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
 use phpDocumentor\Guides\Nodes\Inline\StrongInlineNode;
-use phpDocumentor\Guides\ParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 /**
@@ -19,7 +19,7 @@ class StrongRule extends AbstractInlineRule
         return $lexer->token?->type === InlineLexer::STRONG_DELIMITER;
     }
 
-    public function apply(ParserContext $parserContext, InlineLexer $lexer): InlineNode|null
+    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): InlineNode|null
     {
         $text = '';
 

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/TextRoleRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/TextRoleRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
-use phpDocumentor\Guides\ParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 use phpDocumentor\Guides\RestructuredText\TextRoles\TextRoleFactory;
 
@@ -25,7 +25,7 @@ class TextRoleRule extends AbstractInlineRule
         return $lexer->token?->type === InlineLexer::COLON;
     }
 
-    public function apply(ParserContext $parserContext, InlineLexer $lexer): InlineNode|null
+    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): InlineNode|null
     {
         $domain = null;
         $role = null;
@@ -58,7 +58,7 @@ class TextRoleRule extends AbstractInlineRule
                         $fullRole = ($domain ? $domain . ':' : '') . $role;
                         $lexer->moveNext();
 
-                        return $textRole->processNode($parserContext, $fullRole, $part, $rawPart);
+                        return $textRole->processNode($documentParserContext->getContext(), $fullRole, $part, $rawPart);
                     }
 
                     $inText = true;

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/VariableInlineRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/VariableInlineRule.php
@@ -6,7 +6,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
 use phpDocumentor\Guides\Nodes\Inline\VariableInlineNode;
-use phpDocumentor\Guides\ParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 /**
@@ -19,7 +19,7 @@ class VariableInlineRule extends AbstractInlineRule
         return $lexer->token?->type === InlineLexer::VARIABLE_DELIMITER;
     }
 
-    public function apply(ParserContext $parserContext, InlineLexer $lexer): InlineNode|null
+    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): InlineNode|null
     {
         $text = '';
 

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/TitleRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/TitleRule.php
@@ -74,13 +74,11 @@ class TitleRule implements Rule
         $documentIterator->next();
         $documentIterator->next();
 
-        $context = $documentParserContext->getContext();
-
         $letter = $overlineLetter ?: $underlineLetter;
         $level = $documentParserContext->getLevel($overlineLetter, $underlineLetter);
 
         return new TitleNode(
-            $this->inlineTokenParser->parse($title, $context),
+            $this->inlineTokenParser->parse($title, $documentParserContext),
             $level,
             (new AsciiSlugger())->slug($title)->lower()->toString(),
         );

--- a/packages/guides-restructured-text/tests/unit/Parser/InlineTokenParserTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/InlineTokenParserTest.php
@@ -15,7 +15,6 @@ use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\StrongInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\VariableInlineNode;
 use phpDocumentor\Guides\Nodes\InlineCompoundNode;
-use phpDocumentor\Guides\ParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules\AnnotationRoleRule;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules\AnonymousPhraseRule;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules\AnonymousReferenceRule;
@@ -42,13 +41,13 @@ use PHPUnit\Framework\TestCase;
 final class InlineTokenParserTest extends TestCase
 {
     public Logger $logger;
-    private ParserContext&MockObject $parserContext;
+    private DocumentParserContext&MockObject $documentParserContext;
     private InlineParser $inlineTokenParser;
 
     public function setUp(): void
     {
         $this->logger = new Logger('test');
-        $this->parserContext = $this->createMock(ParserContext::class);
+        $this->documentParserContext = $this->createMock(DocumentParserContext::class);
         $defaultTextRoleFactory = new DefaultTextRoleFactory(
             new GenericTextRole(),
             [
@@ -78,7 +77,7 @@ final class InlineTokenParserTest extends TestCase
     #[DataProvider('inlineNodeProvider')]
     public function testString(string $content, InlineCompoundNode $expected): void
     {
-        $result = $this->inlineTokenParser->parse($content, $this->parserContext);
+        $result = $this->inlineTokenParser->parse($content, $this->documentParserContext);
         self::assertEquals($expected, $result);
     }
 

--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/InlineRules/TextRoleRuleTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/InlineRules/TextRoleRuleTest.php
@@ -7,6 +7,7 @@ namespace phpDocumentor\Guides\Parser\Productions\InlineRules;
 use Generator;
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
 use phpDocumentor\Guides\ParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules\TextRoleRule;
 use phpDocumentor\Guides\RestructuredText\TextRoles\TextRole;
@@ -91,7 +92,7 @@ final class TextRoleRuleTest extends TestCase
         $textRoleRule = new TextRoleRule($textRoleFactory);
         self::assertTrue($textRoleRule->applies($lexer));
         $node = $textRoleRule->apply(
-            $this->createStub(ParserContext::class),
+            $this->createStub(DocumentParserContext::class),
             $lexer,
         );
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.13.1@086b94371304750d1c673315321a55d15fc59015">
+<files psalm-version="5.14.1@b9d355e0829c397b9b3b47d0c0ed042a8a70284d">
   <file src="packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DocumentRule.php">
     <MoreSpecificImplementedParamType>
       <code>$on</code>


### PR DESCRIPTION
The ParserContext is a Part of the DocumentParserContext, therefore information got lost that will be needed