### PR TITLE
[FEATURE] Make logger messages more verbose

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Directives/RoleDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/RoleDirective.php
@@ -21,6 +21,7 @@ use Psr\Log\LoggerInterface;
 
 use function is_string;
 use function preg_match;
+use function sprintf;
 use function trim;
 
 /**
@@ -53,7 +54,10 @@ class RoleDirective extends ActionDirective
 
         $baseRole = $blockContext->getDocumentParserContext()->getTextRoleFactoryForDocument()->getTextRole($role);
         if (!$baseRole instanceof BaseTextRole) {
-            $this->logger->error('Text role "' . $role . '", class ' . $baseRole::class . ' cannot be extended. ');
+            $this->logger->error(
+                sprintf('Text role "%s", class %s cannot be extended. ', $role, $baseRole::class),
+                $blockContext->getLoggerInformation(),
+            );
 
             return;
         }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/BlockContext.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/BlockContext.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Parser;
 
+use function array_merge;
+
 /**
  * Our document parser contains
  */
@@ -24,6 +26,7 @@ class BlockContext
         private readonly DocumentParserContext $documentParserContext,
         string $contents,
         bool $preserveSpace = false,
+        private readonly int $lineOffset = 0,
     ) {
         $this->documentIterator = new LinesIterator();
         $this->documentIterator->load($contents, $preserveSpace);
@@ -37,5 +40,16 @@ class BlockContext
     public function getDocumentParserContext(): DocumentParserContext
     {
         return $this->documentParserContext;
+    }
+
+    /** @return array<string, int|string> */
+    public function getLoggerInformation(): array
+    {
+        $info = [
+            'currentLine' => $this->documentIterator->current(),
+            'currentLineNumber' => $this->lineOffset + $this->documentIterator->key(),
+        ];
+
+        return array_merge($this->getDocumentParserContext()->getLoggerInformation(), $info);
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/DocumentParserContext.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/DocumentParserContext.php
@@ -20,6 +20,8 @@ use phpDocumentor\Guides\RestructuredText\MarkupLanguageParser;
 use phpDocumentor\Guides\RestructuredText\TextRoles\TextRoleFactory;
 use RuntimeException;
 
+use function array_merge;
+
 /**
  * Our document parser contains
  */
@@ -106,5 +108,18 @@ class DocumentParserContext
     public function setCodeBlockDefaultLanguage(string $codeBlockDefaultLanguage): void
     {
         $this->codeBlockDefaultLanguage = $codeBlockDefaultLanguage;
+    }
+    
+    /** @return array<string, string> */
+    public function getLoggerInformation(): array
+    {
+        $info = [];
+        if ($this->document !== null) {
+            $info = array_merge($this->document->getLoggerInformation(), $info);
+        } else {
+            $info['documentNode'] = 'null';
+        }
+
+        return array_merge($this->getContext()->getLoggerInformation(), $info);
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/AnnotationRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/AnnotationRule.php
@@ -84,7 +84,7 @@ final class AnnotationRule implements Rule
 
         $buffer->trimLines();
         $this->inlineMarkupRule->apply(
-            new BlockContext($blockContext->getDocumentParserContext(), $buffer->getLinesString()),
+            new BlockContext($blockContext->getDocumentParserContext(), $buffer->getLinesString(), false, $documentIterator->key()),
             $node,
         );
 

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DefinitionListRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DefinitionListRule.php
@@ -80,10 +80,10 @@ final class DefinitionListRule implements Rule
         $parts = explode(' : ', $term);
         $term = ltrim(array_shift($parts), '\\');
         $definitionListItem = new DefinitionListItemNode(
-            $this->inlineMarkupRule->apply(new BlockContext($blockContext->getDocumentParserContext(), $term)),
+            $this->inlineMarkupRule->apply(new BlockContext($blockContext->getDocumentParserContext(), $term, false, $documentIterator->key())),
             array_map(
                 fn ($classification): InlineCompoundNode => $this->inlineMarkupRule->apply(
-                    new BlockContext($blockContext->getDocumentParserContext(), $classification),
+                    new BlockContext($blockContext->getDocumentParserContext(), $classification, false, $documentIterator->key()),
                 ),
                 $parts,
             ),
@@ -128,7 +128,7 @@ final class DefinitionListRule implements Rule
         }
 
         $node = new DefinitionNode([]);
-        $subContext = new BlockContext($blockContext->getDocumentParserContext(), $buffer->getLinesString());
+        $subContext = new BlockContext($blockContext->getDocumentParserContext(), $buffer->getLinesString(), false, $documentIterator->key());
         while ($subContext->getDocumentIterator()->valid()) {
             $this->bodyElements->apply($subContext, $node);
         }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
@@ -103,7 +103,7 @@ final class DirectiveRule implements Rule
                 $openingLine,
             );
 
-            $this->logger->error($message, $blockContext->getDocumentParserContext()->getContext()->getLoggerInformation());
+            $this->logger->error($message, $blockContext->getLoggerInformation());
 
             return null;
         }
@@ -114,7 +114,7 @@ final class DirectiveRule implements Rule
         // Processing the Directive, the handler is responsible for adding the right Nodes to the document.
         try {
             $node = $directiveHandler->process(
-                new BlockContext($blockContext->getDocumentParserContext(), $buffer->getLinesString(), true),
+                new BlockContext($blockContext->getDocumentParserContext(), $buffer->getLinesString(), true, $documentIterator->key()),
                 $directive,
             );
 
@@ -143,7 +143,7 @@ final class DirectiveRule implements Rule
             );
 
 
-            $this->logger->error($message, $blockContext->getDocumentParserContext()->getContext()->getLoggerInformation());
+            $this->logger->error($message, $blockContext->getLoggerInformation());
         }
 
         return null;
