### PR TITLE
[BUGFIX] Fix generated menu when progress bar is active

### DIFF
--- a/docs/include.rst.txt
+++ b/docs/include.rst.txt
@@ -1,15 +1,4 @@
 ..  documentblock::
-    :identifier: mainmenu
-
-    ..  rubric:: My Header
-
-    ..  menu::
-        :menu: mainmenu
-
-        /*
-        /*/index
-
-..  documentblock::
     :identifier: navbar
 
     .. menu::

--- a/packages/guides-cli/src/Command/Run.php
+++ b/packages/guides-cli/src/Command/Run.php
@@ -173,6 +173,7 @@ final class Run extends Command
             $this->commandBus->handle(
                 new RenderCommand(
                     $format,
+                    $documents,
                     $progressBar === null ? $documents : $progressBar->iterate($documents),
                     $sourceFileSystem,
                     $destinationFileSystem,

--- a/packages/guides/src/Handlers/RenderCommand.php
+++ b/packages/guides/src/Handlers/RenderCommand.php
@@ -10,10 +10,14 @@ use phpDocumentor\Guides\Nodes\ProjectNode;
 
 final class RenderCommand
 {
-    /** @param iterable<DocumentNode> $documents */
+    /**
+     * @param DocumentNode[] $documentArray
+     * @param iterable<DocumentNode> $documentIterator
+     */
     public function __construct(
         private readonly string $outputFormat,
-        private readonly iterable $documents,
+        private readonly array $documentArray,
+        private readonly iterable $documentIterator,
         private readonly FilesystemInterface $origin,
         private readonly FilesystemInterface $destination,
         private readonly ProjectNode $projectNode,
@@ -26,10 +30,16 @@ final class RenderCommand
         return $this->outputFormat;
     }
 
-    /** @return iterable<DocumentNode> */
-    public function getDocuments(): iterable
+    /** @return DocumentNode[] $documentArray */
+    public function getDocumentArray(): array
     {
-        return $this->documents;
+        return $this->documentArray;
+    }
+
+    /** @return iterable<DocumentNode> $documentIterator */
+    public function getDocumentIterator(): iterable
+    {
+        return $this->documentIterator;
     }
 
     public function getOrigin(): FilesystemInterface

--- a/packages/guides/src/Renderer/BaseTypeRenderer.php
+++ b/packages/guides/src/Renderer/BaseTypeRenderer.php
@@ -19,13 +19,13 @@ abstract class BaseTypeRenderer implements TypeRenderer
 
     public function render(RenderCommand $renderCommand): void
     {
-        foreach ($renderCommand->getDocuments() as $document) {
+        foreach ($renderCommand->getDocumentIterator() as $document) {
             $this->commandBus->handle(
                 new RenderDocumentCommand(
                     $document,
                     RenderContext::forDocument(
                         $document,
-                        (array) $renderCommand->getDocuments(),
+                        $renderCommand->getDocumentArray(),
                         $renderCommand->getOrigin(),
                         $renderCommand->getDestination(),
                         $renderCommand->getDestinationPath(),


### PR DESCRIPTION
The progress bar turns the $documents array into an iterator that can only be iterated once and is empty thereafter. We need to use the iterator to render each document so that the progress bar works, but the array to pass to the render context.