### PR TITLE
[TASK] Move Cache of development tools into /.cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
 /vendor/
-/.build
-.phpunit.cache
-.deptrac.cache
-/.psalm
+/.cache
 /**/temp
 /output/

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ cleanup-cache:
 
 .PHONY: test-architecture
 test-architecture: vendor ## Runs deptrac to enfore architecural rules
-	$(PHP_BIN) ./vendor/bin/deptrac --config-file deptrac.packages.yaml
+	$(PHP_BIN) ./vendor/bin/deptrac --config-file deptrac.packages.yaml --cache-file=.cache/.deptrac.cache
 
 vendor: composer.json composer.lock
 	composer validate --no-check-publish

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -44,4 +44,4 @@ parameters:
 #    - packages/guides-markdown/tests
     - packages/guides-restructured-text/tests
 
-  tmpDir: .build/phpstan/
+  tmpDir: .cache/phpstan/

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,7 +13,7 @@
         displayDetailsOnTestsThatTriggerNotices="true"
         displayDetailsOnTestsThatTriggerWarnings="true"
         displayDetailsOnTestsThatTriggerErrors="true"
-        cacheDirectory=".phpunit.cache"
+        cacheDirectory=".cache/.phpunit.cache"
         requireCoverageMetadata="false"
 >
     <testsuites>

--- a/psalm.xml
+++ b/psalm.xml
@@ -2,7 +2,7 @@
 <psalm
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
-    cacheDirectory=".psalm/cache"
+    cacheDirectory=".cache/psalm"
     errorLevel="5"
     errorBaseline="psalm-baseline.xml"
     findUnusedBaselineEntry="true"


### PR DESCRIPTION
This way all caches can be deleted with deleting .cache, also it is more tidy and we have less files lying around in the main directory