@@ -155,7 +155,7 @@ final class DirectiveRule implements Rule
             return;
         }
 
-        $subContext = new BlockContext($blockContext->getDocumentParserContext(), $directive->getData());
+        $subContext = new BlockContext($blockContext->getDocumentParserContext(), $directive->getData(), false, $blockContext->getDocumentIterator()->key());
         $inlineNode = $this->inlineMarkupRule->apply(
             $subContext,
             null,

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/EnumeratedListRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/EnumeratedListRule.php
@@ -173,7 +173,7 @@ final class EnumeratedListRule implements Rule
     {
         $marker = trim($listConfig['marker'], '.()');
         $listItem = new ListItemNode($marker, false, []);
-        $subContext = new BlockContext($blockContext->getDocumentParserContext(), $buffer->getLinesString());
+        $subContext = new BlockContext($blockContext->getDocumentParserContext(), $buffer->getLinesString(), false, $blockContext->getDocumentIterator()->key());
         while ($subContext->getDocumentIterator()->valid()) {
             $this->productions->apply($subContext, $listItem);
         }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/ProjectFieldListItemRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/ProjectFieldListItemRule.php
@@ -35,7 +35,7 @@ class ProjectFieldListItemRule implements FieldListItemRule
                 'Project title was set more then once: %s and %s',
                 $currentTitle,
                 $newTitle,
-            ));
+            ), $blockContext->getLoggerInformation());
         }
 
         $blockContext->getDocumentParserContext()->getProjectNode()->setTitle($newTitle);

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/VersionFieldListItemRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/VersionFieldListItemRule.php
@@ -34,7 +34,7 @@ class VersionFieldListItemRule implements FieldListItemRule
                 'Project version was set more then once: %s and %s',
                 $currentVersion,
                 $fieldListItemNode->getPlaintextContent(),
-            ));
+            ), $blockContext->getLoggerInformation());
         }
 
         $blockContext->getDocumentParserContext()->getProjectNode()->setVersion($fieldListItemNode->getPlaintextContent());

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldListRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldListRule.php
@@ -165,6 +165,8 @@ final class FieldListRule implements Rule
         $subContext = new BlockContext(
             $blockContext->getDocumentParserContext(),
             $firstLine . "\n" . $buffer->getLinesString(),
+            false,
+            $documentIterator->key(),
         );
         while ($subContext->getDocumentIterator()->valid()) {
             $this->productions->apply($subContext, $fieldListItemNode);

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/GridTableRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/GridTableRule.php
@@ -71,7 +71,7 @@ final class GridTableRule implements Rule
                     $documentIterator->current(),
                 );
 
