### PR TITLE
[BUGFIX] Correct Namespace in Test

### DIFF
--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/InlineRules/TextRoleRuleTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/InlineRules/TextRoleRuleTest.php
@@ -2,13 +2,12 @@
 
 declare(strict_types=1);
 
-namespace phpDocumentor\Guides\Parser\Productions\InlineRules;
+namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use Generator;
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
 use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
-use phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules\TextRoleRule;
 use phpDocumentor\Guides\RestructuredText\TextRoles\TextRole;
 use phpDocumentor\Guides\RestructuredText\TextRoles\TextRoleFactory;
 use PHPUnit\Framework\Attributes\DataProvider;


### PR DESCRIPTION
The Namespace was not inline with those of the classes causing unnecessary imports and warnings in the IDE.