### PR TITLE
[FEATURE] Add option input-file to render a specific file

### DIFF
--- a/packages/guides-cli/resources/schema/guides.xsd
+++ b/packages/guides-cli/resources/schema/guides.xsd
@@ -16,6 +16,7 @@
         </xsd:choice>
 
         <xsd:attribute name="input" type="xsd:string"/>
+        <xsd:attribute name="input-file" type="xsd:string"/>
         <xsd:attribute name="output" type="xsd:string"/>
         <xsd:attribute name="input-format" type="xsd:string"/>
         <xsd:attribute name="log-path" type="xsd:string"/>

--- a/packages/guides/src/DependencyInjection/GuidesExtension.php
+++ b/packages/guides/src/DependencyInjection/GuidesExtension.php
@@ -22,6 +22,7 @@ use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use function assert;
 use function dirname;
 use function is_array;
+use function pathinfo;
 
 class GuidesExtension extends Extension implements CompilerPassInterface, ConfigurationInterface
 {
@@ -53,6 +54,7 @@ class GuidesExtension extends Extension implements CompilerPassInterface, Config
                 ->end()
                 ->scalarNode('theme')->end()
                 ->scalarNode('input')->end()
+                ->scalarNode('input_file')->end()
                 ->scalarNode('output')->end()
                 ->scalarNode('input_format')->end()
                 ->arrayNode('output_format')
@@ -126,6 +128,15 @@ class GuidesExtension extends Extension implements CompilerPassInterface, Config
 
         if (isset($config['input'])) {
             $projectSettings->setInput((string) $config['input']);
+        }
+
+        if (isset($config['input_file']) && $config['input_file'] !== '') {
+            $inputFile = (string) $config['input_file'];
+            $pathInfo = pathinfo($inputFile);
+            $projectSettings->setInputFile($pathInfo['filename']);
+            if (!empty($pathInfo['extension'])) {
+                $projectSettings->setInputFormat($pathInfo['extension']);
+            }
         }
 
         if (isset($config['output'])) {

--- a/packages/guides/src/Settings/ProjectSettings.php
+++ b/packages/guides/src/Settings/ProjectSettings.php
@@ -12,6 +12,7 @@ class ProjectSettings
     private string $version = '';
     private string $theme = 'default';
     private string $input = 'docs';
+    private string $inputFile = '';
     private string $output = 'output';
     private string $inputFormat = 'rst';
     /** @var string[]  */
@@ -132,5 +133,15 @@ class ProjectSettings
     public function setOutputFormats(array $outputFormats): void
     {
         $this->outputFormats = $outputFormats;
+    }
+
+    public function getInputFile(): string
+    {
+        return $this->inputFile;
+    }
+
+    public function setInputFile(string $inputFile): void
+    {
+        $this->inputFile = $inputFile;
     }
 }

--- a/tests/Integration/tests/input-file/expected/README.html
+++ b/tests/Integration/tests/input-file/expected/README.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>Document Title</title>
+</head>
+<body>
+    <div class="section" id="document-title">
+    <h1>Document Title</h1>
+            <p>Lorem Ipsum Dolor.</p>
+    </div>
+</body>
+</html>

--- a/tests/Integration/tests/input-file/input/README.rst
+++ b/tests/Integration/tests/input-file/input/README.rst
@@ -1,0 +1,5 @@
+==============
+Document Title
+==============
+
+Lorem Ipsum Dolor.

--- a/tests/Integration/tests/input-file/input/guides.xml
+++ b/tests/Integration/tests/input-file/input/guides.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd"
+        input-file="README.rst"
+>
+</guides>


### PR DESCRIPTION
This can be used to parse READMEs or other standalone reST files. It is also a preparation for rendering specific mark down files in future like a README.md