### PR TITLE
!![TASK] Replace the subparser with a starting rule in directives

### DIFF
--- a/packages/guides-restructured-text/resources/config/guides-restructured-text.php
+++ b/packages/guides-restructured-text/resources/config/guides-restructured-text.php
@@ -38,6 +38,7 @@ use phpDocumentor\Guides\RestructuredText\Directives\RoleDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\RubricDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\SeeAlsoDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\SidebarDirective;
+use phpDocumentor\Guides\RestructuredText\Directives\SubDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\TipDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\TitleDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\ToctreeDirective;
@@ -53,6 +54,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\Productions\AnnotationRule;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\BlockQuoteRule;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\CommentRule;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\DefinitionListRule;
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\DirectiveContentRule;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\DirectiveRule;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\DocumentRule;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\EnumeratedListRule;
@@ -124,6 +126,8 @@ return static function (ContainerConfigurator $container): void {
         ->tag('phpdoc.guides.noderenderer.html')
         ->instanceof(TextRole::class)
         ->tag('phpdoc.guides.parser.rst.text_role')
+        ->instanceof(SubDirective::class)
+        ->bind('$startingRule', service(DirectiveContentRule::class))
 
         ->load(
             'phpDocumentor\\Guides\RestructuredText\\Parser\\Productions\\InlineRules\\',
@@ -135,6 +139,7 @@ return static function (ContainerConfigurator $container): void {
         )
 
 
+        ->set(DirectiveContentRule::class)
         ->set(DocReferenceTextRole::class)
         ->set(ReferenceTextRole::class)
         ->set(AbbreviationTextRole::class)

--- a/packages/guides-restructured-text/resources/config/guides-restructured-text.php
+++ b/packages/guides-restructured-text/resources/config/guides-restructured-text.php
@@ -219,6 +219,7 @@ return static function (ContainerConfigurator $container): void {
         ->set(LiteralBlockRule::class)
         ->tag('phpdoc.guides.parser.rst.body_element', ['priority' => LiteralBlockRule::PRIORITY])
         ->set(BlockQuoteRule::class)
+        ->arg('$startingRule', service(DirectiveContentRule::class))
         ->tag('phpdoc.guides.parser.rst.body_element', ['priority' => BlockQuoteRule::PRIORITY])
         ->set(ListRule::class)
         ->arg('$productions', service('phpdoc.guides.parser.rst.body_elements'))

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/AbstractAdmonitionDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/AbstractAdmonitionDirective.php
@@ -13,15 +13,17 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
-use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Nodes\AdmonitionNode;
+use phpDocumentor\Guides\RestructuredText\Nodes\CollectionNode;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
 
 abstract class AbstractAdmonitionDirective extends SubDirective
 {
-    public function __construct(private readonly string $name, private readonly string $text)
+    public function __construct(protected Rule $startingRule, private readonly string $name, private readonly string $text)
     {
+        parent::__construct($startingRule);
     }
 
     /** {@inheritDoc}
@@ -29,14 +31,14 @@ abstract class AbstractAdmonitionDirective extends SubDirective
      * @param Directive $directive
      */
     final protected function processSub(
-        DocumentNode $document,
+        CollectionNode $collectionNode,
         Directive $directive,
     ): Node|null {
         return new AdmonitionNode(
             $this->name,
             $directive->getDataNode(),
             $this->text,
-            $document->getChildren(),
+            $collectionNode->getChildren(),
         );
     }
 

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/AbstractVersionChangeDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/AbstractVersionChangeDirective.php
@@ -13,16 +13,18 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
-use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Nodes\CollectionNode;
 use phpDocumentor\Guides\RestructuredText\Nodes\VersionChangeNode;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
 
 /** @see https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-versionadded */
 abstract class AbstractVersionChangeDirective extends SubDirective
 {
-    public function __construct(private readonly string $type, private readonly string $label)
+    public function __construct(protected Rule $startingRule, private readonly string $type, private readonly string $label)
     {
+        parent::__construct($startingRule);
     }
 
     /** {@inheritDoc}
@@ -30,14 +32,14 @@ abstract class AbstractVersionChangeDirective extends SubDirective
      * @param Directive $directive
      */
     final protected function processSub(
-        DocumentNode $document,
+        CollectionNode $collectionNode,
         Directive $directive,
     ): Node|null {
         return new VersionChangeNode(
             $this->type,
             $this->label,
             $directive->getData(),
-            $document->getChildren(),
+            $collectionNode->getChildren(),
         );
     }
 

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/AdmonitionDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/AdmonitionDirective.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
-use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Nodes\AdmonitionNode;
+use phpDocumentor\Guides\RestructuredText\Nodes\CollectionNode;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
 use function preg_replace;
@@ -44,8 +44,10 @@ class AdmonitionDirective extends SubDirective
      *
      * @param Directive $directive
      */
-    protected function processSub(DocumentNode $document, Directive $directive): Node|null
-    {
+    protected function processSub(
+        CollectionNode $collectionNode,
+        Directive $directive,
+    ): Node|null {
         $name = trim(
             preg_replace('/[^0-9a-zA-Z]+/', '-', strtolower($directive->getData())) ?? '',
             '-',
@@ -55,7 +57,7 @@ class AdmonitionDirective extends SubDirective
             $name,
             $directive->getDataNode(),
             $directive->getData(),
-            $document->getChildren(),
+            $collectionNode->getChildren(),
             true,
         );
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/AttentionDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/AttentionDirective.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
+
 class AttentionDirective extends AbstractAdmonitionDirective
 {
-    public function __construct()
+    public function __construct(protected Rule $startingRule)
     {
-        parent::__construct('attention', 'Attention');
+        parent::__construct($startingRule, 'attention', 'Attention');
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/CautionDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/CautionDirective.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
+
 class CautionDirective extends AbstractAdmonitionDirective
 {
-    public function __construct()
+    public function __construct(protected Rule $startingRule)
     {
-        parent::__construct('caution', 'Caution');
+        parent::__construct($startingRule, 'caution', 'Caution');
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ClassDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ClassDirective.php
@@ -39,7 +39,7 @@ class ClassDirective extends SubDirective
      * @param Directive $directive
      */
     protected function processSub(
-        DocumentNode $document,
+        CollectionNode $collectionNode,
         Directive $directive,
     ): Node|null {
         $classes = explode(' ', $directive->getData());
@@ -49,18 +49,18 @@ class ClassDirective extends SubDirective
             $classes,
         );
 
-        $document->setClasses($normalizedClasses);
+        $collectionNode->setClasses($normalizedClasses);
 
-        if ($document->getNodes() === []) {
+        if ($collectionNode->getChildren() === []) {
             $classNode = new ClassNode($directive->getData());
             $classNode->setClasses($classes);
 
             return $classNode;
         }
 
-        $this->setNodesClasses($document->getNodes(), $classes);
+        $this->setNodesClasses($collectionNode->getChildren(), $classes);
 
-        return new CollectionNode($document->getNodes());
+        return new CollectionNode($collectionNode->getChildren());
     }
 
     /**

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ContainerDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ContainerDirective.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
-use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Nodes\CollectionNode;
 use phpDocumentor\Guides\RestructuredText\Nodes\ContainerNode;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
@@ -32,9 +32,9 @@ class ContainerDirective extends SubDirective
      * @param Directive $directive
      */
     protected function processSub(
-        DocumentNode $document,
+        CollectionNode $collectionNode,
         Directive $directive,
     ): Node|null {
-        return (new ContainerNode($document->getChildren()))->withOptions(['class' => $directive->getData()]);
+        return (new ContainerNode($collectionNode->getChildren()))->withOptions(['class' => $directive->getData()]);
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/DangerDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/DangerDirective.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
+
 class DangerDirective extends AbstractAdmonitionDirective
 {
-    public function __construct()
+    public function __construct(protected Rule $startingRule)
     {
-        parent::__construct('danger', 'Danger');
+        parent::__construct($startingRule, 'danger', 'Danger');
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/DeprecatedDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/DeprecatedDirective.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
+
 class DeprecatedDirective extends AbstractVersionChangeDirective
 {
-    public function __construct()
+    public function __construct(protected Rule $startingRule)
     {
-        parent::__construct('deprecated', 'Deprecated since version %s');
+        parent::__construct($startingRule, 'deprecated', 'Deprecated since version %s');
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/DocumentBlockDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/DocumentBlockDirective.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 use phpDocumentor\Guides\Nodes\DocumentBlockNode;
-use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Nodes\CollectionNode;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
 class DocumentBlockDirective extends SubDirective
@@ -20,12 +20,14 @@ class DocumentBlockDirective extends SubDirective
      *
      * @param Directive $directive
      */
-    protected function processSub(DocumentNode $document, Directive $directive): Node|null
-    {
+    protected function processSub(
+        CollectionNode $collectionNode,
+        Directive $directive,
+    ): Node|null {
         $identifier = ((string) $directive->getOption('identifier')->getValue());
 
         return new DocumentBlockNode(
-            $document->getChildren(),
+            $collectionNode->getChildren(),
             $identifier,
         );
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ErrorDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ErrorDirective.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
+
 class ErrorDirective extends AbstractAdmonitionDirective
 {
-    public function __construct()
+    public function __construct(protected Rule $startingRule)
     {
-        parent::__construct('error', 'Error');
+        parent::__construct($startingRule, 'error', 'Error');
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/FigureDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/FigureDirective.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
-use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\Nodes\FigureNode;
 use phpDocumentor\Guides\Nodes\ImageNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Nodes\CollectionNode;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
 use phpDocumentor\Guides\UrlGeneratorInterface;
 
 /**
@@ -23,8 +23,9 @@ use phpDocumentor\Guides\UrlGeneratorInterface;
  */
 class FigureDirective extends SubDirective
 {
-    public function __construct(private readonly UrlGeneratorInterface $urlGenerator)
+    public function __construct(protected Rule $startingRule, private readonly UrlGeneratorInterface $urlGenerator)
     {
+        parent::__construct($startingRule);
     }
 
     public function getName(): string
@@ -37,7 +38,7 @@ class FigureDirective extends SubDirective
      * @param Directive $directive
      */
     protected function processSub(
-        DocumentNode $document,
+        CollectionNode $collectionNode,
         Directive $directive,
     ): Node|null {
         $image = new ImageNode($this->urlGenerator->relativeUrl($directive->getData()));
@@ -52,6 +53,6 @@ class FigureDirective extends SubDirective
             'name' => $scalarOptions['name'] ?? null,
         ]);
 
-        return new FigureNode($image, new CollectionNode($document->getChildren()));
+        return new FigureNode($image, new CollectionNode($collectionNode->getChildren()));
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/HintDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/HintDirective.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
+
 class HintDirective extends AbstractAdmonitionDirective
 {
-    public function __construct()
+    public function __construct(protected Rule $startingRule)
     {
-        parent::__construct('hint', 'Hint');
+        parent::__construct($startingRule, 'hint', 'Hint');
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ImportantDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ImportantDirective.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
+
 class ImportantDirective extends AbstractAdmonitionDirective
 {
-    public function __construct()
+    public function __construct(protected Rule $startingRule)
     {
-        parent::__construct('important', 'Important');
+        parent::__construct($startingRule, 'important', 'Important');
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/NoteDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/NoteDirective.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
+
 class NoteDirective extends AbstractAdmonitionDirective
 {
-    public function __construct()
+    public function __construct(protected Rule $startingRule)
     {
-        parent::__construct('note', 'Note');
+        parent::__construct($startingRule, 'note', 'Note');
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ReplaceDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ReplaceDirective.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
-use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\Nodes\InlineCompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\ParagraphNode;
 use phpDocumentor\Guides\Nodes\ReplacementNode;
+use phpDocumentor\Guides\RestructuredText\Nodes\CollectionNode;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
 use function count;
@@ -20,10 +20,6 @@ use function count;
  */
 class ReplaceDirective extends SubDirective
 {
-    public function __construct()
-    {
-    }
-
     public function getName(): string
     {
         return 'replace';
@@ -34,11 +30,11 @@ class ReplaceDirective extends SubDirective
      * @param Directive $directive
      */
     final protected function processSub(
-        DocumentNode $document,
+        CollectionNode $collectionNode,
         Directive $directive,
     ): Node|null {
         /** @var array<InlineCompoundNode> $children */
-        $children = $document->getChildren();
+        $children = $collectionNode->getChildren();
         $data = $directive->getDataNode();
         if ($data !== null) {
             if (count($children) > 0) {

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/SeeAlsoDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/SeeAlsoDirective.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
+
 class SeeAlsoDirective extends AbstractAdmonitionDirective
 {
-    public function __construct()
+    public function __construct(protected Rule $startingRule)
     {
-        parent::__construct('seealso', 'See also');
+        parent::__construct($startingRule, 'seealso', 'See also');
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/SidebarDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/SidebarDirective.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
-use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Nodes\CollectionNode;
 use phpDocumentor\Guides\RestructuredText\Nodes\SidebarNode;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
@@ -35,12 +35,12 @@ class SidebarDirective extends SubDirective
      * @param Directive $directive
      */
     protected function processSub(
-        DocumentNode $document,
+        CollectionNode $collectionNode,
         Directive $directive,
     ): Node|null {
         return new SidebarNode(
             $directive->getData(),
-            $document->getChildren(),
+            $collectionNode->getChildren(),
         );
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/TipDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/TipDirective.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
+
 class TipDirective extends AbstractAdmonitionDirective
 {
-    public function __construct()
+    public function __construct(protected Rule $startingRule)
     {
-        parent::__construct('tip', 'Tip');
+        parent::__construct($startingRule, 'tip', 'Tip');
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/TodoDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/TodoDirective.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
-use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Nodes\CollectionNode;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
 /**
@@ -19,7 +19,7 @@ class TodoDirective extends SubDirective
     }
 
     protected function processSub(
-        DocumentNode $document,
+        CollectionNode $collectionNode,
         Directive $directive,
     ): Node|null {
         return null;

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/TopicDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/TopicDirective.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
-use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Nodes\CollectionNode;
 use phpDocumentor\Guides\RestructuredText\Nodes\TopicNode;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
@@ -22,12 +22,12 @@ class TopicDirective extends SubDirective
 {
     /** {@inheritDoc} */
     final protected function processSub(
-        DocumentNode $document,
+        CollectionNode $collectionNode,
         Directive $directive,
     ): Node|null {
         return new TopicNode(
             $directive->getData(),
-            $document->getChildren(),
+            $collectionNode->getChildren(),
         );
     }
 

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/VersionAddedDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/VersionAddedDirective.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
+
 class VersionAddedDirective extends AbstractVersionChangeDirective
 {
-    public function __construct()
+    public function __construct(protected Rule $startingRule)
     {
-        parent::__construct('versionadded', 'New in version %s');
+        parent::__construct($startingRule, 'versionadded', 'New in version %s');
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/VersionChangedDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/VersionChangedDirective.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
+
 class VersionChangedDirective extends AbstractVersionChangeDirective
 {
-    public function __construct()
+    public function __construct(protected Rule $startingRule)
     {
-        parent::__construct('versionchanged', 'Changed in version %s');
+        parent::__construct($startingRule, 'versionchanged', 'Changed in version %s');
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/WarningDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/WarningDirective.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
+
 class WarningDirective extends AbstractAdmonitionDirective
 {
-    public function __construct()
+    public function __construct(protected Rule $startingRule)
     {
-        parent::__construct('warning', 'Warning');
+        parent::__construct($startingRule, 'warning', 'Warning');
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/WrapDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/WrapDirective.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
-use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Nodes\CollectionNode;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
@@ -24,9 +23,9 @@ class WrapDirective extends SubDirective
      * @param Directive $directive
      */
     protected function processSub(
-        DocumentNode $document,
+        CollectionNode $collectionNode,
         Directive $directive,
     ): Node|null {
-        return new CollectionNode($document->getChildren());
+        return $collectionNode;
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveContentRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveContentRule.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\RestructuredText\Parser\Productions;
+
+use phpDocumentor\Guides\Nodes\CompoundNode;
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Nodes\CollectionNode;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
+
+/** @implements Rule<CollectionNode> */
+class DirectiveContentRule implements Rule
+{
+    public function __construct(private readonly RuleContainer $bodyElements)
+    {
+    }
+
+    public function applies(BlockContext $blockContext): bool
+    {
+        return true;
+    }
+
+    public function apply(BlockContext $blockContext, CompoundNode|null $on = null): Node|null
+    {
+        $node = new CollectionNode([]);
+        $documentIterator = $blockContext->getDocumentIterator();
+        // We explicitly do not use foreach, but rather the cursors of the DocumentIterator
+        // this is done because we are transitioning to a method where a Substate can take the current
+        // cursor as starting point and loop through the cursor
+        while ($documentIterator->valid()) {
+            $this->bodyElements->apply($blockContext, $node);
+        }
+        
+        return $node;
+    }
+}

--- a/tests/Functional/tests/field-list-in-directive/field-list-in-directive.html
+++ b/tests/Functional/tests/field-list-in-directive/field-list-in-directive.html
@@ -1,4 +1,3 @@
-SKIP Field list disappear from directive content
 <div class="section" id="field-list">
     <h1>
         Field List


### PR DESCRIPTION
This change is breaking for anyone who implemented a SubDirective with a constructor as now the parent constructor has to be called. It also fixes the bug of disappearing field lists in direcitves.

getSubParser is only used in 2 other places that can be dealed with in a follow up such that we can remove the deprecated method all together,

I also removed the subparser in the Blockquotes. So it is only used in the include directive now. 