### PR TITLE
Allow setting a default language for literal blocks

### DIFF
--- a/packages/guides-cli/resources/schema/guides.xsd
+++ b/packages/guides-cli/resources/schema/guides.xsd
@@ -23,6 +23,7 @@
         <xsd:attribute name="fail-on-log" type="xsd:string"/>
         <xsd:attribute name="show-progress" type="xsd:string"/>
         <xsd:attribute name="theme" type="xsd:string"/>
+        <xsd:attribute name="default-code-language" type="xsd:string"/>
     </xsd:complexType>
 
     <xsd:complexType name="extension">

--- a/packages/guides-restructured-text/resources/config/guides-restructured-text.php
+++ b/packages/guides-restructured-text/resources/config/guides-restructured-text.php
@@ -53,6 +53,7 @@ use phpDocumentor\Guides\RestructuredText\Directives\VersionChangedDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\WarningDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\WrapDirective;
 use phpDocumentor\Guides\RestructuredText\MarkupLanguageParser;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContextFactory;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineParser;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\AnnotationRule;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\BlockQuoteRule;
@@ -318,6 +319,8 @@ return static function (ContainerConfigurator $container): void {
 
         ->set(SectionRule::class)
         ->tag('phpdoc.guides.parser.rst.structural_element', ['priority' => SectionRule::PRIORITY])
+
+        ->set(DocumentParserContextFactory::class)
 
         ->set(MarkupLanguageParser::class)
         ->args([

--- a/packages/guides-restructured-text/src/RestructuredText/MarkupLanguageParser.php
+++ b/packages/guides-restructured-text/src/RestructuredText/MarkupLanguageParser.php
@@ -10,8 +10,8 @@ use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\ParserContext;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContextFactory;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
-use phpDocumentor\Guides\RestructuredText\TextRoles\TextRoleFactory;
 use RuntimeException;
 use Webmozart\Assert\Assert;
 
@@ -28,7 +28,7 @@ class MarkupLanguageParser implements ParserInterface
     /** @param Rule<DocumentNode> $startingRule */
     public function __construct(
         private readonly Rule $startingRule,
-        private readonly TextRoleFactory $textRoleFactory,
+        private readonly DocumentParserContextFactory $documentParserContextFactory,
     ) {
     }
 
@@ -42,7 +42,7 @@ class MarkupLanguageParser implements ParserInterface
     {
         return new MarkupLanguageParser(
             $this->startingRule,
-            $this->textRoleFactory,
+            $this->documentParserContextFactory,
         );
     }
 
@@ -75,11 +75,7 @@ class MarkupLanguageParser implements ParserInterface
     {
         $this->parserContext = $parserContext;
 
-        $this->documentParser = new DocumentParserContext(
-            $parserContext,
-            $this->textRoleFactory,
-            $this,
-        );
+        $this->documentParser = $this->documentParserContextFactory->create($this);
 
         $blockContext = new BlockContext($this->documentParser, $contents);
         if ($this->startingRule->applies($blockContext)) {

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/DocumentParserContextFactory.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/DocumentParserContextFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\RestructuredText\Parser;
+
+use phpDocumentor\Guides\RestructuredText\MarkupLanguageParser;
+use phpDocumentor\Guides\RestructuredText\TextRoles\TextRoleFactory;
+use phpDocumentor\Guides\Settings\SettingsManager;
+
+class DocumentParserContextFactory
+{
+    public function __construct(
+        private readonly TextRoleFactory $textRoleFactory,
+        private readonly SettingsManager $settingsManager,
+    ) {
+    }
+
+    public function create(MarkupLanguageParser $markupLanguageParser): DocumentParserContext
+    {
+        $documentParser = new DocumentParserContext(
+            $markupLanguageParser->getParserContext(),
+            $this->textRoleFactory,
+            $markupLanguageParser,
+        );
+
+        $documentParser->setCodeBlockDefaultLanguage($this->settingsManager->getProjectSettings()->getDefaultCodeLanguage());
+
+        return $documentParser;
+    }
+}

--- a/packages/guides/src/DependencyInjection/GuidesExtension.php
+++ b/packages/guides/src/DependencyInjection/GuidesExtension.php
@@ -74,6 +74,7 @@ class GuidesExtension extends Extension implements CompilerPassInterface, Config
                     ->defaultValue([])
                     ->scalarPrototype()->end()
                 ->end()
+                ->scalarNode('default_code_language')->defaultValue('')->end()
                 ->arrayNode('themes')
                     ->defaultValue([])
                     ->arrayPrototype()
@@ -157,6 +158,10 @@ class GuidesExtension extends Extension implements CompilerPassInterface, Config
 
         if (isset($config['fail_on_log'])) {
             $projectSettings->setFailOnError((bool) $config['show_progress']);
+        }
+
+        if (isset($config['default_code_language'])) {
+            $projectSettings->setDefaultCodeLanguage((string) $config['default_code_language']);
         }
 
         $container->getDefinition(SettingsManager::class)

--- a/packages/guides/src/Settings/ProjectSettings.php
+++ b/packages/guides/src/Settings/ProjectSettings.php
@@ -20,6 +20,7 @@ class ProjectSettings
     private string $logPath = 'php://stder';
     private bool $failOnError = false;
     private bool $showProgressBar = true;
+    private string $defaultCodeLanguage = '';
 
     public function getTitle(): string
     {
@@ -133,6 +134,16 @@ class ProjectSettings
     public function setOutputFormats(array $outputFormats): void
     {
         $this->outputFormats = $outputFormats;
+    }
+
+    public function setDefaultCodeLanguage(string $defaultCodeLanguage): void
+    {
+        $this->defaultCodeLanguage = $defaultCodeLanguage;
+    }
+
+    public function getDefaultCodeLanguage(): string
+    {
+        return $this->defaultCodeLanguage;
     }
 
     public function getInputFile(): string

--- a/packages/guides/src/Settings/SettingsManager.php
+++ b/packages/guides/src/Settings/SettingsManager.php
@@ -6,11 +6,9 @@ namespace phpDocumentor\Guides\Settings;
 
 class SettingsManager
 {
-    private ProjectSettings $projectSettings;
-
-    public function __construct(ProjectSettings|null $projectSettings = null)
-    {
-        $this->projectSettings = $projectSettings ?? new ProjectSettings();
+    public function __construct(
+        private ProjectSettings $projectSettings = new ProjectSettings(),
+    ) {
     }
 
     public function getProjectSettings(): ProjectSettings

--- a/tests/Integration/tests/code/literal-block-default-language-php/expected/index.html
+++ b/tests/Integration/tests/code/literal-block-default-language-php/expected/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Code Block</title>
+
+</head>
+<body>
+    <div class="section" id="code-block">
+    <h1>Code Block</h1>
+
+            <pre><code class="language-php">$some = &#039;PHP&#039;;
+</code></pre>
+            <pre><code class="language-php">$someThing = &#039;else&#039;;</code></pre>
+    </div>
+
+</body>
+</html>

--- a/tests/Integration/tests/code/literal-block-default-language-php/input/guides.xml
+++ b/tests/Integration/tests/code/literal-block-default-language-php/input/guides.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides xmlns="https://www.phpdoc.org/guides"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd"
+        default-code-language="php"
+>
+</guides>

--- a/tests/Integration/tests/code/literal-block-default-language-php/input/index.rst
+++ b/tests/Integration/tests/code/literal-block-default-language-php/input/index.rst
@@ -1,0 +1,10 @@
+Code Block
+==========
+
+::
+
+    $some = 'PHP';
+
+..  code-block::
+
+    $someThing = 'else';


### PR DESCRIPTION
Besides setting the local language using the `.. highlight::` directive, Sphinx also allows specifying a global default language for literal blocks. We use this in Symfony to mark all literal blocks as "php".

After this PR, you can configure the default language in `guides.xml`:

```xml
    <extension class="phpDocumentor\Guides\RestructuredText"
        default-code-language="php"
    />
```