### PR TITLE
[BUGFIX] Replace special signs in directive template names

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/NodeRenderers/Html/GeneralDirectiveNodeRenderer.php
+++ b/packages/guides-restructured-text/src/RestructuredText/NodeRenderers/Html/GeneralDirectiveNodeRenderer.php
@@ -21,7 +21,9 @@ use phpDocumentor\Guides\RestructuredText\Nodes\GeneralDirectiveNode;
 use phpDocumentor\Guides\TemplateRenderer;
 use Psr\Log\LoggerInterface;
 
+use function preg_replace;
 use function sprintf;
+use function str_replace;
 
 /** @implements NodeRenderer<GeneralDirectiveNode> */
 class GeneralDirectiveNodeRenderer implements NodeRenderer
@@ -43,7 +45,7 @@ class GeneralDirectiveNodeRenderer implements NodeRenderer
             throw new InvalidArgumentException('Node must be an instance of ' . GeneralDirectiveNode::class);
         }
 
-        $template = 'body/directive/' . $node->getName() . '.html.twig';
+        $template = 'body/directive/' . $this->getTemplateName($node->getName()) . '.html.twig';
         $data = ['node' => $node];
         if ($this->renderer->isTemplateFound($renderContext, $template)) {
             return $this->renderer->renderTemplate($renderContext, $template, $data);
@@ -57,5 +59,13 @@ class GeneralDirectiveNodeRenderer implements NodeRenderer
         $template = 'body/directive/not-found.html.twig';
 
         return $this->renderer->renderTemplate($renderContext, $template, $data);
+    }
+    
+    private function getTemplateName(string $directiveName): string
+    {
+        $directiveName = str_replace(':', '/', $directiveName);
+        $directiveName = preg_replace('/[^a-zA-Z0-9-_\/]/', '_', $directiveName);
+
+        return '' . $directiveName;
     }
 }

--- a/packages/guides-restructured-text/tests/unit/NodeRenderers/Html/GeneralDirectiveNodeRendererTest.php
+++ b/packages/guides-restructured-text/tests/unit/NodeRenderers/Html/GeneralDirectiveNodeRendererTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\RestructuredText\NodeRenderers\Html;
+
+use Monolog\Logger;
+use phpDocumentor\Guides\Nodes\InlineCompoundNode;
+use phpDocumentor\Guides\RenderContext;
+use phpDocumentor\Guides\RestructuredText\Nodes\GeneralDirectiveNode;
+use phpDocumentor\Guides\RestructuredText\TextRoles\DefaultTextRoleFactory;
+use phpDocumentor\Guides\RestructuredText\TextRoles\GenericTextRole;
+use phpDocumentor\Guides\RestructuredText\TextRoles\LiteralTextRole;
+use phpDocumentor\Guides\TemplateRenderer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class GeneralDirectiveNodeRendererTest extends TestCase
+{
+    private GeneralDirectiveNodeRenderer $generalDirectiveNodeRenderer;
+    private RenderContext&MockObject $renderContext;
+    private TemplateRenderer&MockObject $renderer;
+
+    public function setUp(): void
+    {
+        $this->renderContext = $this->createMock(RenderContext::class);
+        $this->renderer = $this->createMock(TemplateRenderer::class);
+        $this->generalDirectiveNodeRenderer = new GeneralDirectiveNodeRenderer(
+            $this->renderer,
+            new Logger('test'),
+        );
+        $textRoleFactory = new DefaultTextRoleFactory(
+            new GenericTextRole(),
+            new LiteralTextRole(),
+            [],
+        );
+    }
+
+    #[DataProvider('templateProvider')]
+    public function testTemplateFallback(string $directiveName, string $templateName): void
+    {
+        $this->renderer->expects(self::once())
+            ->method('isTemplateFound')
+            ->with($this->renderContext, 'body/directive/' . $templateName)
+            ->willReturn(true);
+        $this->generalDirectiveNodeRenderer->render(
+            new GeneralDirectiveNode($directiveName, '', new InlineCompoundNode([])),
+            $this->renderContext,
+        );
+    }
+
+    /** @return array<string, string[]> */
+    public static function templateProvider(): array
+    {
+        return [
+            'simple name' => ['name', 'name.html.twig'],
+            'with minus' => ['some-name', 'some-name.html.twig'],
+            'with space' => ['some name', 'some_name.html.twig'],
+            'with special signs' => ['some\\name', 'some_name.html.twig'],
+            'with namespace' => ['some:name', 'some/name.html.twig'],
+        ];
+    }
+}


### PR DESCRIPTION
And handle directives in namespaces as having templates in subdirectories