-                $this->logger->error($message, $blockContext->getDocumentParserContext()->getContext()->getLoggerInformation());
+                $this->logger->error($message, $blockContext->getLoggerInformation());
             }
 
             if ($this->isHeaderDefinitionLine($documentIterator->current())) {

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/ListRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/ListRule.php
@@ -172,7 +172,7 @@ final class ListRule implements Rule
         }
 
         if (!isset($nodes[0])) {
-            $this->logger->warning('List item without content');
+            $this->logger->warning('List item without content', $blockContext->getLoggerInformation());
 
             return $listItem;
         }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/ParagraphRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/ParagraphRule.php
@@ -90,7 +90,7 @@ final class ParagraphRule implements Rule
         $node = new ParagraphNode();
 
         $this->inlineMarkupRule->apply(
-            new BlockContext($blockContext->getDocumentParserContext(), $buffer->getLinesString()),
+            new BlockContext($blockContext->getDocumentParserContext(), $buffer->getLinesString(), false, $documentIterator->key()),
             $node,
         );
 

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/SimpleTableRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/SimpleTableRule.php
@@ -145,6 +145,7 @@ final class SimpleTableRule implements Rule
                     $gap,
                     $line,
                 ),
+                $blockContext->getLoggerInformation(),
             );
         }
 
@@ -187,7 +188,7 @@ final class SimpleTableRule implements Rule
         }
 
         $column = new TableColumn(trim($content), $colspan);
-        $subContext = new BlockContext($blockContext->getDocumentParserContext(), $content);
+        $subContext = new BlockContext($blockContext->getDocumentParserContext(), $content, false, $blockContext->getDocumentIterator()->key());
         while ($subContext->getDocumentIterator()->valid()) {
             $this->productions->apply($subContext, $column);
         }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/Table/GridTableBuilder.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/Table/GridTableBuilder.php
@@ -218,7 +218,7 @@ class GridTableBuilder
                     $blockContext->getDocumentParserContext()->getContext()->getCurrentFileName(),
                     $tableAsString,
                 );
-                $this->logger->error($message, $blockContext->getDocumentParserContext()->getContext()->getLoggerInformation());
+                $this->logger->error($message, $blockContext->getLoggerInformation());
             }
 
             return null;
@@ -256,7 +256,7 @@ class GridTableBuilder
         RuleContainer $productions,
     ): TableColumn {
         $content = $col->getContent();
-        $subContext = new BlockContext($blockContext->getDocumentParserContext(), $content);
+        $subContext = new BlockContext($blockContext->getDocumentParserContext(), $content, false, $blockContext->getDocumentIterator()->key());
         while ($subContext->getDocumentIterator()->valid()) {
             $productions->apply($subContext, $col);
         }

--- a/packages/guides-restructured-text/src/RestructuredText/TextRoles/AbstractReferenceTextRole.php
+++ b/packages/guides-restructured-text/src/RestructuredText/TextRoles/AbstractReferenceTextRole.php
@@ -58,7 +58,7 @@ abstract class AbstractReferenceTextRole implements TextRole
                                 'Reference contains unexpected content after closing `>`: "%s"',
                                 $content,
                             ),
-                            $documentParserContext->getContext()->getLoggerInformation(),
+                            $documentParserContext->getLoggerInformation(),
                         );
                     }
 

--- a/packages/guides/src/Compiler/CompilerContext.php
+++ b/packages/guides/src/Compiler/CompilerContext.php
@@ -19,6 +19,8 @@ use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\ProjectNode;
 
+use function array_merge;
+
 class CompilerContext
 {
     /** @var TreeNode<Node> */
@@ -68,5 +70,11 @@ class CompilerContext
         }
 
         return $this->shadowTree;
