### PR TITLE
[BUGFIX] Content of the code role must not be escaped

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/TextRoleRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/TextRoleRule.php
@@ -70,11 +70,7 @@ class TextRoleRule extends AbstractInlineRule
                     break;
                 case InlineLexer::ESCAPED_SIGN:
                     $part .= substr($token->value, 1);
-                    if ($token->value === '\`') {
-                        $rawPart .= '`';
-                    } else {
-                        $rawPart .= $token->value;
-                    }
+                    $rawPart .= $token->value;
 
                     break;
                 default:

--- a/packages/guides-restructured-text/src/RestructuredText/TextRoles/LiteralTextRole.php
+++ b/packages/guides-restructured-text/src/RestructuredText/TextRoles/LiteralTextRole.php
@@ -11,6 +11,12 @@ class LiteralTextRole extends BaseTextRole
 {
     protected string $name = 'literal';
 
+    /** @return string[] */
+    public function getAliases(): array
+    {
+        return ['code'];
+    }
+
     public function processNode(
         DocumentParserContext $documentParserContext,
         string $role,

--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/InlineRules/TextRoleRuleTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/InlineRules/TextRoleRuleTest.php
@@ -39,7 +39,7 @@ final class TextRoleRuleTest extends TestCase
             ':role:`con\`tent`',
             'role',
             'con`tent',
-            'con`tent',
+            'con\`tent',
         ];
     }
 

--- a/tests/Functional/tests/code-textrole-no-escape/code-textrole-no-escape.html
+++ b/tests/Functional/tests/code-textrole-no-escape/code-textrole-no-escape.html
@@ -1,0 +1,3 @@
+<p><code>Backslashes are not escaped \\ \` \&lt; in literals</code></p>
+<p><code>Backslashes are not escaped \\ \` \&lt; in default text roles</code></p>
+<p><code>Backslashes are not escaped \\ \` \&lt; in code</code></p>

--- a/tests/Functional/tests/code-textrole-no-escape/code-textrole-no-escape.rst
+++ b/tests/Functional/tests/code-textrole-no-escape/code-textrole-no-escape.rst
@@ -1,0 +1,5 @@
+``Backslashes are not escaped \\ \` \< in literals``
+
+`Backslashes are not escaped \\ \` \< in default text roles`
+
+:code:`Backslashes are not escaped \\ \` \< in code`

--- a/tests/Functional/tests/escape/escape.html
+++ b/tests/Functional/tests/escape/escape.html
@@ -1,5 +1,5 @@
 <p>Testing that this is escaped: &lt;script&gt;</p>
 <p>*4, class_, *args, **kwargs, `TeX-quoted&#039;, *ML, *.txt, ``random``</p>
-<p>Literals containing backslashes: <code>App\Entity\Example</code>, <code>some`thing</code>.</p>
+<p>Literals containing backslashes: <code>App\Entity\Example</code>, <code>some\`thing</code>.</p>
 <p>Escaped whitespaces are removed, like <strong>re</strong>Structured.</p>
 <p>Other escape characters are <strong>ignored</strong>, but these ones aren&#039;t: \stdClass, <strong>\stdClass</strong></p>


### PR DESCRIPTION
This is the behaviour of code and literal text roles in Sphinx and reST in general. All three roles now produce the same output