### PR TITLE
[FIX]: be more strict on anonymous links

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Parser/DocumentParserContext.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/DocumentParserContext.php
@@ -21,6 +21,9 @@ use phpDocumentor\Guides\RestructuredText\TextRoles\TextRoleFactory;
 use RuntimeException;
 
 use function array_merge;
+use function array_shift;
+use function strtolower;
+use function trim;
 
 /**
  * Our document parser contains
@@ -41,6 +44,12 @@ class DocumentParserContext
 
     /** @var string[] */
     private array $titleLetters = [];
+
+    /** @var array<string, string> */
+    private array $links = [];
+
+    /** @var string[] */
+    private array $anonymous = [];
 
     public function __construct(
         private readonly ParserContext $context,
@@ -108,6 +117,33 @@ class DocumentParserContext
     public function setCodeBlockDefaultLanguage(string $codeBlockDefaultLanguage): void
     {
         $this->codeBlockDefaultLanguage = $codeBlockDefaultLanguage;
+    }
+
+    public function setLink(string $name, string $url): void
+    {
+        $name = strtolower(trim($name));
+
+        if ($name === '_') {
+            $name = array_shift($this->anonymous);
+        }
+
+        $this->links[$name] = trim($url);
+    }
+
+    public function resetAnonymousStack(): void
+    {
+        $this->anonymous = [];
+    }
+
+    public function pushAnonymous(string $name): void
+    {
+        $this->anonymous[] = strtolower(trim($name));
+    }
+
+    /** @return array<string, string> */
+    public function getLinks(): array
+    {
+        return $this->links;
     }
 
     /** @return array<string, string> */

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/InlineLexer.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/InlineLexer.php
@@ -57,8 +57,8 @@ final class InlineLexer extends AbstractLexer
             '\\\\``', // must be a separate case, as the next pattern would split in "\`" + "`", causing it to become a intepreted text
             '\\\\[\s\S]', // Escaping hell... needs escaped slash in regex, but also in php.
             '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}',
-            '[a-z0-9-]+_{2}', //Inline href.
-            '[a-z0-9-]+_{1}(?=[\s\.+]|$)', //Inline href.
+            '(?<=^|\s)[a-z0-9-]+_{2}', //Inline href.
+            '(?<=^|\s)[a-z0-9-]+_{1}(?=[\s\.+]|$)', //Inline href.
             '``.+?``(?!`)',
             '_{2}',
             '_',

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DocumentRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DocumentRule.php
@@ -52,6 +52,8 @@ final class DocumentRule implements Rule
             $this->structuralElements->apply($blockContext, $on);
         }
 
+        $on->setLinks($blockContext->getDocumentParserContext()->getLinks());
+
         return $on;
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/AnonymousPhraseRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/AnonymousPhraseRule.php
@@ -66,9 +66,8 @@ class AnonymousPhraseRule extends ReferenceRule
 
     private function createAnonymousReference(BlockContext $blockContext, string $link, string|null $embeddedUrl): HyperLinkNode
     {
-        $blockContext->getDocumentParserContext()->getContext()->resetAnonymousStack();
         $node = $this->createReference($blockContext, $link, $embeddedUrl, false);
-        $blockContext->getDocumentParserContext()->getContext()->pushAnonymous($link);
+        $blockContext->getDocumentParserContext()->pushAnonymous($link);
 
         return $node;
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/AnonymousReferenceRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/AnonymousReferenceRule.php
@@ -39,9 +39,8 @@ class AnonymousReferenceRule extends ReferenceRule
 
     private function createAnonymousReference(BlockContext $blockContext, string $link): HyperLinkNode
     {
-        $blockContext->getDocumentParserContext()->getContext()->resetAnonymousStack();
         $node = $this->createReference($blockContext, $link, null, false);
-        $blockContext->getDocumentParserContext()->getContext()->pushAnonymous($link);
+        $blockContext->getDocumentParserContext()->pushAnonymous($link);
 
         return $node;
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/ReferenceRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/ReferenceRule.php
@@ -22,7 +22,7 @@ abstract class ReferenceRule extends AbstractInlineRule
         $link = trim(preg_replace('/\s+/', ' ', $link) ?? '');
 
         if ($registerLink && $embeddedUrl !== null) {
-            $blockContext->getDocumentParserContext()->getContext()->setLink($link, $embeddedUrl);
+            $blockContext->getDocumentParserContext()->setLink($link, $embeddedUrl);
         }
 
         return new HyperLinkNode($link, $embeddedUrl ?? $link);

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/LinkRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/LinkRule.php
@@ -53,7 +53,7 @@ final class LinkRule implements Rule
         }
 
         //TODO: pass link object to setLink
-        $blockContext->getDocumentParserContext()->getContext()->setLink($link->getName(), $link->getUrl());
+        $blockContext->getDocumentParserContext()->setLink($link->getName(), $link->getUrl());
 
         return $node;
     }