+    }
+
+    /** @return array<string, string> */
+    public function getLoggerInformation(): array
+    {
+        return array_merge($this->getDocumentNode()->getLoggerInformation());
     }
 }

--- a/packages/guides/src/Compiler/NodeTransformers/DocumentEntryRegistrationTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/DocumentEntryRegistrationTransformer.php
@@ -32,7 +32,7 @@ class DocumentEntryRegistrationTransformer implements NodeTransformer
         }
 
         if ($node->getTitle() === null && !$node->isOrphan()) {
-            $this->logger->warning('Document has not title', $node->getLoggerInformation());
+            $this->logger->warning('Document has no title', $compilerContext->getLoggerInformation());
         }
 
         $entry = new DocumentEntryNode($node->getFilePath(), $node->getTitle() ?? TitleNode::emptyNode(), $node->isRoot());

--- a/packages/guides/src/Compiler/NodeTransformers/MenuNodeAddEntryTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/MenuNodeAddEntryTransformer.php
@@ -211,7 +211,7 @@ class MenuNodeAddEntryTransformer implements NodeTransformer
                     $documentEntryInToc->getFile(),
                     $documentEntryInToc->getParent()->getFile(),
                     $compilerContext->getDocumentNode()->getDocumentEntry()->getFile(),
-                ));
+                ), $compilerContext->getLoggerInformation());
             }
 
             if ($documentEntryInToc->getParent() !== null) {

--- a/packages/guides/src/Compiler/NodeTransformers/VariableInlineNodeTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/VariableInlineNodeTransformer.php
@@ -43,7 +43,7 @@ class VariableInlineNodeTransformer implements NodeTransformer
         } else {
             $this->logger->warning(
                 'No replacement was found for variable |' . $node->getValue() . '|',
-                ['document', $compilerContext->getDocumentNode()->getFilePath()],
+                $compilerContext->getLoggerInformation(),
             );
             $node->setChild(new PlainTextInlineNode('|' . $node->getValue() . '|'));
         }

--- a/packages/guides/src/NodeRenderers/DefaultNodeRenderer.php
+++ b/packages/guides/src/NodeRenderers/DefaultNodeRenderer.php
@@ -20,6 +20,7 @@ use Psr\Log\LoggerInterface;
 use function assert;
 use function is_array;
 use function is_string;
+use function sprintf;
 
 /** @implements NodeRenderer<Node> */
 class DefaultNodeRenderer implements NodeRenderer, NodeRendererFactoryAware
@@ -51,7 +52,10 @@ class DefaultNodeRenderer implements NodeRenderer, NodeRendererFactoryAware
                 if ($child instanceof Node) {
                     $returnValue .= $this->render($child, $renderContext);
                 } else {
-                    $this->logger->error('The default renderer cannot be applied to node ' . $node::class);
+                    $this->logger->error(
+                        sprintf('The default renderer cannot be applied to node %s', $node::class),
+                        $renderContext->getLoggerInformation(),
+                    );
                 }
             }
 
@@ -62,7 +66,10 @@ class DefaultNodeRenderer implements NodeRenderer, NodeRendererFactoryAware
             return $value;
         }
 
-        $this->logger->error('The default renderer cannot be applied to node ' . $node::class);
+        $this->logger->error(
+            sprintf('The default renderer cannot be applied to node %s', $node::class),
+            $renderContext->getLoggerInformation(),
+        );
 
         return '';
     }

--- a/packages/guides/src/ReferenceResolvers/DelegatingReferenceResolver.php
+++ b/packages/guides/src/ReferenceResolvers/DelegatingReferenceResolver.php
@@ -8,6 +8,8 @@ use phpDocumentor\Guides\Nodes\Inline\LinkInlineNode;
 use phpDocumentor\Guides\RenderContext;
 use Psr\Log\LoggerInterface;
 
+use function sprintf;
+
 /**
  * Resolves the URL for all inline link nodes using reference resolvers.
  */
@@ -26,6 +28,13 @@ final class DelegatingReferenceResolver
             }
         }
 
