### PR TITLE
[BUGFIX] Make Email detection in lexer more strict

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Parser/InlineLexer.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/InlineLexer.php
@@ -56,7 +56,7 @@ final class InlineLexer extends AbstractLexer
         return [
             '\\\\``', // must be a separate case, as the next pattern would split in "\`" + "`", causing it to become a intepreted text
             '\\\\[\s\S]', // Escaping hell... needs escaped slash in regex, but also in php.
-            '\\S+@\\S+\\.\\S+',
+            '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}',
             '[a-z0-9-]+_{2}', //Inline href.
             '[a-z0-9-]+_{1}(?=[\s\.+]|$)', //Inline href.
             '``.+?``(?!`)',
@@ -116,7 +116,7 @@ final class InlineLexer extends AbstractLexer
             return self::HYPERLINK;
         }
 
-        if (preg_match('/\\S+@\\S+\\.\\S+/i', $value)) {
+        if (preg_match('/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}/i', $value)) {
             return self::EMAIL;
         }
 

--- a/packages/guides-restructured-text/tests/unit/Parser/InlineLexerTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/InlineLexerTest.php
@@ -52,6 +52,14 @@ class InlineLexerTest extends TestCase
                 'css_ and something',
                 [InlineLexer::NAMED_REFERENCE],
             ],
+            'Email' => [
+                'git@github.com',
+                [InlineLexer::EMAIL],
+            ],
+            'Email in backticks' => [
+                '`git@github.com`',
+                [InlineLexer::BACKTICK],
+            ],
         ];
     }
 }

--- a/tests/Integration/tests/list-with-code/expected/index.html
+++ b/tests/Integration/tests/list-with-code/expected/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Test</title>
+
+</head>
+<body>
+    <div class="section" id="test">
+    <h1>Test</h1>
+
+            
+
+<ul>
+    <li>Lorem:  <code>Ipsum</code></li>
+
+    <li>Dolor:  <code>git@github.com</code></li>
+
+    <li>URL of fork:  <code>git@github.com:&lt;your username&gt;/TYPO3CMS-Guide-HowToDocument.git</code></li>
+
+    <li>original URL: <code>git@github.com:TYPO3-Documentation/TYPO3CMS-Guide-HowToDocument.git</code></li>
+
+</ul>
+
+    </div>
+
+</body>
+</html>

--- a/tests/Integration/tests/list-with-code/input/index.rst
+++ b/tests/Integration/tests/list-with-code/input/index.rst
@@ -1,0 +1,9 @@
+
+====
+Test
+====
+
+*  Lorem:  `Ipsum`
+*  Dolor:  `git@github.com`
+*  URL of fork:  `git@github.com:<your username>/TYPO3CMS-Guide-HowToDocument.git`
+*  original URL: `git@github.com:TYPO3-Documentation/TYPO3CMS-Guide-HowToDocument.git`


### PR DESCRIPTION
So it does not catch email like expressions in backticks