### PR TITLE
[TASK] Make Markdown availible in integration tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "phpdocumentor/guides": "@dev",
         "phpdocumentor/guides-cli": "@dev",
         "phpdocumentor/guides-graphs": "@dev",
+        "phpdocumentor/guides-markdown": "@dev",
         "phpdocumentor/guides-restructured-text": "@dev",
         "phpdocumentor/guides-theme-bootstrap": "@dev",
         "psr/event-dispatcher": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a11c6aa529dc08d696e5cb5e0ea8c134",
+    "content-hash": "90b062fa06ee3fa4fe3e17715ae6c6f8",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -1238,6 +1238,41 @@
                 "MIT"
             ],
             "description": "Provides Plantuml support for restructured text rendered by the phpDocumentor's Guides library.",
+            "homepage": "https://www.phpdoc.org",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "phpdocumentor/guides-markdown",
+            "version": "dev-main",
+            "dist": {
+                "type": "path",
+                "url": "./packages/guides-markdown",
+                "reference": "70ac6334139fe80a3c394ea58a931ceafaae7b53"
+            },
+            "require": {
+                "league/commonmark": "^2.4",
+                "php": "^8.1",
+                "phpdocumentor/guides": "self.version"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Guides\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "phpDocumentor\\Guides\\": [
+                        "tests/unit/"
+                    ]
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "description": "Adds Markdown support to the phpDocumentor's Guides library.",
             "homepage": "https://www.phpdoc.org",
             "transport-options": {
                 "relative": true
@@ -6644,6 +6679,7 @@
         "phpdocumentor/guides": 20,
         "phpdocumentor/guides-cli": 20,
         "phpdocumentor/guides-graphs": 20,
+        "phpdocumentor/guides-markdown": 20,
         "phpdocumentor/guides-restructured-text": 20,
         "phpdocumentor/guides-theme-bootstrap": 20
     },

--- a/packages/guides-markdown/resources/config/guides-markdown.php
+++ b/packages/guides-markdown/resources/config/guides-markdown.php
@@ -2,11 +2,15 @@
 
 declare(strict_types=1);
 
+use phpDocumentor\Guides\Markdown\MarkupLanguageParser;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $container): void {
     $container->services()
         ->defaults()
         ->autowire()
-        ->autoconfigure();
+        ->autoconfigure()
+
+        ->set(MarkupLanguageParser::class)
+        ->tag('phpdoc.guides.parser.markupLanguageParser');
 };

--- a/tests/ApplicationTestCase.php
+++ b/tests/ApplicationTestCase.php
@@ -7,6 +7,7 @@ namespace phpDocumentor\Guides;
 use phpDocumentor\Guides\Cli\DependencyInjection\ApplicationExtension;
 use phpDocumentor\Guides\Cli\DependencyInjection\ContainerFactory;
 use phpDocumentor\Guides\DependencyInjection\TestExtension;
+use phpDocumentor\Guides\Markdown\DependencyInjection\MarkdownExtension;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
@@ -37,6 +38,7 @@ class ApplicationTestCase extends TestCase
         $containerFactory = new ContainerFactory([
             new ApplicationExtension(),
             new TestExtension(),
+            new MarkdownExtension(),
             ...$extraExtensions,
         ]);
 

--- a/tests/Integration/tests/markdown/index-md/expected/index.html
+++ b/tests/Integration/tests/markdown/index-md/expected/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Project Title</title>
+
+</head>
+<body>
+    <h1>Markdown Example</h1>
+    <p>This is a Markdown document with some basic formatting.</p>
+
+<h2>Headings</h2>
+
+    <p>You can create headings using hash symbols.</p>
+
+</body>
+</html>

--- a/tests/Integration/tests/markdown/index-md/input/guides.xml
+++ b/tests/Integration/tests/markdown/index-md/input/guides.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd"
+        input-format="md"
+>
+    <project title="Project Title" version="6.4"/>
+</guides>

--- a/tests/Integration/tests/markdown/index-md/input/index.md
+++ b/tests/Integration/tests/markdown/index-md/input/index.md
@@ -1,0 +1,7 @@
+# Markdown Example
+
+This is a Markdown document with some basic formatting.
+
+## Headings
+
+You can create headings using hash symbols.

--- a/tests/Integration/tests/markdown/index-md/input/skip
+++ b/tests/Integration/tests/markdown/index-md/input/skip
@@ -1,0 +1,1 @@
+Paragraph text is missing in output, there is a warning about the document having no title even though it has a title


### PR DESCRIPTION
Install the markdown extension in the composer.json and load it for the integration tests. Introduce a test (still skipped as there are issues to solve)