### PR TITLE
!!![TASK] Move LineIterators to Block Context

### DIFF
--- a/packages/guides-graphs/src/Graphs/Directives/UmlDirective.php
+++ b/packages/guides-graphs/src/Graphs/Directives/UmlDirective.php
@@ -8,8 +8,8 @@ use phpDocumentor\Guides\Graphs\Nodes\UmlNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\ParserContext;
 use phpDocumentor\Guides\RestructuredText\Directives\BaseDirective;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use Psr\Log\LoggerInterface;
 use Webmozart\Assert\Assert;
 
@@ -46,13 +46,13 @@ final class UmlDirective extends BaseDirective
 
     /** {@inheritDoc} */
     public function process(
-        DocumentParserContext $documentParserContext,
+        BlockContext $blockContext,
         Directive $directive,
     ): Node|null {
-        $parser = $documentParserContext->getParser();
+        $parser = $blockContext->getDocumentParserContext()->getParser();
         $parserContext = $parser->getParserContext();
 
-        $value = implode("\n", $documentParserContext->getDocumentIterator()->toArray());
+        $value = implode("\n", $blockContext->getDocumentIterator()->toArray());
 
         if (empty($value)) {
             $value = $this->loadExternalUmlFile($parserContext, $directive->getData());

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ActionDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ActionDirective.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 
 /**
  * Extend this class to create a directive that does some actions, for example on the parser context, without
@@ -15,21 +15,21 @@ use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 abstract class ActionDirective extends BaseDirective
 {
     public function process(
-        DocumentParserContext $documentParserContext,
+        BlockContext $blockContext,
         Directive $directive,
     ): Node|null {
-        $this->processAction($documentParserContext, $directive);
+        $this->processAction($blockContext, $directive);
 
         return null;
     }
 
     /**
-     * @param DocumentParserContext $documentParserContext the current document context with the content
+     * @param BlockContext $blockContext the current document context with the content
      *    of the directive
      * @param Directive $directive parsed directive containing options and variable
      */
     abstract public function processAction(
-        DocumentParserContext $documentParserContext,
+        BlockContext $blockContext,
         Directive $directive,
     ): void;
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/BaseDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/BaseDirective.php
@@ -6,9 +6,9 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 use phpDocumentor\Guides\Nodes\GenericNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 use phpDocumentor\Guides\RestructuredText\Parser\DirectiveOption;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 
 use function array_map;
 
@@ -50,15 +50,15 @@ abstract class BaseDirective
      *
      * The node that directly follows the directive is also passed to it
      *
-     * @param DocumentParserContext $documentParserContext the current document context with the content
+     * @param BlockContext $blockContext the current document context with the content
      *    of the directive
      * @param Directive $directive parsed directive containing options and variable
      */
     public function process(
-        DocumentParserContext $documentParserContext,
+        BlockContext $blockContext,
         Directive $directive,
     ): Node|null {
-        return $this->processNode($documentParserContext, $directive)
+        return $this->processNode($blockContext, $directive)
             // Ensure options are always available
             ->withOptions($this->optionsToArray($directive->getOptions()));
     }
@@ -70,7 +70,7 @@ abstract class BaseDirective
      * The arguments are the same that process
      */
     public function processNode(
-        DocumentParserContext $documentParserContext,
+        BlockContext $blockContext,
         Directive $directive,
     ): Node {
         return new GenericNode($directive->getVariable(), $directive->getData());

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/CodeBlockDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/CodeBlockDirective.php
@@ -7,9 +7,9 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 use phpDocumentor\Guides\Nodes\CodeNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Directives\OptionMapper\CodeNodeOptionMapper;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 use phpDocumentor\Guides\RestructuredText\Parser\DirectiveOption;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 
 use function trim;
 
@@ -43,11 +43,11 @@ class CodeBlockDirective extends BaseDirective
 
     /** {@inheritDoc} */
     public function process(
-        DocumentParserContext $documentParserContext,
+        BlockContext $blockContext,
         Directive $directive,
     ): Node|null {
         $node = new CodeNode(
-            $documentParserContext->getDocumentIterator()->toArray(),
+            $blockContext->getDocumentIterator()->toArray(),
         );
 
         $node->setLanguage(trim($directive->getData()));
@@ -56,7 +56,7 @@ class CodeBlockDirective extends BaseDirective
         $this->codeNodeOptionMapper->apply($node, $directive->getOptions());
 
         if ($directive->getVariable() !== '') {
-            $document = $documentParserContext->getDocument();
+            $document = $blockContext->getDocumentParserContext()->getDocument();
             $document->addVariable($directive->getVariable(), $node);
 
             return null;

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ContentsDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ContentsDirective.php
@@ -6,8 +6,8 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 use phpDocumentor\Guides\Nodes\Menu\ContentMenuNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\UrlGeneratorInterface;
 
 /**
@@ -28,13 +28,13 @@ class ContentsDirective extends BaseDirective
 
     /** {@inheritDoc} */
     public function process(
-        DocumentParserContext $documentParserContext,
+        BlockContext $blockContext,
         Directive $directive,
     ): Node|null {
         $options = $directive->getOptions();
         $absoluteUrl = $this->urlGenerator->absoluteUrl(
-            $documentParserContext->getContext()->getDirName(),
-            $documentParserContext->getContext()->getCurrentFileName(),
+            $blockContext->getDocumentParserContext()->getContext()->getDirName(),
+            $blockContext->getDocumentParserContext()->getContext()->getCurrentFileName(),
         );
 
         return (new ContentMenuNode([$absoluteUrl]))

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/DefaultRoleDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/DefaultRoleDirective.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 
 /**
  * sets the default interpreted text role, the role that is used for interpreted text without an explicit role.
@@ -29,10 +29,10 @@ class DefaultRoleDirective extends ActionDirective
     }
 
     public function processAction(
-        DocumentParserContext $documentParserContext,
+        BlockContext $blockContext,
         Directive $directive,
     ): void {
         $name = $directive->getData();
-        $documentParserContext->getTextRoleFactoryForDocument()->setDefaultTextRole($name);
+        $blockContext->getDocumentParserContext()->getTextRoleFactoryForDocument()->setDefaultTextRole($name);
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ImageDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ImageDirective.php
@@ -6,8 +6,8 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 use phpDocumentor\Guides\Nodes\ImageNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\UrlGeneratorInterface;
 
 use function dirname;
@@ -32,12 +32,12 @@ class ImageDirective extends BaseDirective
 
     /** {@inheritDoc} */
     public function processNode(
-        DocumentParserContext $documentParserContext,
+        BlockContext $blockContext,
         Directive $directive,
     ): Node {
         return new ImageNode(
             $this->urlGenerator->absoluteUrl(
-                dirname($documentParserContext->getContext()->getCurrentAbsolutePath()),
+                dirname($blockContext->getDocumentParserContext()->getContext()->getCurrentAbsolutePath()),
                 $directive->getData(),
             ),
         );

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/IncludeDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/IncludeDirective.php
@@ -17,8 +17,8 @@ use phpDocumentor\Guides\Nodes\CodeNode;
 use phpDocumentor\Guides\Nodes\LiteralBlockNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Nodes\CollectionNode;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use RuntimeException;
 
 use function array_key_exists;
@@ -35,10 +35,10 @@ final class IncludeDirective extends BaseDirective
 
     /** {@inheritDoc} */
     public function processNode(
-        DocumentParserContext $documentParserContext,
+        BlockContext $blockContext,
         Directive $directive,
     ): Node {
-        $parser = $documentParserContext->getParser();
+        $parser = $blockContext->getDocumentParserContext()->getParser();
         $subParser = $parser->getSubParser();
         $parserContext = $parser->getParserContext();
         $path = $parserContext->absoluteRelativePath($directive->getData());

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/LaTeXMain.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/LaTeXMain.php
@@ -6,8 +6,8 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 use phpDocumentor\Guides\Nodes\MainNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 
 /**
  * Marks the document as LaTeX main
@@ -21,7 +21,7 @@ class LaTeXMain extends BaseDirective
 
     /** {@inheritDoc} */
     public function processNode(
-        DocumentParserContext $documentParserContext,
+        BlockContext $blockContext,
         Directive $directive,
     ): Node {
         return new MainNode($directive->getData());

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/LiteralincludeDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/LiteralincludeDirective.php
@@ -16,8 +16,8 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 use phpDocumentor\Guides\Nodes\CodeNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Directives\OptionMapper\CodeNodeOptionMapper;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use RuntimeException;
 
 use function explode;
@@ -36,10 +36,10 @@ final class LiteralincludeDirective extends BaseDirective
 
     /** {@inheritDoc} */
     public function processNode(
-        DocumentParserContext $documentParserContext,
+        BlockContext $blockContext,
         Directive $directive,
     ): Node {
-        $parser = $documentParserContext->getParser();
+        $parser = $blockContext->getDocumentParserContext()->getParser();
         $parserContext = $parser->getParserContext();
         $path = $parserContext->absoluteRelativePath($directive->getData());
 

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/MenuDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/MenuDirective.php
@@ -6,9 +6,9 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 use phpDocumentor\Guides\Nodes\Menu\NavMenuNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 use phpDocumentor\Guides\RestructuredText\Parser\DirectiveOption;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Toc\ToctreeBuilder;
 
 use function count;
@@ -33,10 +33,10 @@ class MenuDirective extends BaseDirective
 
     /** {@inheritDoc} */
     public function process(
-        DocumentParserContext $documentParserContext,
+        BlockContext $blockContext,
         Directive $directive,
     ): Node|null {
-        $parserContext = $documentParserContext->getParser()->getParserContext();
+        $parserContext = $blockContext->getDocumentParserContext()->getParser()->getParserContext();
         $options = $directive->getOptions();
         $options['glob'] = new DirectiveOption('glob', true);
         $options['titlesonly'] = new DirectiveOption('titlesonly', false);
@@ -44,7 +44,7 @@ class MenuDirective extends BaseDirective
 
         $toctreeFiles = $this->toctreeBuilder->buildToctreeFiles(
             $parserContext,
-            $documentParserContext->getDocumentIterator(),
+            $blockContext->getDocumentIterator(),
             $options,
         );
         if (count($toctreeFiles) === 0) {

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/MetaDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/MetaDirective.php
@@ -6,8 +6,8 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 use phpDocumentor\Guides\Nodes\Metadata\MetaNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 
 /**
  * Add a meta information:
@@ -24,10 +24,10 @@ class MetaDirective extends BaseDirective
 
     /** {@inheritDoc} */
     public function process(
-        DocumentParserContext $documentParserContext,
+        BlockContext $blockContext,
         Directive $directive,
     ): Node|null {
-        $document = $documentParserContext->getDocument();
+        $document = $blockContext->getDocumentParserContext()->getDocument();
 
         foreach ($directive->getOptions() as $option) {
             $document->addHeaderNode(new MetaNode($option->getName(), (string) $option->getValue()));

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/RawDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/RawDirective.php
@@ -6,8 +6,8 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\RawNode;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 
 use function implode;
 
@@ -29,9 +29,9 @@ class RawDirective extends BaseDirective
 
     /** {@inheritDoc} */
     public function process(
-        DocumentParserContext $documentParserContext,
+        BlockContext $blockContext,
         Directive $directive,
     ): Node|null {
-        return new RawNode(implode("\n", $documentParserContext->getDocumentIterator()->toArray()));
+        return new RawNode(implode("\n", $blockContext->getDocumentIterator()->toArray()));
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/RoleDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/RoleDirective.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\TextRoles\BaseTextRole;
 use phpDocumentor\Guides\RestructuredText\TextRoles\GenericTextRole;
 use Psr\Log\LoggerInterface;
@@ -41,7 +41,7 @@ class RoleDirective extends ActionDirective
     }
 
     public function processAction(
-        DocumentParserContext $documentParserContext,
+        BlockContext $blockContext,
         Directive $directive,
     ): void {
         $name = $directive->getData();
@@ -51,7 +51,7 @@ class RoleDirective extends ActionDirective
             $role = $match[2];
         }
 
-        $baseRole = $documentParserContext->getTextRoleFactoryForDocument()->getTextRole($role);
+        $baseRole = $blockContext->getDocumentParserContext()->getTextRoleFactoryForDocument()->getTextRole($role);
         if (!$baseRole instanceof BaseTextRole) {
             $this->logger->error('Text role "' . $role . '", class ' . $baseRole::class . ' cannot be extended. ');
 
@@ -69,6 +69,6 @@ class RoleDirective extends ActionDirective
             $customRole->setBaseRole($role);
         }
 
-        $documentParserContext->getTextRoleFactoryForDocument()->replaceTextRole($customRole);
+        $blockContext->getDocumentParserContext()->getTextRoleFactoryForDocument()->replaceTextRole($customRole);
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/RubricDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/RubricDirective.php
@@ -6,8 +6,8 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\RubricNode;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 
 /**
  * The "rubric" directive inserts a "rubric" node into the document tree. A rubric is like an informal heading
@@ -23,7 +23,7 @@ class RubricDirective extends BaseDirective
     }
 
     public function processNode(
-        DocumentParserContext $documentParserContext,
+        BlockContext $blockContext,
         Directive $directive,
     ): Node {
         return new RubricNode($directive->getData());

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/SubDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/SubDirective.php
@@ -6,8 +6,8 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 
 use function implode;
 
@@ -25,13 +25,13 @@ abstract class SubDirective extends BaseDirective
 {
     /** {@inheritDoc} */
     final public function process(
-        DocumentParserContext $documentParserContext,
+        BlockContext $blockContext,
         Directive $directive,
     ): Node|null {
-        $subParser = $documentParserContext->getParser()->getSubParser();
+        $subParser = $blockContext->getDocumentParserContext()->getParser()->getSubParser();
         $document = $subParser->parse(
-            $documentParserContext->getContext(),
-            implode("\n", $documentParserContext->getDocumentIterator()->toArray()),
+            $blockContext->getDocumentParserContext()->getContext(),
+            implode("\n", $blockContext->getDocumentIterator()->toArray()),
         );
 
         $node = $this->processSub($document, $directive);

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/TitleDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/TitleDirective.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 
 /**
  * Add a meta title to the document
@@ -22,10 +22,10 @@ class TitleDirective extends BaseDirective
 
     /** {@inheritDoc} */
     public function process(
-        DocumentParserContext $documentParserContext,
+        BlockContext $blockContext,
         Directive $directive,
     ): Node|null {
-        $document = $documentParserContext->getDocument();
+        $document = $blockContext->getDocumentParserContext()->getDocument();
         $document->setMetaTitle($directive->getData());
 
         return null;

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ToctreeDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ToctreeDirective.php
@@ -6,9 +6,9 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 use phpDocumentor\Guides\Nodes\Menu\TocNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 use phpDocumentor\Guides\RestructuredText\Parser\DirectiveOption;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Toc\ToctreeBuilder;
 
 /**
@@ -33,16 +33,16 @@ class ToctreeDirective extends BaseDirective
 
     /** {@inheritDoc} */
     public function process(
-        DocumentParserContext $documentParserContext,
+        BlockContext $blockContext,
         Directive $directive,
     ): Node|null {
-        $parserContext = $documentParserContext->getParser()->getParserContext();
+        $parserContext = $blockContext->getDocumentParserContext()->getParser()->getParserContext();
         $options = $directive->getOptions();
         $options['globExclude'] ??= new DirectiveOption('globExclude', 'index,Index');
 
         $toctreeFiles = $this->toctreeBuilder->buildToctreeFiles(
             $parserContext,
-            $documentParserContext->getDocumentIterator(),
+            $blockContext->getDocumentIterator(),
             $options,
         );
 

--- a/packages/guides-restructured-text/src/RestructuredText/MarkupLanguageParser.php
+++ b/packages/guides-restructured-text/src/RestructuredText/MarkupLanguageParser.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use phpDocumentor\Guides\MarkupLanguageParser as ParserInterface;
 use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\ParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
 use phpDocumentor\Guides\RestructuredText\TextRoles\TextRoleFactory;
@@ -81,22 +82,9 @@ class MarkupLanguageParser implements ParserInterface
             $this,
         );
 
-        if ($this->startingRule->applies($this->documentParser)) {
-            $document = $this->startingRule->apply($this->documentParser);
-            Assert::isInstanceOf($document, DocumentNode::class);
-
-            return $document;
-        }
-
-        throw new InvalidArgumentException('Content is not a valid document content');
-    }
-
-    /** @deprecated this should be replaced by proper usage of productions in other productions, by now this is a hack. */
-    public function parseFragment(DocumentParserContext $documentParserContext, string $contents): DocumentNode
-    {
-        $documentParserContext = $documentParserContext->withContents($contents);
-        if ($this->startingRule->applies($documentParserContext)) {
-            $document = $this->startingRule->apply($documentParserContext);
+        $blockContext = new BlockContext($this->documentParser, $contents);
+        if ($this->startingRule->applies($blockContext)) {
+            $document = $this->startingRule->apply($blockContext);
             Assert::isInstanceOf($document, DocumentNode::class);
 
             return $document;

--- a/packages/guides-restructured-text/src/RestructuredText/MarkupLanguageParser.php
+++ b/packages/guides-restructured-text/src/RestructuredText/MarkupLanguageParser.php
@@ -76,7 +76,6 @@ class MarkupLanguageParser implements ParserInterface
         $this->parserContext = $parserContext;
 
         $this->documentParser = new DocumentParserContext(
-            $contents,
             $parserContext,
             $this->textRoleFactory,
             $this,

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/BlockContext.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/BlockContext.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\RestructuredText\Parser;
+
+/**
+ * Our document parser contains
+ */
+class BlockContext
+{
+    private LinesIterator $documentIterator;
+    
+    public function __construct(
+        private readonly DocumentParserContext $documentParserContext,
+        string $contents,
+        bool $preserveSpace = false,
+    ) {
+        $this->documentIterator = new LinesIterator();
+        $this->documentIterator->load($contents, $preserveSpace);
+    }
+    
+    public function getDocumentIterator(): LinesIterator
+    {
+        return $this->documentIterator;
+    }
+
+    public function getDocumentParserContext(): DocumentParserContext
+    {
+        return $this->documentParserContext;
+    }
+}

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/DocumentParserContext.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/DocumentParserContext.php
@@ -29,8 +29,7 @@ class DocumentParserContext
     public bool $nextIndentedBlockShouldBeALiteralBlock = false;
 
     public DocumentNode|null $document = null;
-
-    private LinesIterator $documentIterator;
+    
     private int $currentTitleLevel;
     /* Each Document has its own text role factory as text roles can be changed on a per document base
         by directives */
@@ -40,14 +39,11 @@ class DocumentParserContext
     private array $titleLetters = [];
 
     public function __construct(
-        string $content,
         private readonly ParserContext $context,
         TextRoleFactory $textRoleFactory,
         private readonly MarkupLanguageParser $markupLanguageParser,
     ) {
-        $this->documentIterator = new LinesIterator();
         $this->textRoleFactoryForDocument = clone $textRoleFactory;
-        $this->documentIterator->load($content);
         $this->currentTitleLevel = $context->getInitialHeaderLevel() - 1;
     }
 
@@ -79,12 +75,7 @@ class DocumentParserContext
     {
         $this->document = $document;
     }
-
-    public function getDocumentIterator(): LinesIterator
-    {
-        return $this->documentIterator;
-    }
-
+    
     public function getLevel(string $overlineLetter, string $underlineLetter): int
     {
         $letter = $overlineLetter . ':' . $underlineLetter;

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/DocumentParserContext.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/DocumentParserContext.php
@@ -100,28 +100,6 @@ class DocumentParserContext
         return $this->currentTitleLevel;
     }
 
-    public function withContents(string $contents): self
-    {
-        $that = clone $this;
-        $that->documentIterator = new LinesIterator();
-        $that->documentIterator->load($contents);
-
-        return $that;
-    }
-
-    /**
-     * can be used to set the content to the document iterator while preserving space
-     * code-block directives have to preserve space
-     */
-    public function withContentsPreserveSpace(string $contents): self
-    {
-        $that = clone $this;
-        $that->documentIterator = new LinesIterator();
-        $that->documentIterator->load($contents, true);
-
-        return $that;
-    }
-
     public function getTextRoleFactoryForDocument(): TextRoleFactory
     {
         return $this->textRoleFactoryForDocument;

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/InlineParser.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/InlineParser.php
@@ -25,7 +25,7 @@ class InlineParser
         });
     }
 
-    public function parse(string $content, DocumentParserContext $documentParserContext): InlineCompoundNode
+    public function parse(string $content, BlockContext $blockContext): InlineCompoundNode
     {
         $lexer = new InlineLexer();
         $lexer->setInput($content);
@@ -37,7 +37,7 @@ class InlineParser
             foreach ($this->rules as $inlineRule) {
                 $node = null;
                 if ($inlineRule->applies($lexer)) {
-                    $node = $inlineRule->apply($documentParserContext, $lexer);
+                    $node = $inlineRule->apply($blockContext, $lexer);
                 }
 
                 if ($node === null) {

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/AnnotationRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/AnnotationRule.php
@@ -18,8 +18,8 @@ use phpDocumentor\Guides\Nodes\CompoundNode;
 use phpDocumentor\Guides\Nodes\FootnoteNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Parser\AnnotationUtility;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Buffer;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\LinesIterator;
 
 use function is_string;
@@ -39,9 +39,9 @@ final class AnnotationRule implements Rule
     ) {
     }
 
-    public function applies(DocumentParserContext $documentParser): bool
+    public function applies(BlockContext $blockContext): bool
     {
-        return $this->isAnnotation($documentParser->getDocumentIterator()->current());
+        return $this->isAnnotation($blockContext->getDocumentIterator()->current());
     }
 
     private function isAnnotation(string $line): bool
@@ -49,9 +49,9 @@ final class AnnotationRule implements Rule
         return preg_match('/^\.\.\s+\[([#a-zA-Z0-9]*)\]\s(.*)$$/mUsi', $line) > 0;
     }
 
-    public function apply(DocumentParserContext $documentParserContext, CompoundNode|null $on = null): Node|null
+    public function apply(BlockContext $blockContext, CompoundNode|null $on = null): Node|null
     {
-        $documentIterator = $documentParserContext->getDocumentIterator();
+        $documentIterator = $blockContext->getDocumentIterator();
         $openingLine = $documentIterator->current();
         preg_match('/^\.\.\s+\[([#a-zA-Z0-9]*)\]\s(.*)$$/mUsi', $openingLine, $matches);
         $annotationKey = $matches[1] ?? null;
@@ -84,7 +84,7 @@ final class AnnotationRule implements Rule
 
         $buffer->trimLines();
         $this->inlineMarkupRule->apply(
-            $documentParserContext->withContents($buffer->getLinesString()),
+            new BlockContext($blockContext->getDocumentParserContext(), $buffer->getLinesString()),
             $node,
         );
 

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/BlockQuoteRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/BlockQuoteRule.php
@@ -16,8 +16,8 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions;
 use phpDocumentor\Guides\Nodes\CompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\QuoteNode;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Buffer;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 
 use function array_values;
 use function count;
@@ -38,17 +38,17 @@ final class BlockQuoteRule implements Rule
 {
     public const PRIORITY = 100;
 
-    public function applies(DocumentParserContext $documentParser): bool
+    public function applies(BlockContext $blockContext): bool
     {
-        $isWhiteSpace = trim($documentParser->getDocumentIterator()->current()) === '';
-        $isBlockLine = $this->isBlockLine($documentParser->getDocumentIterator()->getNextLine());
+        $isWhiteSpace = trim($blockContext->getDocumentIterator()->current()) === '';
+        $isBlockLine = $this->isBlockLine($blockContext->getDocumentIterator()->getNextLine());
 
-        return $isWhiteSpace && $isBlockLine && $documentParser->nextIndentedBlockShouldBeALiteralBlock === false;
+        return $isWhiteSpace && $isBlockLine && $blockContext->getDocumentParserContext()->nextIndentedBlockShouldBeALiteralBlock === false;
     }
 
-    public function apply(DocumentParserContext $documentParserContext, CompoundNode|null $on = null): Node|null
+    public function apply(BlockContext $blockContext, CompoundNode|null $on = null): Node|null
     {
-        $documentIterator = $documentParserContext->getDocumentIterator();
+        $documentIterator = $blockContext->getDocumentIterator();
         $buffer = new Buffer();
         $documentIterator->next();
         $indent = mb_strlen($documentIterator->current()) - mb_strlen(trim($documentIterator->current()));
@@ -65,8 +65,8 @@ final class BlockQuoteRule implements Rule
         }
 
         return new QuoteNode(
-            $documentParserContext->getParser()->getSubParser()->parse(
-                $documentParserContext->getContext(),
+            $blockContext->getDocumentParserContext()->getParser()->getSubParser()->parse(
+                $blockContext->getDocumentParserContext()->getContext(),
                 (new Buffer($lines))->getLinesString(),
             )->getChildren(),
         );

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/CommentRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/CommentRule.php
@@ -15,8 +15,8 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions;
 
 use phpDocumentor\Guides\Nodes\CompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Buffer;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 
 use function preg_match;
 use function trim;
@@ -30,14 +30,14 @@ final class CommentRule implements Rule
 {
     public const PRIORITY = 60;
 
-    public function applies(DocumentParserContext $documentParser): bool
+    public function applies(BlockContext $blockContext): bool
     {
-        return $this->isComment($documentParser->getDocumentIterator()->current());
+        return $this->isComment($blockContext->getDocumentIterator()->current());
     }
 
-    public function apply(DocumentParserContext $documentParserContext, CompoundNode|null $on = null): Node|null
+    public function apply(BlockContext $blockContext, CompoundNode|null $on = null): Node|null
     {
-        $documentIterator = $documentParserContext->getDocumentIterator();
+        $documentIterator = $blockContext->getDocumentIterator();
         $buffer = new Buffer();
         $buffer->push($documentIterator->current());
 

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
@@ -114,7 +114,7 @@ final class DirectiveRule implements Rule
         // Processing the Directive, the handler is responsible for adding the right Nodes to the document.
         try {
             $node = $directiveHandler->process(
-                $blockContext->getDocumentParserContext()->withContentsPreserveSpace($buffer->getLinesString()),
+                new BlockContext($blockContext->getDocumentParserContext(), $buffer->getLinesString(), true),
                 $directive,
             );
 

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DocumentRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DocumentRule.php
@@ -16,7 +16,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions;
 use phpDocumentor\Guides\Nodes\CompoundNode;
 use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\Nodes\Node;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 
 use function implode;
 use function md5;
@@ -28,27 +28,27 @@ final class DocumentRule implements Rule
     {
     }
 
-    public function applies(DocumentParserContext $documentParser): bool
+    public function applies(BlockContext $blockContext): bool
     {
-        return $documentParser->getDocumentIterator()->atStart();
+        return $blockContext->getDocumentIterator()->atStart();
     }
 
     /** @param DocumentNode|null $on */
-    public function apply(DocumentParserContext $documentParserContext, CompoundNode|null $on = null): Node|null
+    public function apply(BlockContext $blockContext, CompoundNode|null $on = null): Node|null
     {
         $on ??= new DocumentNode(
-            md5(implode("\n", $documentParserContext->getDocumentIterator()->toArray())),
-            $documentParserContext->getContext()->getCurrentFileName(),
+            md5(implode("\n", $blockContext->getDocumentIterator()->toArray())),
+            $blockContext->getDocumentParserContext()->getContext()->getCurrentFileName(),
         );
 
-        $documentParserContext->setDocument($on);
-        $documentIterator = $documentParserContext->getDocumentIterator();
+        $blockContext->getDocumentParserContext()->setDocument($on);
+        $documentIterator = $blockContext->getDocumentIterator();
 
         // We explicitly do not use foreach, but rather the cursors of the DocumentIterator
         // this is done because we are transitioning to a method where a Substate can take the current
         // cursor as starting point and loop through the cursor
         while ($documentIterator->valid()) {
-            $this->structuralElements->apply($documentParserContext, $on);
+            $this->structuralElements->apply($blockContext, $on);
         }
 
         return $on;

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/AbstractFieldListItemRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/AbstractFieldListItemRule.php
@@ -7,7 +7,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldList;
 use phpDocumentor\Guides\Nodes\FieldLists\FieldListItemNode;
 use phpDocumentor\Guides\Nodes\Metadata\MetadataNode;
 use phpDocumentor\Guides\Nodes\Metadata\TopicNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 
 use function strtolower;
 
@@ -18,7 +18,7 @@ class AbstractFieldListItemRule implements FieldListItemRule
         return strtolower($fieldListItemNode->getTerm()) === 'abstract';
     }
 
-    public function apply(FieldListItemNode $fieldListItemNode, DocumentParserContext $documentParserContext): MetadataNode
+    public function apply(FieldListItemNode $fieldListItemNode, BlockContext $blockContext): MetadataNode
     {
         return new TopicNode('abstract', $fieldListItemNode->getPlaintextContent());
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/AddressFieldListItemRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/AddressFieldListItemRule.php
@@ -7,7 +7,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldList;
 use phpDocumentor\Guides\Nodes\FieldLists\FieldListItemNode;
 use phpDocumentor\Guides\Nodes\Metadata\AddressNode;
 use phpDocumentor\Guides\Nodes\Metadata\MetadataNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 
 use function strtolower;
 
@@ -18,7 +18,7 @@ class AddressFieldListItemRule implements FieldListItemRule
         return strtolower($fieldListItemNode->getTerm()) === 'address';
     }
 
-    public function apply(FieldListItemNode $fieldListItemNode, DocumentParserContext $documentParserContext): MetadataNode
+    public function apply(FieldListItemNode $fieldListItemNode, BlockContext $blockContext): MetadataNode
     {
         return new AddressNode($fieldListItemNode->getPlaintextContent());
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/AuthorFieldListItemRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/AuthorFieldListItemRule.php
@@ -7,7 +7,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldList;
 use phpDocumentor\Guides\Nodes\FieldLists\FieldListItemNode;
 use phpDocumentor\Guides\Nodes\Metadata\AuthorNode;
 use phpDocumentor\Guides\Nodes\Metadata\MetadataNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 
 use function strtolower;
 
@@ -18,7 +18,7 @@ class AuthorFieldListItemRule implements FieldListItemRule
         return strtolower($fieldListItemNode->getTerm()) === 'author';
     }
 
-    public function apply(FieldListItemNode $fieldListItemNode, DocumentParserContext $documentParserContext): MetadataNode
+    public function apply(FieldListItemNode $fieldListItemNode, BlockContext $blockContext): MetadataNode
     {
         return new AuthorNode($fieldListItemNode->getPlaintextContent(), $fieldListItemNode->getChildren());
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/AuthorsFieldListItemRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/AuthorsFieldListItemRule.php
@@ -11,7 +11,7 @@ use phpDocumentor\Guides\Nodes\Metadata\AuthorsNode;
 use phpDocumentor\Guides\Nodes\Metadata\MetadataNode;
 use phpDocumentor\Guides\Nodes\ParagraphNode;
 use phpDocumentor\Guides\Nodes\RawNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 
 use function assert;
 use function count;
@@ -26,7 +26,7 @@ class AuthorsFieldListItemRule implements FieldListItemRule
         return strtolower($fieldListItemNode->getTerm()) === 'authors';
     }
 
-    public function apply(FieldListItemNode $fieldListItemNode, DocumentParserContext $documentParserContext): MetadataNode
+    public function apply(FieldListItemNode $fieldListItemNode, BlockContext $blockContext): MetadataNode
     {
         $authorNodes = [];
         if (count($fieldListItemNode->getChildren()) === 1) {

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/ContactFieldListItemRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/ContactFieldListItemRule.php
@@ -7,7 +7,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldList;
 use phpDocumentor\Guides\Nodes\FieldLists\FieldListItemNode;
 use phpDocumentor\Guides\Nodes\Metadata\ContactNode;
 use phpDocumentor\Guides\Nodes\Metadata\MetadataNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 
 use function strtolower;
 
@@ -18,7 +18,7 @@ class ContactFieldListItemRule implements FieldListItemRule
         return strtolower($fieldListItemNode->getTerm()) === 'contact';
     }
 
-    public function apply(FieldListItemNode $fieldListItemNode, DocumentParserContext $documentParserContext): MetadataNode
+    public function apply(FieldListItemNode $fieldListItemNode, BlockContext $blockContext): MetadataNode
     {
         return new ContactNode($fieldListItemNode->getPlaintextContent());
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/CopyrightFieldListItemRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/CopyrightFieldListItemRule.php
@@ -7,7 +7,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldList;
 use phpDocumentor\Guides\Nodes\FieldLists\FieldListItemNode;
 use phpDocumentor\Guides\Nodes\Metadata\CopyrightNode;
 use phpDocumentor\Guides\Nodes\Metadata\MetadataNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 
 use function strtolower;
 
@@ -18,7 +18,7 @@ class CopyrightFieldListItemRule implements FieldListItemRule
         return strtolower($fieldListItemNode->getTerm()) === 'copyright';
     }
 
-    public function apply(FieldListItemNode $fieldListItemNode, DocumentParserContext $documentParserContext): MetadataNode
+    public function apply(FieldListItemNode $fieldListItemNode, BlockContext $blockContext): MetadataNode
     {
         return new CopyrightNode($fieldListItemNode->getPlaintextContent());
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/DateFieldListItemRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/DateFieldListItemRule.php
@@ -7,7 +7,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldList;
 use phpDocumentor\Guides\Nodes\FieldLists\FieldListItemNode;
 use phpDocumentor\Guides\Nodes\Metadata\DateNode;
 use phpDocumentor\Guides\Nodes\Metadata\MetadataNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 
 use function strtolower;
 
@@ -18,7 +18,7 @@ class DateFieldListItemRule implements FieldListItemRule
         return strtolower($fieldListItemNode->getTerm()) === 'date';
     }
 
-    public function apply(FieldListItemNode $fieldListItemNode, DocumentParserContext $documentParserContext): MetadataNode
+    public function apply(FieldListItemNode $fieldListItemNode, BlockContext $blockContext): MetadataNode
     {
         return new DateNode($fieldListItemNode->getPlaintextContent());
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/DedicationFieldListItemRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/DedicationFieldListItemRule.php
@@ -7,7 +7,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldList;
 use phpDocumentor\Guides\Nodes\FieldLists\FieldListItemNode;
 use phpDocumentor\Guides\Nodes\Metadata\MetadataNode;
 use phpDocumentor\Guides\Nodes\Metadata\TopicNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 
 use function strtolower;
 
@@ -18,7 +18,7 @@ class DedicationFieldListItemRule implements FieldListItemRule
         return strtolower($fieldListItemNode->getTerm()) === 'dedication';
     }
 
-    public function apply(FieldListItemNode $fieldListItemNode, DocumentParserContext $documentParserContext): MetadataNode
+    public function apply(FieldListItemNode $fieldListItemNode, BlockContext $blockContext): MetadataNode
     {
         return new TopicNode('dedication', $fieldListItemNode->getPlaintextContent());
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/FieldListItemRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/FieldListItemRule.php
@@ -15,11 +15,11 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldList;
 
 use phpDocumentor\Guides\Nodes\FieldLists\FieldListItemNode;
 use phpDocumentor\Guides\Nodes\Metadata\MetadataNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 
 interface FieldListItemRule
 {
     public function applies(FieldListItemNode $fieldListItemNode): bool;
 
-    public function apply(FieldListItemNode $fieldListItemNode, DocumentParserContext $documentParserContext): MetadataNode|null;
+    public function apply(FieldListItemNode $fieldListItemNode, BlockContext $blockContext): MetadataNode|null;
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/NocommentsFieldListItemRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/NocommentsFieldListItemRule.php
@@ -7,7 +7,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldList;
 use phpDocumentor\Guides\Nodes\FieldLists\FieldListItemNode;
 use phpDocumentor\Guides\Nodes\Metadata\MetadataNode;
 use phpDocumentor\Guides\Nodes\Metadata\NoCommentsNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 
 use function strtolower;
 
@@ -18,7 +18,7 @@ class NocommentsFieldListItemRule implements FieldListItemRule
         return strtolower($fieldListItemNode->getTerm()) === 'nocomments';
     }
 
-    public function apply(FieldListItemNode $fieldListItemNode, DocumentParserContext $documentParserContext): MetadataNode
+    public function apply(FieldListItemNode $fieldListItemNode, BlockContext $blockContext): MetadataNode
     {
         return new NoCommentsNode();
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/NosearchFieldListItemRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/NosearchFieldListItemRule.php
@@ -7,7 +7,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldList;
 use phpDocumentor\Guides\Nodes\FieldLists\FieldListItemNode;
 use phpDocumentor\Guides\Nodes\Metadata\MetadataNode;
 use phpDocumentor\Guides\Nodes\Metadata\NoSearchNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 
 use function strtolower;
 
@@ -18,7 +18,7 @@ class NosearchFieldListItemRule implements FieldListItemRule
         return strtolower($fieldListItemNode->getTerm()) === 'nosearch';
     }
 
-    public function apply(FieldListItemNode $fieldListItemNode, DocumentParserContext $documentParserContext): MetadataNode
+    public function apply(FieldListItemNode $fieldListItemNode, BlockContext $blockContext): MetadataNode
     {
         return new NoSearchNode();
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/OrganizationFieldListItemRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/OrganizationFieldListItemRule.php
@@ -7,7 +7,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldList;
 use phpDocumentor\Guides\Nodes\FieldLists\FieldListItemNode;
 use phpDocumentor\Guides\Nodes\Metadata\MetadataNode;
 use phpDocumentor\Guides\Nodes\Metadata\OrganizationNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 
 use function strtolower;
 
@@ -18,7 +18,7 @@ class OrganizationFieldListItemRule implements FieldListItemRule
         return strtolower($fieldListItemNode->getTerm()) === 'organization';
     }
 
-    public function apply(FieldListItemNode $fieldListItemNode, DocumentParserContext $documentParserContext): MetadataNode
+    public function apply(FieldListItemNode $fieldListItemNode, BlockContext $blockContext): MetadataNode
     {
         return new OrganizationNode(
             $fieldListItemNode->getPlaintextContent(),

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/OrphanFieldListItemRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/OrphanFieldListItemRule.php
@@ -7,7 +7,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldList;
 use phpDocumentor\Guides\Nodes\FieldLists\FieldListItemNode;
 use phpDocumentor\Guides\Nodes\Metadata\MetadataNode;
 use phpDocumentor\Guides\Nodes\Metadata\OrphanNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 
 use function strtolower;
 
@@ -18,9 +18,9 @@ class OrphanFieldListItemRule implements FieldListItemRule
         return strtolower($fieldListItemNode->getTerm()) === 'orphan';
     }
 
-    public function apply(FieldListItemNode $fieldListItemNode, DocumentParserContext $documentParserContext): MetadataNode
+    public function apply(FieldListItemNode $fieldListItemNode, BlockContext $blockContext): MetadataNode
     {
-        $documentParserContext->getDocument()->setOrphan(true);
+        $blockContext->getDocumentParserContext()->getDocument()->setOrphan(true);
 
         return new OrphanNode();
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/ProjectFieldListItemRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/ProjectFieldListItemRule.php
@@ -6,7 +6,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldList;
 
 use phpDocumentor\Guides\Nodes\FieldLists\FieldListItemNode;
 use phpDocumentor\Guides\Nodes\Metadata\MetadataNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use Psr\Log\LoggerInterface;
 
 use function sprintf;
@@ -23,9 +23,9 @@ class ProjectFieldListItemRule implements FieldListItemRule
         return strtolower($fieldListItemNode->getTerm()) === 'project';
     }
 
-    public function apply(FieldListItemNode $fieldListItemNode, DocumentParserContext $documentParserContext): MetadataNode|null
+    public function apply(FieldListItemNode $fieldListItemNode, BlockContext $blockContext): MetadataNode|null
     {
-        $currentTitle = $documentParserContext->getProjectNode()->getTitle();
+        $currentTitle = $blockContext->getDocumentParserContext()->getProjectNode()->getTitle();
         $newTitle = $fieldListItemNode->getPlaintextContent();
         if (
             $currentTitle !== null
@@ -38,7 +38,7 @@ class ProjectFieldListItemRule implements FieldListItemRule
             ));
         }
 
-        $documentParserContext->getProjectNode()->setTitle($newTitle);
+        $blockContext->getDocumentParserContext()->getProjectNode()->setTitle($newTitle);
 
         return null;
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/RevisionFieldListItemRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/RevisionFieldListItemRule.php
@@ -7,7 +7,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldList;
 use phpDocumentor\Guides\Nodes\FieldLists\FieldListItemNode;
 use phpDocumentor\Guides\Nodes\Metadata\MetadataNode;
 use phpDocumentor\Guides\Nodes\Metadata\RevisionNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 
 use function strtolower;
 
@@ -18,7 +18,7 @@ class RevisionFieldListItemRule implements FieldListItemRule
         return strtolower($fieldListItemNode->getTerm()) === 'revision';
     }
 
-    public function apply(FieldListItemNode $fieldListItemNode, DocumentParserContext $documentParserContext): MetadataNode
+    public function apply(FieldListItemNode $fieldListItemNode, BlockContext $blockContext): MetadataNode
     {
         return new RevisionNode($fieldListItemNode->getPlaintextContent());
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/TocDepthFieldListItemRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/TocDepthFieldListItemRule.php
@@ -7,7 +7,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldList;
 use phpDocumentor\Guides\Nodes\FieldLists\FieldListItemNode;
 use phpDocumentor\Guides\Nodes\Metadata\MetadataNode;
 use phpDocumentor\Guides\Nodes\Metadata\TocDepthNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 
 use function strtolower;
 
@@ -18,7 +18,7 @@ class TocDepthFieldListItemRule implements FieldListItemRule
         return strtolower($fieldListItemNode->getTerm()) === 'tocdepth';
     }
 
-    public function apply(FieldListItemNode $fieldListItemNode, DocumentParserContext $documentParserContext): MetadataNode
+    public function apply(FieldListItemNode $fieldListItemNode, BlockContext $blockContext): MetadataNode
     {
         return new TocDepthNode((int) $fieldListItemNode->getPlaintextContent());
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/VersionFieldListItemRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/VersionFieldListItemRule.php
@@ -6,7 +6,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldList;
 
 use phpDocumentor\Guides\Nodes\FieldLists\FieldListItemNode;
 use phpDocumentor\Guides\Nodes\Metadata\MetadataNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use Psr\Log\LoggerInterface;
 
 use function sprintf;
@@ -23,9 +23,9 @@ class VersionFieldListItemRule implements FieldListItemRule
         return strtolower($fieldListItemNode->getTerm()) === 'version';
     }
 
-    public function apply(FieldListItemNode $fieldListItemNode, DocumentParserContext $documentParserContext): MetadataNode|null
+    public function apply(FieldListItemNode $fieldListItemNode, BlockContext $blockContext): MetadataNode|null
     {
-        $currentVersion = $documentParserContext->getProjectNode()->getVersion();
+        $currentVersion = $blockContext->getDocumentParserContext()->getProjectNode()->getVersion();
         if (
             $currentVersion !== null
             && $currentVersion !== $fieldListItemNode->getPlaintextContent()
@@ -37,7 +37,7 @@ class VersionFieldListItemRule implements FieldListItemRule
             ));
         }
 
-        $documentParserContext->getProjectNode()->setVersion($fieldListItemNode->getPlaintextContent());
+        $blockContext->getDocumentParserContext()->getProjectNode()->setVersion($fieldListItemNode->getPlaintextContent());
 
         return null;
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/GridTableRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/GridTableRule.php
@@ -16,7 +16,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions;
 use phpDocumentor\Guides\Nodes\CompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\TableNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\LinesIterator;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\Table\GridTableBuilder;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\Table\ParserContext;
@@ -42,14 +42,14 @@ final class GridTableRule implements Rule
     {
     }
 
-    public function applies(DocumentParserContext $documentParser): bool
+    public function applies(BlockContext $blockContext): bool
     {
-        return $this->isColumnDefinitionLine($documentParser->getDocumentIterator()->current());
+        return $this->isColumnDefinitionLine($blockContext->getDocumentIterator()->current());
     }
 
-    public function apply(DocumentParserContext $documentParserContext, CompoundNode|null $on = null): Node|null
+    public function apply(BlockContext $blockContext, CompoundNode|null $on = null): Node|null
     {
-        $documentIterator = $documentParserContext->getDocumentIterator();
+        $documentIterator = $blockContext->getDocumentIterator();
         $line = $documentIterator->current();
 
         $tableSeparatorLineConfig = $this->tableLineConfig($line, '-');
@@ -71,7 +71,7 @@ final class GridTableRule implements Rule
                     $documentIterator->current(),
                 );
 
-                $this->logger->error($message, $documentParserContext->getContext()->getLoggerInformation());
+                $this->logger->error($message, $blockContext->getDocumentParserContext()->getContext()->getLoggerInformation());
             }
 
             if ($this->isHeaderDefinitionLine($documentIterator->current())) {
@@ -106,7 +106,7 @@ final class GridTableRule implements Rule
             $context->pushContentLine($documentIterator->current());
         }
 
-        return $this->builder->buildNode($context, $documentParserContext, $this->productions);
+        return $this->builder->buildNode($context, $blockContext, $this->productions);
     }
 
     private function tableLineConfig(string $line, string $char): TableSeparatorLineConfig

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineMarkupRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineMarkupRule.php
@@ -16,8 +16,8 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions;
 use phpDocumentor\Guides\Nodes\CompoundNode;
 use phpDocumentor\Guides\Nodes\InlineCompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Buffer;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineParser;
 use phpDocumentor\Guides\RestructuredText\Parser\LinesIterator;
 
@@ -36,8 +36,8 @@ use function trim;
  *
  * ```php
  *   $buffer = new Buffer();
- *   while ($this->isEnd($documentParser->getDocumentIterator()->getNextLine()) === false) {
- *       $buffer->push($documentParser->getDocumentIterator()->current());
+ *   while ($this->isEnd($blockContext->getDocumentIterator()->getNextLine()) === false) {
+ *       $buffer->push($blockContext->getDocumentIterator()->current());
  *   }
  *
  *   $inlineRule = new InlineMarkupRule($spanParser);
@@ -52,18 +52,18 @@ final class InlineMarkupRule implements Rule
     {
     }
 
-    public function applies(DocumentParserContext $documentParser): bool
+    public function applies(BlockContext $blockContext): bool
     {
-        return trim($documentParser->getDocumentIterator()->current()) !== '';
+        return trim($blockContext->getDocumentIterator()->current()) !== '';
     }
 
     /** @return ($on is null ? InlineCompoundNode: CompoundNode<Node>|InlineCompoundNode|null) */
-    public function apply(DocumentParserContext $documentParserContext, CompoundNode|null $on = null): Node|null
+    public function apply(BlockContext $blockContext, CompoundNode|null $on = null): Node|null
     {
-        $documentIterator = $documentParserContext->getDocumentIterator();
+        $documentIterator = $blockContext->getDocumentIterator();
         $buffer = $this->collectContent($documentIterator);
 
-        $node = $this->inlineTokenParser->parse($buffer->getLinesString(), $documentParserContext);
+        $node = $this->inlineTokenParser->parse($buffer->getLinesString(), $blockContext);
 
         if ($on !== null) {
             $on->setValue([$node]);

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/AnnotationRoleRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/AnnotationRoleRule.php
@@ -8,7 +8,7 @@ use phpDocumentor\Guides\Nodes\Inline\CitationInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\FootnoteInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
 use phpDocumentor\Guides\RestructuredText\Parser\AnnotationUtility;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 /**
@@ -21,7 +21,7 @@ class AnnotationRoleRule extends AbstractInlineRule
         return $lexer->token?->type === InlineLexer::ANNOTATION_START;
     }
 
-    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): InlineNode|null
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNode|null
     {
         $startPosition = $lexer->token?->position;
         $annotationName = '';

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/AnonymousPhraseRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/AnonymousPhraseRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\HyperLinkNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 /**
@@ -25,7 +25,7 @@ class AnonymousPhraseRule extends ReferenceRule
         return $lexer->token?->type === InlineLexer::BACKTICK;
     }
 
-    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): HyperLinkNode|null
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): HyperLinkNode|null
     {
         $text = '';
         $embeddedUrl = null;
@@ -36,7 +36,7 @@ class AnonymousPhraseRule extends ReferenceRule
                 case InlineLexer::PHRASE_ANONYMOUS_END:
                     $lexer->moveNext();
 
-                    return $this->createAnonymousReference($documentParserContext, $text, $embeddedUrl);
+                    return $this->createAnonymousReference($blockContext, $text, $embeddedUrl);
 
                 case InlineLexer::EMBEDED_URL_START:
                     $embeddedUrl = $this->parseEmbeddedUrl($lexer);
@@ -57,11 +57,11 @@ class AnonymousPhraseRule extends ReferenceRule
         return null;
     }
 
-    private function createAnonymousReference(DocumentParserContext $documentParserContext, string $link, string|null $embeddedUrl): HyperLinkNode
+    private function createAnonymousReference(BlockContext $blockContext, string $link, string|null $embeddedUrl): HyperLinkNode
     {
-        $documentParserContext->getContext()->resetAnonymousStack();
-        $node = $this->createReference($documentParserContext, $link, $embeddedUrl, false);
-        $documentParserContext->getContext()->pushAnonymous($link);
+        $blockContext->getDocumentParserContext()->getContext()->resetAnonymousStack();
+        $node = $this->createReference($blockContext, $link, $embeddedUrl, false);
+        $blockContext->getDocumentParserContext()->getContext()->pushAnonymous($link);
 
         return $node;
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/AnonymousReferenceRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/AnonymousReferenceRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\HyperLinkNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 use function trim;
@@ -26,10 +26,10 @@ class AnonymousReferenceRule extends ReferenceRule
         return $lexer->token?->type === InlineLexer::ANONYMOUSE_REFERENCE;
     }
 
-    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): HyperLinkNode|null
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): HyperLinkNode|null
     {
         $node = $this->createAnonymousReference(
-            $documentParserContext,
+            $blockContext,
             trim((string) $lexer->token?->value, '_'),
         );
         $lexer->moveNext();
@@ -37,11 +37,11 @@ class AnonymousReferenceRule extends ReferenceRule
         return $node;
     }
 
-    private function createAnonymousReference(DocumentParserContext $documentParserContext, string $link): HyperLinkNode
+    private function createAnonymousReference(BlockContext $blockContext, string $link): HyperLinkNode
     {
-        $documentParserContext->getContext()->resetAnonymousStack();
-        $node = $this->createReference($documentParserContext, $link, null, false);
-        $documentParserContext->getContext()->pushAnonymous($link);
+        $blockContext->getDocumentParserContext()->getContext()->resetAnonymousStack();
+        $node = $this->createReference($blockContext, $link, null, false);
+        $blockContext->getDocumentParserContext()->getContext()->pushAnonymous($link);
 
         return $node;
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/DefaultTextRoleRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/DefaultTextRoleRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 /**
@@ -18,7 +18,7 @@ class DefaultTextRoleRule extends AbstractInlineRule
         return $lexer->token?->type === InlineLexer::BACKTICK;
     }
 
-    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): InlineNode|null
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNode|null
     {
         $text = '';
 
@@ -35,10 +35,10 @@ class DefaultTextRoleRule extends AbstractInlineRule
 
                     $lexer->moveNext();
 
-                    return $documentParserContext
+                    return $blockContext->getDocumentParserContext()
                         ->getTextRoleFactoryForDocument()
                         ->getDefaultTextRole()
-                        ->processNode($documentParserContext, '', $text, $text);
+                        ->processNode($blockContext->getDocumentParserContext(), '', $text, $text);
 
                 default:
                     $text .= $token->value;

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/EmphasisRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/EmphasisRule.php
@@ -6,7 +6,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\EmphasisInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 /**
@@ -19,7 +19,7 @@ class EmphasisRule extends AbstractInlineRule
         return $lexer->token?->type === InlineLexer::EMPHASIS_DELIMITER;
     }
 
-    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): InlineNode|null
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNode|null
     {
         $text = '';
 

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/EscapeRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/EscapeRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 use function preg_match;
@@ -21,7 +21,7 @@ class EscapeRule extends ReferenceRule
         return $lexer->token?->type === InlineLexer::ESCAPED_SIGN;
     }
 
-    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): PlainTextInlineNode|null
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): PlainTextInlineNode|null
     {
         $char = $lexer->token?->value ?? '';
         $char = substr($char, 1);

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/InlineRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/InlineRule.php
@@ -14,14 +14,14 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 interface InlineRule
 {
     public function applies(InlineLexer $lexer): bool;
 
-    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): InlineNode|null;
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNode|null;
 
     public function getPriority(): int;
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/InternalReferenceRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/InternalReferenceRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 class InternalReferenceRule extends ReferenceRule
@@ -15,7 +15,7 @@ class InternalReferenceRule extends ReferenceRule
         return $lexer->token?->type === InlineLexer::INTERNAL_REFERENCE_START;
     }
 
-    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): InlineNode|null
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNode|null
     {
         $text = '';
         $initialPosition = $lexer->token?->position;
@@ -25,7 +25,7 @@ class InternalReferenceRule extends ReferenceRule
                 case InlineLexer::BACKTICK:
                     $lexer->moveNext();
 
-                    return $this->createReference($documentParserContext, $text);
+                    return $this->createReference($blockContext, $text);
 
                 default:
                     $text .= $lexer->token->value;

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/LiteralRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/LiteralRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\LiteralInlineNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 use function strlen;
@@ -21,7 +21,7 @@ class LiteralRule extends AbstractInlineRule
         return $lexer->token?->type === InlineLexer::LITERAL;
     }
 
-    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): LiteralInlineNode
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): LiteralInlineNode
     {
         $literal = $lexer->token?->value ?? '';
         if (strlen($literal) > 4) {

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/NamedPhraseRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/NamedPhraseRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 /**
@@ -25,7 +25,7 @@ class NamedPhraseRule extends ReferenceRule
         return $lexer->token?->type === InlineLexer::BACKTICK;
     }
 
-    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): InlineNode|null
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNode|null
     {
         $text = '';
         $embeddedUrl = null;
@@ -39,7 +39,7 @@ class NamedPhraseRule extends ReferenceRule
                         $text = $embeddedUrl ?? '';
                     }
 
-                    return $this->createReference($documentParserContext, $text, $embeddedUrl);
+                    return $this->createReference($blockContext, $text, $embeddedUrl);
 
                 case InlineLexer::EMBEDED_URL_START:
                     $embeddedUrl = $this->parseEmbeddedUrl($lexer);

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/NamedReferenceRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/NamedReferenceRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 use function rtrim;
@@ -26,10 +26,10 @@ class NamedReferenceRule extends ReferenceRule
         return $lexer->token?->type === InlineLexer::NAMED_REFERENCE;
     }
 
-    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): InlineNode|null
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNode|null
     {
         $value = rtrim($lexer->token?->value ?? '', '_');
-        $node = $this->createReference($documentParserContext, $value);
+        $node = $this->createReference($blockContext, $value);
 
         $lexer->moveNext();
 

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/NbspRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/NbspRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\WhitespaceInlineNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 /**
@@ -18,7 +18,7 @@ class NbspRule extends ReferenceRule
         return $lexer->token?->type === InlineLexer::NBSP;
     }
 
-    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): WhitespaceInlineNode
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): WhitespaceInlineNode
     {
         $lexer->moveNext();
 

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/PlainTextRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/PlainTextRule.php
@@ -6,7 +6,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
 use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 class PlainTextRule implements InlineRule
@@ -16,7 +16,7 @@ class PlainTextRule implements InlineRule
         return true;
     }
 
-    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): InlineNode|null
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNode|null
     {
         $node = new PlainTextInlineNode($lexer->token?->value ?? '');
         $lexer->moveNext();

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/ReferenceRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/ReferenceRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\HyperLinkNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 use function preg_replace;
@@ -14,7 +14,7 @@ use function trim;
 
 abstract class ReferenceRule extends AbstractInlineRule
 {
-    protected function createReference(DocumentParserContext $documentParserContext, string $link, string|null $embeddedUrl = null, bool $registerLink = true): HyperLinkNode
+    protected function createReference(BlockContext $blockContext, string $link, string|null $embeddedUrl = null, bool $registerLink = true): HyperLinkNode
     {
         // the link may have a new line in it, so we need to strip it
         // before setting the link and adding a token to be replaced
@@ -22,7 +22,7 @@ abstract class ReferenceRule extends AbstractInlineRule
         $link = trim(preg_replace('/\s+/', ' ', $link) ?? '');
 
         if ($registerLink && $embeddedUrl !== null) {
-            $documentParserContext->getContext()->setLink($link, $embeddedUrl);
+            $blockContext->getDocumentParserContext()->getContext()->setLink($link, $embeddedUrl);
         }
 
         return new HyperLinkNode($link, $embeddedUrl ?? $link);

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/StandaloneEmailRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/StandaloneEmailRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\HyperLinkNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 /**
@@ -24,10 +24,10 @@ class StandaloneEmailRule extends ReferenceRule
         return $lexer->token?->type === InlineLexer::EMAIL;
     }
 
-    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): HyperLinkNode|null
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): HyperLinkNode|null
     {
         $value = $lexer->token?->value ?? '';
-        $node = $this->createReference($documentParserContext, $value, $value, false);
+        $node = $this->createReference($blockContext, $value, $value, false);
 
         $lexer->moveNext();
 

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/StandaloneHyperlinkRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/StandaloneHyperlinkRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\HyperLinkNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 /**
@@ -24,10 +24,10 @@ class StandaloneHyperlinkRule extends ReferenceRule
         return $lexer->token?->type === InlineLexer::HYPERLINK;
     }
 
-    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): HyperLinkNode|null
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): HyperLinkNode|null
     {
         $value = $lexer->token?->value ?? '';
-        $node = $this->createReference($documentParserContext, $value, $value, false);
+        $node = $this->createReference($blockContext, $value, $value, false);
 
         $lexer->moveNext();
 

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/StrongRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/StrongRule.php
@@ -6,7 +6,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
 use phpDocumentor\Guides\Nodes\Inline\StrongInlineNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 /**
@@ -19,7 +19,7 @@ class StrongRule extends AbstractInlineRule
         return $lexer->token?->type === InlineLexer::STRONG_DELIMITER;
     }
 
-    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): InlineNode|null
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNode|null
     {
         $text = '';
 

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/TextRoleRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/TextRoleRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 use function substr;
@@ -20,7 +20,7 @@ class TextRoleRule extends AbstractInlineRule
         return $lexer->token?->type === InlineLexer::COLON;
     }
 
-    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): InlineNode|null
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNode|null
     {
         $domain = null;
         $role = null;
@@ -49,11 +49,11 @@ class TextRoleRule extends AbstractInlineRule
                     }
 
                     if ($inText) {
-                        $textRole = $documentParserContext->getTextRoleFactoryForDocument()->getTextRole($role, $domain);
+                        $textRole = $blockContext->getDocumentParserContext()->getTextRoleFactoryForDocument()->getTextRole($role, $domain);
                         $fullRole = ($domain ? $domain . ':' : '') . $role;
                         $lexer->moveNext();
 
-                        return $textRole->processNode($documentParserContext, $fullRole, $part, $rawPart);
+                        return $textRole->processNode($blockContext->getDocumentParserContext(), $fullRole, $part, $rawPart);
                     }
 
                     $inText = true;

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/VariableInlineRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/VariableInlineRule.php
@@ -6,7 +6,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
 use phpDocumentor\Guides\Nodes\Inline\VariableInlineNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 /**
@@ -19,7 +19,7 @@ class VariableInlineRule extends AbstractInlineRule
         return $lexer->token?->type === InlineLexer::VARIABLE_DELIMITER;
     }
 
-    public function apply(DocumentParserContext $documentParserContext, InlineLexer $lexer): InlineNode|null
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNode|null
     {
         $text = '';
 

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/LinkRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/LinkRule.php
@@ -18,7 +18,7 @@ use phpDocumentor\Guides\Nodes\AnchorNode;
 use phpDocumentor\Guides\Nodes\CompoundNode;
 use phpDocumentor\Guides\Nodes\Links\Link as LinkParser;
 use phpDocumentor\Guides\Nodes\Node;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 
 use function preg_match;
 use function trim;
@@ -32,16 +32,16 @@ final class LinkRule implements Rule
 {
     public const PRIORITY = 120;
 
-    public function applies(DocumentParserContext $documentParser): bool
+    public function applies(BlockContext $blockContext): bool
     {
-        $link = $this->parseLink($documentParser->getDocumentIterator()->current());
+        $link = $this->parseLink($blockContext->getDocumentIterator()->current());
 
         return $link !== null;
     }
 
-    public function apply(DocumentParserContext $documentParserContext, CompoundNode|null $on = null): Node|null
+    public function apply(BlockContext $blockContext, CompoundNode|null $on = null): Node|null
     {
-        $documentIterator = $documentParserContext->getDocumentIterator();
+        $documentIterator = $blockContext->getDocumentIterator();
         $link = $this->parseLink($documentIterator->current());
         if ($link === null) {
             throw new InvalidArgumentException();
@@ -53,7 +53,7 @@ final class LinkRule implements Rule
         }
 
         //TODO: pass link object to setLink
-        $documentParserContext->getContext()->setLink($link->getName(), $link->getUrl());
+        $blockContext->getDocumentParserContext()->getContext()->setLink($link->getName(), $link->getUrl());
 
         return $node;
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/LiteralBlockRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/LiteralBlockRule.php
@@ -16,8 +16,8 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions;
 use phpDocumentor\Guides\Nodes\CodeNode;
 use phpDocumentor\Guides\Nodes\CompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Buffer;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 
 use function array_values;
 use function count;
@@ -32,22 +32,22 @@ final class LiteralBlockRule implements Rule
 {
     public const PRIORITY = 120;
 
-    public function applies(DocumentParserContext $documentParser): bool
+    public function applies(BlockContext $blockContext): bool
     {
-        $nextIndentedBlockShouldBeALiteralBlock = $documentParser->nextIndentedBlockShouldBeALiteralBlock;
+        $nextIndentedBlockShouldBeALiteralBlock = $blockContext->getDocumentParserContext()->nextIndentedBlockShouldBeALiteralBlock;
 
         // always reset the `nextIndentedBlockShouldBeALiteralBlock` state; because if this isn't a block line, you
         // do not want the indented block somewhere else in the document to suddenly become a code block
-        $documentParser->nextIndentedBlockShouldBeALiteralBlock = false;
+        $blockContext->getDocumentParserContext()->nextIndentedBlockShouldBeALiteralBlock = false;
 
-        $isBlockLine = $this->isBlockLine($documentParser->getDocumentIterator()->current());
+        $isBlockLine = $this->isBlockLine($blockContext->getDocumentIterator()->current());
 
         return $isBlockLine && $nextIndentedBlockShouldBeALiteralBlock;
     }
 
-    public function apply(DocumentParserContext $documentParserContext, CompoundNode|null $on = null): Node|null
+    public function apply(BlockContext $blockContext, CompoundNode|null $on = null): Node|null
     {
-        $documentIterator = $documentParserContext->getDocumentIterator();
+        $documentIterator = $blockContext->getDocumentIterator();
 
         $buffer = new Buffer();
         $buffer->push($documentIterator->current());

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/ParagraphRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/ParagraphRule.php
@@ -16,8 +16,8 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions;
 use phpDocumentor\Guides\Nodes\CompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\ParagraphNode;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Buffer;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\LinesIterator;
 
 use function str_ends_with;
@@ -38,17 +38,17 @@ final class ParagraphRule implements Rule
     ) {
     }
 
-    public function applies(DocumentParserContext $documentParser): bool
+    public function applies(BlockContext $blockContext): bool
     {
         // Should be last in the series of rules; basically: if it ain't anything else, it is a paragraph.
         // This could prove to be wrong when we pull up the spec, but the existing implementation applies this concept
         // and we roll with it for now.
-        return trim($documentParser->getDocumentIterator()->current()) !== '';
+        return trim($blockContext->getDocumentIterator()->current()) !== '';
     }
 
-    public function apply(DocumentParserContext $documentParserContext, CompoundNode|null $on = null): Node|null
+    public function apply(BlockContext $blockContext, CompoundNode|null $on = null): Node|null
     {
-        $documentIterator = $documentParserContext->getDocumentIterator();
+        $documentIterator = $blockContext->getDocumentIterator();
 
         $buffer = new Buffer();
         $buffer->push($documentIterator->current());
@@ -74,7 +74,7 @@ final class ParagraphRule implements Rule
                 $lastLine .= ':';
             }
 
-            $documentParserContext->nextIndentedBlockShouldBeALiteralBlock = true;
+            $blockContext->getDocumentParserContext()->nextIndentedBlockShouldBeALiteralBlock = true;
 
             if ($lastLine !== '') {
                 $buffer->push($lastLine);
@@ -90,7 +90,7 @@ final class ParagraphRule implements Rule
         $node = new ParagraphNode();
 
         $this->inlineMarkupRule->apply(
-            $documentParserContext->withContents($buffer->getLinesString()),
+            new BlockContext($blockContext->getDocumentParserContext(), $buffer->getLinesString()),
             $node,
         );
 

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/Rule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/Rule.php
@@ -15,12 +15,12 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions;
 
 use phpDocumentor\Guides\Nodes\CompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 
 /** @template-covariant TNode as Node */
 interface Rule
 {
-    public function applies(DocumentParserContext $documentParser): bool;
+    public function applies(BlockContext $blockContext): bool;
 
     /**
      * Enters this state and loops through all relevant lines until a Node is produced.
@@ -39,5 +39,5 @@ interface Rule
      *
      * @template TParent as CompoundNode
      */
-    public function apply(DocumentParserContext $documentParserContext, CompoundNode|null $on = null): Node|null;
+    public function apply(BlockContext $blockContext, CompoundNode|null $on = null): Node|null;
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/RuleContainer.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/RuleContainer.php
@@ -16,7 +16,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions;
 use phpDocumentor\Guides\Nodes\CompoundNode;
 use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\Nodes\Node;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 
 final class RuleContainer
 {
@@ -36,16 +36,16 @@ final class RuleContainer
     }
 
     /** @param CompoundNode<Node> $on */
-    public function apply(DocumentParserContext $documentParserContext, CompoundNode $on): void
+    public function apply(BlockContext $blockContext, CompoundNode $on): void
     {
-        $documentIterator = $documentParserContext->getDocumentIterator();
+        $documentIterator = $blockContext->getDocumentIterator();
 
         foreach ($this->productions as $production) {
-            if (!$production->applies($documentParserContext)) {
+            if (!$production->applies($blockContext)) {
                 continue;
             }
 
-            $newNode = $production->apply($documentParserContext, $on);
+            $newNode = $production->apply($blockContext, $on);
             if ($newNode !== null) {
                 $on->addChildNode($newNode);
             }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/TitleRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/TitleRule.php
@@ -16,7 +16,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions;
 use phpDocumentor\Guides\Nodes\CompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\TitleNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineParser;
 use phpDocumentor\Guides\RestructuredText\Parser\LineChecker;
 use phpDocumentor\Guides\RestructuredText\Parser\LinesIterator;
@@ -39,18 +39,18 @@ class TitleRule implements Rule
     {
     }
 
-    public function applies(DocumentParserContext $documentParser): bool
+    public function applies(BlockContext $blockContext): bool
     {
-        $line = $documentParser->getDocumentIterator()->current();
-        $nextLine = $documentParser->getDocumentIterator()->getNextLine();
+        $line = $blockContext->getDocumentIterator()->current();
+        $nextLine = $blockContext->getDocumentIterator()->getNextLine();
 
         return $this->currentLineIsAnOverline($line, $nextLine)
             || $this->nextLineIsAnUnderline($line, $nextLine);
     }
 
-    public function apply(DocumentParserContext $documentParserContext, CompoundNode|null $on = null): Node|null
+    public function apply(BlockContext $blockContext, CompoundNode|null $on = null): Node|null
     {
-        $documentIterator = $documentParserContext->getDocumentIterator();
+        $documentIterator = $blockContext->getDocumentIterator();
         $title = '';
         $overlineLetter = $this->currentLineIsAnOverline(
             $documentIterator->current(),
@@ -75,10 +75,10 @@ class TitleRule implements Rule
         $documentIterator->next();
 
         $letter = $overlineLetter ?: $underlineLetter;
-        $level = $documentParserContext->getLevel($overlineLetter, $underlineLetter);
+        $level = $blockContext->getDocumentParserContext()->getLevel($overlineLetter, $underlineLetter);
 
         return new TitleNode(
-            $this->inlineTokenParser->parse($title, $documentParserContext),
+            $this->inlineTokenParser->parse($title, $blockContext),
             $level,
             (new AsciiSlugger())->slug($title)->lower()->toString(),
         );

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/TransitionRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/TransitionRule.php
@@ -16,7 +16,7 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions;
 use phpDocumentor\Guides\Nodes\CompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\SeparatorNode;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\LineChecker;
 use phpDocumentor\Guides\RestructuredText\Parser\LinesIterator;
 
@@ -30,17 +30,17 @@ final class TransitionRule implements Rule
     public const PRIORITY = 20;
     public const SEPERATOR_LENGTH_MIN = 4;
 
-    public function applies(DocumentParserContext $documentParser): bool
+    public function applies(BlockContext $blockContext): bool
     {
-        $line = $documentParser->getDocumentIterator()->current();
-        $nextLine = $documentParser->getDocumentIterator()->getNextLine();
+        $line = $blockContext->getDocumentIterator()->current();
+        $nextLine = $blockContext->getDocumentIterator()->getNextLine();
 
         return $this->currentLineIsASeparator($line, $nextLine) !== null;
     }
 
-    public function apply(DocumentParserContext $documentParserContext, CompoundNode|null $on = null): Node|null
+    public function apply(BlockContext $blockContext, CompoundNode|null $on = null): Node|null
     {
-        $documentIterator = $documentParserContext->getDocumentIterator();
+        $documentIterator = $blockContext->getDocumentIterator();
 
         $overlineLetter = $this->currentLineIsASeparator(
             $documentIterator->current(),

--- a/packages/guides-restructured-text/tests/unit/Parser/DummyBaseDirective.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/DummyBaseDirective.php
@@ -17,7 +17,7 @@ class DummyBaseDirective extends DirectiveHandler
     }
 
     public function process(
-        DocumentParserContext $documentParserContext,
+        BlockContext $blockContext,
         Directive $directive,
     ): Node|null {
         return new DummyNode($directive->getVariable(), $directive->getData(), $directive->getOptions());

--- a/packages/guides-restructured-text/tests/unit/Parser/InlineTokenParserTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/InlineTokenParserTest.php
@@ -87,7 +87,7 @@ final class InlineTokenParserTest extends TestCase
     #[DataProvider('inlineNodeProvider')]
     public function testString(string $content, InlineCompoundNode $expected): void
     {
-        $result = $this->inlineTokenParser->parse($content, $this->documentParserContext);
+        $result = $this->inlineTokenParser->parse($content, new BlockContext($this->documentParserContext, ''));
         self::assertEquals($expected, $result);
     }
 

--- a/packages/guides-restructured-text/tests/unit/Parser/InlineTokenParserTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/InlineTokenParserTest.php
@@ -60,7 +60,6 @@ final class InlineTokenParserTest extends TestCase
             ],
         );
         $this->documentParserContext = new DocumentParserContext(
-            '',
             $this->createStub(ParserContext::class),
             $this->textRoleFactory,
             $this->createStub(MarkupLanguageParser::class),

--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/AnnotationRuleTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/AnnotationRuleTest.php
@@ -65,17 +65,17 @@ final class AnnotationRuleTest extends RuleTestCase
         string|null $nextLine = null,
         bool $nextLiteral = false,
     ): void {
-        $documentParser = $this->createContext($input);
+        $blockParser = $this->createContext($input);
 
-        self::assertTrue($this->rule->applies($documentParser));
-        $result = $this->rule->apply($documentParser);
+        self::assertTrue($this->rule->applies($blockParser));
+        $result = $this->rule->apply($blockParser);
         self::assertEquals(
             $node,
             $result,
         );
 
-        self::assertSame($nextLine, $documentParser->getDocumentIterator()->getNextLine());
-        self::assertSame($nextLiteral, $documentParser->nextIndentedBlockShouldBeALiteralBlock);
+        self::assertSame($nextLine, $blockParser->getDocumentIterator()->getNextLine());
+        self::assertSame($nextLiteral, $blockParser->getDocumentParserContext()->nextIndentedBlockShouldBeALiteralBlock);
     }
 
     /** @return array<string, array<string, string|AnnotationNode|null>> */

--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/CollectAllRule.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/CollectAllRule.php
@@ -7,23 +7,23 @@ namespace phpDocumentor\Guides\RestructuredText\Parser\Productions;
 use phpDocumentor\Guides\Nodes\CompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\RawNode;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Buffer;
-use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 
 /** @implements Rule<RawNode> */
 class CollectAllRule implements Rule
 {
-    public function applies(DocumentParserContext $documentParser): bool
+    public function applies(BlockContext $blockContext): bool
     {
         return true;
     }
 
-    public function apply(DocumentParserContext $documentParserContext, CompoundNode|null $on = null): Node|null
+    public function apply(BlockContext $blockContext, CompoundNode|null $on = null): Node|null
     {
         $buffer = new Buffer();
-        while ($documentParserContext->getDocumentIterator()->valid()) {
-            $buffer->push($documentParserContext->getDocumentIterator()->current());
-            $documentParserContext->getDocumentIterator()->next();
+        while ($blockContext->getDocumentIterator()->valid()) {
+            $buffer->push($blockContext->getDocumentIterator()->current());
+            $blockContext->getDocumentIterator()->next();
         }
 
         return new RawNode($buffer->getLinesString());

--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/FieldListRuleTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/FieldListRuleTest.php
@@ -94,7 +94,7 @@ final class FieldListRuleTest extends RuleTestCase
         $result = $this->rule->apply($context, $documentNode);
 
         self::assertNull($result);
-        self::assertEquals($expectedTitle, $context->getProjectNode()->getTitle());
+        self::assertEquals($expectedTitle, $context->getDocumentParserContext()->getProjectNode()->getTitle());
         self::assertEquals($expectedNodesArray, $documentNode->getHeaderNodes());
         self::assertRemainingEquals($nextLine ?? '', $context->getDocumentIterator());
     }
@@ -111,7 +111,7 @@ final class FieldListRuleTest extends RuleTestCase
         $result = $this->rule->apply($context, $documentNode);
 
         self::assertNull($result);
-        self::assertEquals($expectedVersion, $context->getProjectNode()->getVersion());
+        self::assertEquals($expectedVersion, $context->getDocumentParserContext()->getProjectNode()->getVersion());
         self::assertEquals($expectedNodesArray, $documentNode->getHeaderNodes());
         self::assertRemainingEquals($nextLine ?? '', $context->getDocumentIterator());
     }

--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/InlineRules/TextRoleRuleTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/InlineRules/TextRoleRuleTest.php
@@ -8,6 +8,7 @@ use Generator;
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
 use phpDocumentor\Guides\ParserContext;
 use phpDocumentor\Guides\RestructuredText\MarkupLanguageParser;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 use phpDocumentor\Guides\RestructuredText\TextRoles\TextRole;
@@ -91,13 +92,14 @@ final class TextRoleRuleTest extends TestCase
 
         $textRoleRule = new TextRoleRule();
         self::assertTrue($textRoleRule->applies($lexer));
+        $documentParserContext = new DocumentParserContext(
+            '',
+            $this->createStub(ParserContext::class),
+            $textRoleFactory,
+            $this->createStub(MarkupLanguageParser::class),
+        );
         $node = $textRoleRule->apply(
-            new DocumentParserContext(
-                '',
-                $this->createStub(ParserContext::class),
-                $textRoleFactory,
-                $this->createStub(MarkupLanguageParser::class),
-            ),
+            new BlockContext($documentParserContext, ''),
             $lexer,
         );
 

--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/InlineRules/TextRoleRuleTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/InlineRules/TextRoleRuleTest.php
@@ -93,7 +93,6 @@ final class TextRoleRuleTest extends TestCase
         $textRoleRule = new TextRoleRule();
         self::assertTrue($textRoleRule->applies($lexer));
         $documentParserContext = new DocumentParserContext(
-            '',
             $this->createStub(ParserContext::class),
             $textRoleFactory,
             $this->createStub(MarkupLanguageParser::class),

--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/LinkRuleTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/LinkRuleTest.php
@@ -24,12 +24,12 @@ class LinkRuleTest extends RuleTestCase
         string $expectedUrl,
         AnchorNode|null $expectedNode,
     ): void {
-        $context = $this->createContext($line);
+        $blockContext = $this->createContext($line);
 
-        self::assertTrue($this->rule->applies($context));
-        self::assertEquals($expectedNode, $this->rule->apply($context));
+        self::assertTrue($this->rule->applies($blockContext));
+        self::assertEquals($expectedNode, $this->rule->apply($blockContext));
 
-        self::assertSame([$expectedLabel => $expectedUrl], $context->getContext()->getLinks());
+        self::assertSame([$expectedLabel => $expectedUrl], $blockContext->getDocumentParserContext()->getContext()->getLinks());
     }
 
     /** @return Generator<string, array{string, string, string, AnchorNode|null}> */

--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/ParagraphRuleTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/ParagraphRuleTest.php
@@ -25,21 +25,21 @@ final class ParagraphRuleTest extends RuleTestCase
         string|null $nextLine,
         bool $nextLiteral = false,
     ): void {
-        $documentParser = $this->createContext($input);
+        $blockParser = $this->createContext($input);
 
         $markupRule = $this->givenInlineMarkupRule();
 
         $rule = new ParagraphRule($markupRule);
 
-        self::assertTrue($rule->applies($documentParser));
-        $result = $rule->apply($documentParser);
+        self::assertTrue($rule->applies($blockParser));
+        $result = $rule->apply($blockParser);
         self::assertEquals(
             $node,
             $result,
         );
 
-        self::assertSame($nextLine, $documentParser->getDocumentIterator()->getNextLine());
-        self::assertSame($nextLiteral, $documentParser->nextIndentedBlockShouldBeALiteralBlock);
+        self::assertSame($nextLine, $blockParser->getDocumentIterator()->getNextLine());
+        self::assertSame($nextLiteral, $blockParser->getDocumentParserContext()->nextIndentedBlockShouldBeALiteralBlock);
     }
 
     /** @return mixed[][] */

--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/RuleTestCase.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/RuleTestCase.php
@@ -44,7 +44,6 @@ abstract class RuleTestCase extends TestCase
             new UrlGenerator(),
         );
         $documentParserContext = new DocumentParserContext(
-            $input,
             $parserContext,
             $this->createStub(TextRoleFactory::class),
             $this->createStub(MarkupLanguageParser::class),

--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/RuleTestCase.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/RuleTestCase.php
@@ -10,6 +10,7 @@ use phpDocumentor\Guides\Nodes\InlineCompoundNode;
 use phpDocumentor\Guides\Nodes\ProjectNode;
 use phpDocumentor\Guides\ParserContext;
 use phpDocumentor\Guides\RestructuredText\MarkupLanguageParser;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineParser;
 use phpDocumentor\Guides\RestructuredText\Parser\LinesIterator;
@@ -32,21 +33,24 @@ abstract class RuleTestCase extends TestCase
         self::assertEquals($expected, $rest);
     }
 
-    protected function createContext(string $input): DocumentParserContext
+    protected function createContext(string $input): BlockContext
     {
-        return new DocumentParserContext(
+        $parserContext = new ParserContext(
+            new ProjectNode(),
+            'test',
+            'test',
+            1,
+            $this->createStub(FilesystemInterface::class),
+            new UrlGenerator(),
+        );
+        $documentParserContext = new DocumentParserContext(
             $input,
-            new ParserContext(
-                new ProjectNode(),
-                'test',
-                'test',
-                1,
-                $this->createStub(FilesystemInterface::class),
-                new UrlGenerator(),
-            ),
+            $parserContext,
             $this->createStub(TextRoleFactory::class),
             $this->createStub(MarkupLanguageParser::class),
         );
+
+        return new BlockContext($documentParserContext, $input);
     }
 
     protected function givenInlineMarkupRule(): InlineMarkupRule

--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/SectionRuleTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/SectionRuleTest.php
@@ -200,7 +200,6 @@ RST;
         );
         
         $documentParserContext = new DocumentParserContext(
-            $content,
             $parserContext,
             $this->createStub(TextRoleFactory::class),
             $this->createStub(MarkupLanguageParser::class),

--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/SectionRuleTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/SectionRuleTest.php
@@ -21,6 +21,7 @@ use phpDocumentor\Guides\Nodes\SectionNode;
 use phpDocumentor\Guides\Nodes\TitleNode;
 use phpDocumentor\Guides\ParserContext;
 use phpDocumentor\Guides\RestructuredText\MarkupLanguageParser;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineParser;
 use phpDocumentor\Guides\RestructuredText\TextRoles\TextRoleFactory;
@@ -187,7 +188,7 @@ RST;
         return $inlineTokenParser;
     }
 
-    private function getDocumentParserContext(string $content): DocumentParserContext
+    private function getDocumentParserContext(string $content): BlockContext
     {
         $parserContext = new ParserContext(
             new ProjectNode(),
@@ -197,12 +198,14 @@ RST;
             $this->createStub(FilesystemInterface::class),
             $this->createStub(UrlGeneratorInterface::class),
         );
-
-        return new DocumentParserContext(
+        
+        $documentParserContext = new DocumentParserContext(
             $content,
             $parserContext,
             $this->createStub(TextRoleFactory::class),
             $this->createStub(MarkupLanguageParser::class),
         );
+
+        return new BlockContext($documentParserContext, $content);
     }
 }


### PR DESCRIPTION
This is quite a breaking change. However we had a real flaw in design here. We stored blocks of lines as line iterator in the DocumentParserContext that do not represent the document. To prevent adverse effects we cloned the DocumentParserContext. But this means that all data stored in the document context can get lost because it is set in a clone and not the original context.

This is needed to make #534 work