### PR TITLE
!!![TASK] Cleanup UrlGeneratorInterface

### DIFF
--- a/packages/guides/src/UrlGenerator.php
+++ b/packages/guides/src/UrlGenerator.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides;
 
-use InvalidArgumentException;
 use League\Uri\UriInfo;
 
 use function array_pop;
@@ -24,20 +23,6 @@ use function trim;
 
 final class UrlGenerator implements UrlGeneratorInterface
 {
-    public function generateUrl(string $path): string
-    {
-        try {
-            $uri = UriFactory::createUri($path);
-            if (UriInfo::isAbsolutePath($uri)) {
-                return $path;
-            }
-
-            return $this->relativeUrl($path);
-        } catch (InvalidArgumentException) {
-            return $path;
-        }
-    }
-
     /**
      * Returns the absolute path, including prefixing '/'.
      *

--- a/packages/guides/src/UrlGeneratorInterface.php
+++ b/packages/guides/src/UrlGeneratorInterface.php
@@ -6,8 +6,6 @@ namespace phpDocumentor\Guides;
 
 interface UrlGeneratorInterface
 {
-    public function generateUrl(string $path): string;
-
     /**
      * Returns the absolute path, including prefixing '/'.
      *

--- a/packages/guides/tests/unit/UrlGeneratorTest.php
+++ b/packages/guides/tests/unit/UrlGeneratorTest.php
@@ -9,6 +9,57 @@ use PHPUnit\Framework\TestCase;
 
 final class UrlGeneratorTest extends TestCase
 {
+    #[DataProvider('fileUrlProvider')]
+    public function testCreateFileUrl(string $expected, string $filename, string $outputFormat = 'html', string|null $anchor = null, string $skip = ''): void
+    {
+        if ($skip !== '') {
+            self::markTestSkipped($skip);
+        }
+
+        $urlGenerator = new UrlGenerator();
+        self::assertSame($expected, $urlGenerator->createFileUrl($filename, $outputFormat, $anchor));
+    }
+
+    /** @return array<string, array<string, string|null>> */
+    public static function fileUrlProvider(): array
+    {
+        return [
+            'Simple Filename' => [
+                'expected' => 'file.html',
+                'filename' => 'file',
+            ],
+            'Complex Filename' => [
+                'expected' => 'file-something.html',
+                'filename' => 'file-something',
+            ],
+            'Output Format' => [
+                'expected' => 'texfile.tex',
+                'filename' => 'texfile',
+                'outputFormat' => 'tex',
+            ],
+            'File with anchor' => [
+                'expected' => 'file.html#anchor',
+                'filename' => 'file',
+                'outputFormat' => 'html',
+                'anchor' => 'anchor',
+            ],
+            'Empty File with anchor' => [
+                'expected' => '#anchor',
+                'filename' => '',
+                'outputFormat' => 'html',
+                'anchor' => 'anchor',
+                'skip' => 'Empty filenames are not supported',
+            ],
+            'Empty File with empty anchor' => [
+                'expected' => '#',
+                'filename' => '',
+                'outputFormat' => 'html',
+                'anchor' => null,
+                'skip' => 'Empty filenames are not supported',
+            ],
+        ];
+    }
+
     #[DataProvider('canonicalUrlProvider')]
     public function testCanonicalUrl(string $basePath, string $url, string $result): void
     {
@@ -85,11 +136,5 @@ final class UrlGeneratorTest extends TestCase
                 'result' => '/dir/file',
             ],
         ];
-    }
-
-    public function testUrlGenerationOfInvalidUrlReturnsInput(): void
-    {
-        $urlGenerator = new UrlGenerator();
-        self::assertSame('tcp://hostname:port', $urlGenerator->generateUrl('tcp://hostname:port'));
     }
 }

--- a/packages/guides/tests/unit/UrlGeneratorTest.php
+++ b/packages/guides/tests/unit/UrlGeneratorTest.php
@@ -10,15 +10,15 @@ use PHPUnit\Framework\TestCase;
 
 final class UrlGeneratorTest extends TestCase
 {
-    #[DataProvider('cannicalUrlProvider')]
-    public function testCannicalUrl(string $basePath, string $url, string $result): void
+    #[DataProvider('canonicalUrlProvider')]
+    public function testCanonicalUrl(string $basePath, string $url, string $result): void
     {
         $urlGenerator = new UrlGenerator();
         self::assertSame($result, $urlGenerator->canonicalUrl($basePath, $url));
     }
 
     /** @return string[][] */
-    public static function cannicalUrlProvider(): array
+    public static function canonicalUrlProvider(): array
     {
         return [
             [

--- a/packages/guides/tests/unit/UrlGeneratorTest.php
+++ b/packages/guides/tests/unit/UrlGeneratorTest.php
@@ -2,9 +2,8 @@
 
 declare(strict_types=1);
 
-namespace unit;
+namespace phpDocumentor\Guides;
 
-use phpDocumentor\Guides\UrlGenerator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
And improve test coverage.

Contains the breaking change of Removing the unused UrlGeneratorInterface::generateUrl as it didnt do anything except leaving each url unchanged and it was not used anymore