### PR TITLE
!!![TASK] Remove UrlGeneratorInterface::relativeURL

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Directives/FigureDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/FigureDirective.php
@@ -10,7 +10,6 @@ use phpDocumentor\Guides\Nodes\ImageNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
-use phpDocumentor\Guides\UrlGeneratorInterface;
 
 /**
  * Renders an image, example :
@@ -23,7 +22,7 @@ use phpDocumentor\Guides\UrlGeneratorInterface;
  */
 class FigureDirective extends SubDirective
 {
-    public function __construct(protected Rule $startingRule, private readonly UrlGeneratorInterface $urlGenerator)
+    public function __construct(protected Rule $startingRule)
     {
         parent::__construct($startingRule);
     }
@@ -41,7 +40,7 @@ class FigureDirective extends SubDirective
         CollectionNode $collectionNode,
         Directive $directive,
     ): Node|null {
-        $image = new ImageNode($this->urlGenerator->relativeUrl($directive->getData()));
+        $image = new ImageNode($directive->getData());
         $scalarOptions = $this->optionsToArray($directive->getOptions());
         $image = $image->withOptions([
             'width' => $scalarOptions['width'] ?? null,

--- a/packages/guides/src/ParserContext.php
+++ b/packages/guides/src/ParserContext.php
@@ -70,11 +70,6 @@ class ParserContext
         return $this->links;
     }
 
-    private function relativeUrl(string $url): string
-    {
-        return $this->urlGenerator->relativeUrl($url);
-    }
-
     public function absoluteRelativePath(string $url): string
     {
         $uri = Uri::createFromString($url);
@@ -82,7 +77,7 @@ class ParserContext
             return $this->currentDirectory . '/' . ltrim($url, '/');
         }
 
-        return $this->currentDirectory . '/' . $this->getDirName() . '/' . $this->relativeUrl($url);
+        return $this->currentDirectory . '/' . $this->getDirName() . '/' . ltrim($url, '/');
     }
 
     public function getDirName(): string

--- a/packages/guides/src/RenderContext.php
+++ b/packages/guides/src/RenderContext.php
@@ -85,19 +85,11 @@ class RenderContext
         return $this->document->getVariable($variable, $default);
     }
 
-    public function getLink(string $name, bool $relative = true): string
+    public function getLink(string $name): string
     {
         $link = $this->document->getLink($name);
 
-        if ($link !== null) {
-            if ($relative) {
-                return $this->urlGenerator->relativeUrl($link);
-            }
-
-            return $link;
-        }
-
-        return '';
+        return $link ?? '';
     }
 
     public function canonicalUrl(string $url): string

--- a/packages/guides/src/UrlGenerator.php
+++ b/packages/guides/src/UrlGenerator.php
@@ -44,24 +44,6 @@ final class UrlGenerator implements UrlGeneratorInterface
     }
 
     /**
-     * Resolves a relative URL.
-     */
-    public function relativeUrl(string $url): string
-    {
-        $uri = UriFactory::createUri($url);
-
-        if (UriInfo::isAbsolutePath($uri)) {
-            return $url;
-        }
-
-        if (UriInfo::isRelativePath($uri)) {
-            return $url;
-        }
-
-        return ltrim($url, '/');
-    }
-
-    /**
      * Returns the Path used in the Metas to find this file.
      *
      * The Metas collection, which is used to build the table of contents, uses these canonical paths as a unique

--- a/packages/guides/src/UrlGeneratorInterface.php
+++ b/packages/guides/src/UrlGeneratorInterface.php
@@ -15,11 +15,6 @@ interface UrlGeneratorInterface
     public function absoluteUrl(string $basePath, string $url): string;
 
     /**
-     * Resolves a relative URL.
-     */
-    public function relativeUrl(string $url): string;
-
-    /**
      * Returns the Path used in the Metas to find this file.
      *
      * The Metas collection, which is used to build the table of contents, uses these canonical paths as a unique


### PR DESCRIPTION
It left the input unchanged unless some invalid URL was entered.

In places we seem to have expected it to ltrim slashes which it didnt do.