### PR TITLE
Endorse divergence from specification for links

### DIFF
--- a/tests/Functional/tests/links/links.html
+++ b/tests/Functional/tests/links/links.html
@@ -9,3 +9,4 @@
 pick it up from <a href="ftp://foo.example.com/rfc/">ftp://foo.example.com/rfc/</a>. Note the warning in
 <a href="http://www.ics.uci.edu/pub/ietf/uri/historical.html#WARNING">http://www.ics.uci.edu/pub/ietf/uri/historical.html#WARNING</a>.</p>
 <p>You can read more on the features of Embeddables objects <a href="http://docs.doctrine-project.org/en/latest/tutorials/embeddables.html">in the documentation</a>.</p>
+<p>Doctrine has a few links that are between brackets (<a href="https://www.doctrine-project.org/projects/doctrine-orm/en/2.16/reference/dql-doctrine-query-language.html#query-hints">such as here</a>)</p>

--- a/tests/Functional/tests/links/links.rst
+++ b/tests/Functional/tests/links/links.rst
@@ -22,5 +22,8 @@ http://www.ics.uci.edu/pub/ietf/uri/historical.html#WARNING.
 You can read more on the features of Embeddables objects `in the documentation
 <http://docs.doctrine-project.org/en/latest/tutorials/embeddables.html>`_.
 
+Doctrine has a few links that are between brackets (`such as here
+<https://www.doctrine-project.org/projects/doctrine-orm/en/2.16/reference/dql-doctrine-query-language.html#query-hints>`_)
+
 .. _`xkcd`: http://xkcd.com/
 .. _something: http://something.com/


### PR DESCRIPTION
According to
https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#inline-markup, inline markup must be separated from surrounding text by non-word characters.

Currently, the library does not seem to be checking for the spaces, and it seems that Github's parser has the same behavior: a link between brackets is recognized.

That behavior is nice, and since Github adopted it, it might not be that risky. Let us add a test so that it can be relied on.