-        $this->logger->warning('Reference ' . $node->getTargetReference() . ' could not be resolved in ' . $renderContext->getCurrentFileName());
+        $this->logger->warning(
+            sprintf(
+                'Reference %s could not be resolved in %s',
+                $node->getTargetReference(),
+                $renderContext->getCurrentFileName(),
+            ),
+            $renderContext->getLoggerInformation(),
+        );
     }
 }

--- a/packages/guides/src/Twig/AssetsExtension.php
+++ b/packages/guides/src/Twig/AssetsExtension.php
@@ -141,24 +141,36 @@ final class AssetsExtension extends AbstractExtension
 
         try {
             if ($renderContext->getOrigin()->has($sourcePath) === false) {
-                $this->logger->error(sprintf('Image reference not found "%s"', $sourcePath));
+                $this->logger->error(
+                    sprintf('Image reference not found "%s"', $sourcePath),
+                    $renderContext->getLoggerInformation(),
+                );
 
                 return $outputPath;
             }
 
             $fileContents = $renderContext->getOrigin()->read($sourcePath);
             if ($fileContents === false) {
-                $this->logger->error(sprintf('Could not read image file "%s"', $sourcePath));
+                $this->logger->error(
+                    sprintf('Could not read image file "%s"', $sourcePath),
+                    $renderContext->getLoggerInformation(),
+                );
 
                 return $outputPath;
             }
 
             $result = $renderContext->getDestination()->put($outputPath, $fileContents);
             if ($result === false) {
-                $this->logger->error(sprintf('Unable to write file "%s"', $outputPath));
+                $this->logger->error(
+                    sprintf('Unable to write file "%s"', $outputPath),
+                    $renderContext->getLoggerInformation(),
+                );
             }
         } catch (LogicException | Exception $e) {
-            $this->logger->error(sprintf('Unable to write file "%s", %s', $outputPath, $e->getMessage()));
+            $this->logger->error(
+                sprintf('Unable to write file "%s", %s', $outputPath, $e->getMessage()),
+                $renderContext->getLoggerInformation(),
+            );
         }
 
         return $outputPath;

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -49,7 +49,7 @@ class FunctionalTest extends ApplicationTestCase
 {
     private const SKIP_INDENTER_FILES = ['code-block-diff'];
 
-    private const IGNORED_WARNINGS = ['Document has not title'];
+    private const IGNORED_WARNINGS = ['Document has no title'];
 
     protected function setUp(): void
     {

--- a/tests/Integration/tests/list-warning/expected/index.html
+++ b/tests/Integration/tests/list-warning/expected/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Document Title</title>
+
+</head>
+<body>
+    <div class="section" id="document-title">
+    <h1>Document Title</h1>
+
+            <p>This is an empty list</p>
+            
+
+<ul>
+    <li></li>
+
+</ul>
+
+            <p>This list has an empty point:</p>
+            
+
+<ul>
+    <li>Something</li>
+
+    <li></li>
+
+</ul>
+
+    </div>
+
+</body>
+</html>

--- a/tests/Integration/tests/list-warning/expected/logs/warning.log
+++ b/tests/Integration/tests/list-warning/expected/logs/warning.log
@@ -1,0 +1,2 @@
+app.WARNING: List item without content {"rst-file":"index.rst","currentLine":"","currentLineNumber":7} []
+app.WARNING: List item without content {"rst-file":"index.rst","currentLine":"*","currentLineNumber":11} []

--- a/tests/Integration/tests/list-warning/input/index.rst
+++ b/tests/Integration/tests/list-warning/input/index.rst
@@ -1,0 +1,12 @@
+==============
+Document Title
+==============
+
+This is an empty list
+
+* 
+
+This list has an empty point:
+
+*   Something
+*   


### PR DESCRIPTION
Add information of the current file and if available line, get Logger Information from the current context

Currently there are messages without any information in the log like:

[2023-08-19T10:29:31.762207+00:00] app.WARNING: List item without content [] []
[2023-08-19T10:29:31.764719+00:00] app.WARNING: List item without content [] []