--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/LinkRuleTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/LinkRuleTest.php
@@ -29,7 +29,7 @@ class LinkRuleTest extends RuleTestCase
         self::assertTrue($this->rule->applies($blockContext));
         self::assertEquals($expectedNode, $this->rule->apply($blockContext));
 
-        self::assertSame([$expectedLabel => $expectedUrl], $blockContext->getDocumentParserContext()->getContext()->getLinks());
+        self::assertSame([$expectedLabel => $expectedUrl], $blockContext->getDocumentParserContext()->getLinks());
     }
 
     /** @return Generator<string, array{string, string, string, AnchorNode|null}> */

--- a/packages/guides/src/Parser.php
+++ b/packages/guides/src/Parser.php
@@ -88,7 +88,6 @@ final class Parser
         $parser = $this->determineParser($inputFormat);
 
         $document = $parser->parse($this->parserContext, $text);
-        $document->setLinks($this->parserContext->getLinks());
 
         $this->parserContext = null;
 

--- a/packages/guides/src/ParserContext.php
+++ b/packages/guides/src/ParserContext.php
@@ -9,20 +9,11 @@ use League\Uri\Uri;
 use League\Uri\UriInfo;
 use phpDocumentor\Guides\Nodes\ProjectNode;
 
-use function array_shift;
 use function dirname;
 use function ltrim;
-use function strtolower;
-use function trim;
 
 class ParserContext
 {
-    /** @var array<string, string> */
-    private array $links = [];
-
-    /** @var string[] */
-    private array $anonymous = [];
-
     public function __construct(
         private readonly ProjectNode $projectNode,
         private readonly string $currentFileName,
@@ -41,33 +32,6 @@ class ParserContext
     public function getInitialHeaderLevel(): int
     {
         return $this->initialHeaderLevel;
-    }
-
-    public function setLink(string $name, string $url): void
-    {
-        $name = strtolower(trim($name));
-
-        if ($name === '_') {
-            $name = array_shift($this->anonymous);
-        }
-
-        $this->links[$name] = trim($url);
-    }
-
-    public function resetAnonymousStack(): void
-    {
-        $this->anonymous = [];
-    }
-
-    public function pushAnonymous(string $name): void
-    {
-        $this->anonymous[] = strtolower(trim($name));
-    }
-
-    /** @return array<string, string> */
-    public function getLinks(): array
-    {
-        return $this->links;
     }
 
     public function absoluteRelativePath(string $url): string

--- a/tests/Functional/tests/anonymous/anonymous.html
+++ b/tests/Functional/tests/anonymous/anonymous.html
@@ -1,2 +1,1 @@
-SKIP anonymous references don't work
-<p>I love <a href="https://github.com/">GitHub</a>, <a href="https://gitlab.com/">GitLab</a> and <a href="https://facebook.com/">Facebook</a>. But I don't affect references to __CLASS__.</p>
+<p>I love <a href="https://github.com/">GitHub</a>, <a href="https://gitlab.com/">GitLab</a> and <a href="https://facebook.com/">Facebook</a>. But I don&#039;t affect references to __CLASS__.</p>

--- a/tests/Functional/tests/anonymous/anonymous.rst
+++ b/tests/Functional/tests/anonymous/anonymous.rst
@@ -1,5 +1,5 @@
 I love GitHub__, GitLab__ and `Facebook`__. But I don't affect references to __CLASS__.
 
-.. __: https://github.com/
+__ https://github.com/
 .. __: https://gitlab.com/
 .. __: https://facebook.com/

--- a/tests/Functional/tests/image-inline-anonymous/image-inline-anonymous.html
+++ b/tests/Functional/tests/image-inline-anonymous/image-inline-anonymous.html
@@ -1,2 +1,0 @@
-SKIP anonymous inline images do not work
-<p>This is also an<img src="test.jpg"/>image.</p>

--- a/tests/Functional/tests/image-inline-anonymous/image-inline-anonymous.rst
+++ b/tests/Functional/tests/image-inline-anonymous/image-inline-anonymous.rst
@@ -1,4 +1,0 @@
-SKIP anonymous inline images do not work
-This is also an :variable:`inline` image.
-
-.. |inline| image:: test.jpg


### PR DESCRIPTION
Anonymous links shall not be prefixed by anything. If a word ends with __ (double underscore) no other chars should be prepending other than a white space or a line start.

The links are now part of the document context as they should be reset after every document. This removes the need for extra resets in between.