### PR TITLE
[FEATURE] Search for configuration in parent of vendor

### DIFF
--- a/packages/guides-cli/bin/guides
+++ b/packages/guides-cli/bin/guides
@@ -33,8 +33,13 @@ if (file_exists($autoloadDirectory)){
 $input = new ArgvInput();
 
 $containerFactory = new ContainerFactory([new ApplicationExtension()]);
+
+if (is_file($vendorDir . '/../guides.xml')) {
+    // vendor folder was placed directly into the project directory
+    $containerFactory->addConfigFile($vendorDir . '/../guides.xml');
+}
 if (is_file($input->getParameterOption('--config', getcwd(), true).'/guides.xml')) {
-    $containerFactory->addConfigFile('guides.xml');
+    $containerFactory->addConfigFile($input->getParameterOption('--config', getcwd(), true).'/guides.xml');
 }
 $container = $containerFactory->create($vendorDir);
 


### PR DESCRIPTION
If the script is executed from any other locatation but its own project directory we need to search for the guides.xml above the vendor.