### PR TITLE
[FEATURE] Enable basic Markdown files

### DIFF
--- a/packages/guides-markdown/resources/config/guides-markdown.php
+++ b/packages/guides-markdown/resources/config/guides-markdown.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use phpDocumentor\Guides\Markdown\MarkupLanguageParser;
+use phpDocumentor\Guides\Markdown\Parsers\BlockQuoteParser;
 use phpDocumentor\Guides\Markdown\Parsers\HeaderParser;
 use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\EmphasisParser;
 use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\InlineCodeParser;
@@ -29,19 +30,23 @@ return static function (ContainerConfigurator $container): void {
         ->set(HeaderParser::class)
         ->arg('$inlineParsers', tagged_iterator('phpdoc.guides.markdown.parser.inlineParser'))
         ->tag('phpdoc.guides.markdown.parser.blockParser')
+        ->set(BlockQuoteParser::class)
+        ->arg('$subParsers', tagged_iterator('phpdoc.guides.markdown.parser.subParser'))
+        ->tag('phpdoc.guides.markdown.parser.blockParser')
+        ->tag('phpdoc.guides.markdown.parser.subParser')
         ->set(ListBlockParser::class)
         ->tag('phpdoc.guides.markdown.parser.blockParser')
-        ->tag('phpdoc.guides.markdown.parser.listSubParser')
+        ->tag('phpdoc.guides.markdown.parser.subParser')
         ->set(ListItemParser::class)
-        ->arg('$subParsers', tagged_iterator('phpdoc.guides.markdown.parser.listSubParser'))
+        ->arg('$subParsers', tagged_iterator('phpdoc.guides.markdown.parser.subParser'))
         ->tag('phpdoc.guides.markdown.parser.blockParser')
         ->set(ParagraphParser::class)
         ->arg('$inlineParsers', tagged_iterator('phpdoc.guides.markdown.parser.inlineParser'))
         ->tag('phpdoc.guides.markdown.parser.blockParser')
-        ->tag('phpdoc.guides.markdown.parser.listSubParser')
+        ->tag('phpdoc.guides.markdown.parser.subParser')
         ->set(SeparatorParser::class)
         ->tag('phpdoc.guides.markdown.parser.blockParser')
-        ->tag('phpdoc.guides.markdown.parser.listSubParser')
+        ->tag('phpdoc.guides.markdown.parser.subParser')
 
         ->set(EmphasisParser::class)
         ->arg('$inlineParsers', tagged_iterator('phpdoc.guides.markdown.parser.inlineParser'))

--- a/packages/guides-markdown/resources/config/guides-markdown.php
+++ b/packages/guides-markdown/resources/config/guides-markdown.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use phpDocumentor\Guides\Markdown\MarkupLanguageParser;
 use phpDocumentor\Guides\Markdown\Parsers\HeaderParser;
 use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\EmphasisParser;
+use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\InlineCodeParser;
 use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\LinkParser;
 use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\PlainTextParser;
 use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\StrongParser;
@@ -45,6 +46,8 @@ return static function (ContainerConfigurator $container): void {
         ->tag('phpdoc.guides.markdown.parser.inlineParser')
         ->set(StrongParser::class)
         ->arg('$inlineParsers', tagged_iterator('phpdoc.guides.markdown.parser.inlineParser'))
+        ->tag('phpdoc.guides.markdown.parser.inlineParser')
+        ->set(InlineCodeParser::class)
         ->tag('phpdoc.guides.markdown.parser.inlineParser')
 
         ->set(MarkupLanguageParser::class)

--- a/packages/guides-markdown/resources/config/guides-markdown.php
+++ b/packages/guides-markdown/resources/config/guides-markdown.php
@@ -10,6 +10,7 @@ use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\LinkParser;
 use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\PlainTextParser;
 use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\StrongParser;
 use phpDocumentor\Guides\Markdown\Parsers\ListBlockParser;
+use phpDocumentor\Guides\Markdown\Parsers\ListItemParser;
 use phpDocumentor\Guides\Markdown\Parsers\ParagraphParser;
 use phpDocumentor\Guides\Markdown\Parsers\SeparatorParser;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -30,11 +31,17 @@ return static function (ContainerConfigurator $container): void {
         ->tag('phpdoc.guides.markdown.parser.blockParser')
         ->set(ListBlockParser::class)
         ->tag('phpdoc.guides.markdown.parser.blockParser')
+        ->tag('phpdoc.guides.markdown.parser.listSubParser')
+        ->set(ListItemParser::class)
+        ->arg('$subParsers', tagged_iterator('phpdoc.guides.markdown.parser.listSubParser'))
+        ->tag('phpdoc.guides.markdown.parser.blockParser')
         ->set(ParagraphParser::class)
         ->arg('$inlineParsers', tagged_iterator('phpdoc.guides.markdown.parser.inlineParser'))
         ->tag('phpdoc.guides.markdown.parser.blockParser')
+        ->tag('phpdoc.guides.markdown.parser.listSubParser')
         ->set(SeparatorParser::class)
         ->tag('phpdoc.guides.markdown.parser.blockParser')
+        ->tag('phpdoc.guides.markdown.parser.listSubParser')
 
         ->set(EmphasisParser::class)
         ->arg('$inlineParsers', tagged_iterator('phpdoc.guides.markdown.parser.inlineParser'))

--- a/packages/guides-markdown/resources/config/guides-markdown.php
+++ b/packages/guides-markdown/resources/config/guides-markdown.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use phpDocumentor\Guides\Markdown\MarkupLanguageParser;
 use phpDocumentor\Guides\Markdown\Parsers\BlockQuoteParser;
+use phpDocumentor\Guides\Markdown\Parsers\CodeBlockParser;
 use phpDocumentor\Guides\Markdown\Parsers\HeaderParser;
 use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\EmphasisParser;
 use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\InlineCodeParser;
@@ -45,6 +46,9 @@ return static function (ContainerConfigurator $container): void {
         ->tag('phpdoc.guides.markdown.parser.blockParser')
         ->tag('phpdoc.guides.markdown.parser.subParser')
         ->set(SeparatorParser::class)
+        ->tag('phpdoc.guides.markdown.parser.blockParser')
+        ->tag('phpdoc.guides.markdown.parser.subParser')
+        ->set(CodeBlockParser::class)
         ->tag('phpdoc.guides.markdown.parser.blockParser')
         ->tag('phpdoc.guides.markdown.parser.subParser')
 

--- a/packages/guides-markdown/resources/config/guides-markdown.php
+++ b/packages/guides-markdown/resources/config/guides-markdown.php
@@ -8,6 +8,7 @@ use phpDocumentor\Guides\Markdown\Parsers\CodeBlockParser;
 use phpDocumentor\Guides\Markdown\Parsers\HeaderParser;
 use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\EmphasisParser;
 use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\InlineCodeParser;
+use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\InlineImageParser;
 use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\LinkParser;
 use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\PlainTextParser;
 use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\StrongParser;
@@ -64,6 +65,9 @@ return static function (ContainerConfigurator $container): void {
         ->arg('$inlineParsers', tagged_iterator('phpdoc.guides.markdown.parser.inlineParser'))
         ->tag('phpdoc.guides.markdown.parser.inlineParser')
         ->set(InlineCodeParser::class)
+        ->tag('phpdoc.guides.markdown.parser.inlineParser')
+        ->set(InlineImageParser::class)
+        ->arg('$inlineParsers', tagged_iterator('phpdoc.guides.markdown.parser.inlineParser'))
         ->tag('phpdoc.guides.markdown.parser.inlineParser')
 
         ->set(MarkupLanguageParser::class)

--- a/packages/guides-markdown/resources/config/guides-markdown.php
+++ b/packages/guides-markdown/resources/config/guides-markdown.php
@@ -3,7 +3,18 @@
 declare(strict_types=1);
 
 use phpDocumentor\Guides\Markdown\MarkupLanguageParser;
+use phpDocumentor\Guides\Markdown\Parsers\HeaderParser;
+use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\EmphasisParser;
+use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\LinkParser;
+use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\PlainTextParser;
+use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\StrongParser;
+use phpDocumentor\Guides\Markdown\Parsers\ListBlockParser;
+use phpDocumentor\Guides\Markdown\Parsers\ParagraphParser;
+use phpDocumentor\Guides\Markdown\Parsers\SeparatorParser;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\String\Slugger\AsciiSlugger;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
 
 return static function (ContainerConfigurator $container): void {
     $container->services()
@@ -11,6 +22,32 @@ return static function (ContainerConfigurator $container): void {
         ->autowire()
         ->autoconfigure()
 
+        ->set(AsciiSlugger::class)
+
+        ->set(HeaderParser::class)
+        ->arg('$inlineParsers', tagged_iterator('phpdoc.guides.markdown.parser.inlineParser'))
+        ->tag('phpdoc.guides.markdown.parser.blockParser')
+        ->set(ListBlockParser::class)
+        ->tag('phpdoc.guides.markdown.parser.blockParser')
+        ->set(ParagraphParser::class)
+        ->arg('$inlineParsers', tagged_iterator('phpdoc.guides.markdown.parser.inlineParser'))
+        ->tag('phpdoc.guides.markdown.parser.blockParser')
+        ->set(SeparatorParser::class)
+        ->tag('phpdoc.guides.markdown.parser.blockParser')
+
+        ->set(EmphasisParser::class)
+        ->arg('$inlineParsers', tagged_iterator('phpdoc.guides.markdown.parser.inlineParser'))
+        ->tag('phpdoc.guides.markdown.parser.inlineParser')
+        ->set(LinkParser::class)
+        ->arg('$inlineParsers', tagged_iterator('phpdoc.guides.markdown.parser.inlineParser'))
+        ->tag('phpdoc.guides.markdown.parser.inlineParser')
+        ->set(PlainTextParser::class)
+        ->tag('phpdoc.guides.markdown.parser.inlineParser')
+        ->set(StrongParser::class)
+        ->arg('$inlineParsers', tagged_iterator('phpdoc.guides.markdown.parser.inlineParser'))
+        ->tag('phpdoc.guides.markdown.parser.inlineParser')
+
         ->set(MarkupLanguageParser::class)
+        ->arg('$parsers', tagged_iterator('phpdoc.guides.markdown.parser.blockParser'))
         ->tag('phpdoc.guides.parser.markupLanguageParser');
 };

--- a/packages/guides-markdown/src/Markdown/MarkupLanguageParser.php
+++ b/packages/guides-markdown/src/Markdown/MarkupLanguageParser.php
@@ -76,7 +76,7 @@ final class MarkupLanguageParser implements MarkupLanguageParserInterface
                 return $document;
             }
 
-            $this->logger->warning(sprintf('DOCUMENT CONTEXT: I am leaving a %s node', $commonMarkNode::class));
+            $this->logger->warning(sprintf('"%s" node is not yet supported in context %s. ', $commonMarkNode::class, 'Document'));
         }
 
         return $document;

--- a/packages/guides-markdown/src/Markdown/MarkupLanguageParser.php
+++ b/packages/guides-markdown/src/Markdown/MarkupLanguageParser.php
@@ -15,9 +15,9 @@ use League\CommonMark\Node\Block\Document;
 use League\CommonMark\Node\Inline\Text;
 use League\CommonMark\Node\NodeWalker;
 use League\CommonMark\Parser\MarkdownParser;
-use phpDocumentor\Guides\Markdown\Parsers\ListBlock;
-use phpDocumentor\Guides\Markdown\Parsers\Paragraph;
-use phpDocumentor\Guides\Markdown\Parsers\ThematicBreak;
+use phpDocumentor\Guides\Markdown\Parsers\ListBlockParser;
+use phpDocumentor\Guides\Markdown\Parsers\ParagraphParser;
+use phpDocumentor\Guides\Markdown\Parsers\SeparatorParser;
 use phpDocumentor\Guides\MarkupLanguageParser as MarkupLanguageParserInterface;
 use phpDocumentor\Guides\Nodes\AnchorNode;
 use phpDocumentor\Guides\Nodes\CodeNode;
@@ -56,9 +56,9 @@ final class MarkupLanguageParser implements MarkupLanguageParserInterface
         $this->markdownParser = new MarkdownParser($cmEnvironment);
         $this->idGenerator = new AsciiSlugger();
         $this->parsers = [
-            new Paragraph($logger),
-            new ListBlock($logger),
-            new ThematicBreak(),
+            new ParagraphParser($logger),
+            new ListBlockParser($logger),
+            new SeparatorParser(),
         ];
     }
 

--- a/packages/guides-markdown/src/Markdown/ParserInterface.php
+++ b/packages/guides-markdown/src/Markdown/ParserInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\Markdown;
 
+use League\CommonMark\Node\Node as CommonMarkNode;
 use League\CommonMark\Node\NodeWalker;
 use League\CommonMark\Node\NodeWalkerEvent;
 use phpDocumentor\Guides\MarkupLanguageParser as GuidesParser;
@@ -13,7 +14,7 @@ use phpDocumentor\Guides\Nodes\Node;
 interface ParserInterface
 {
     /** @return TValue */
-    public function parse(GuidesParser $parser, NodeWalker $walker): Node;
+    public function parse(GuidesParser $parser, NodeWalker $walker, CommonMarkNode $current): Node;
 
     public function supports(NodeWalkerEvent $event): bool;
 }

--- a/packages/guides-markdown/src/Markdown/Parsers/AbstractBlockParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/AbstractBlockParser.php
@@ -11,6 +11,6 @@ use phpDocumentor\Guides\Nodes\Node;
  * @template TValue as Node
  * @implements ParserInterface<TValue>
  */
-abstract class AbstractBlock implements ParserInterface
+abstract class AbstractBlockParser implements ParserInterface
 {
 }

--- a/packages/guides-markdown/src/Markdown/Parsers/BlockQuoteParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/BlockQuoteParser.php
@@ -49,7 +49,7 @@ final class BlockQuoteParser extends AbstractBlockParser
                 return new QuoteNode($content);
             }
 
-            $this->logger->warning(sprintf('BlockQuote CONTEXT: I am leaving a %s node', $commonMarkNode::class));
+            $this->logger->warning(sprintf('"%s" node is not yet supported in context %s. ', $commonMarkNode::class, 'BlockQuote'));
         }
 
         throw new RuntimeException('Unexpected end of NodeWalker');

--- a/packages/guides-markdown/src/Markdown/Parsers/BlockQuoteParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/BlockQuoteParser.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Markdown\Parsers;
+
+use League\CommonMark\Extension\CommonMark\Node\Block\BlockQuote;
+use League\CommonMark\Node\Node as CommonMarkNode;
+use League\CommonMark\Node\NodeWalker;
+use League\CommonMark\Node\NodeWalkerEvent;
+use phpDocumentor\Guides\MarkupLanguageParser;
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\Nodes\QuoteNode;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+use function sprintf;
+
+/** @extends AbstractBlockParser<QuoteNode> */
+final class BlockQuoteParser extends AbstractBlockParser
+{
+    /** @param iterable<AbstractBlockParser<Node>> $subParsers */
+    public function __construct(
+        private readonly iterable $subParsers,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): QuoteNode
+    {
+        $content = [];
+
+        while ($event = $walker->next()) {
+            $commonMarkNode = $event->getNode();
+
+            if ($event->isEntering()) {
+                foreach ($this->subParsers as $subParser) {
+                    if ($subParser->supports($event)) {
+                        $content[] = $subParser->parse($parser, $walker, $commonMarkNode);
+                        break;
+                    }
+                }
+
+                continue;
+            }
+
+            // leaving the heading node
+            if ($commonMarkNode instanceof BlockQuote) {
+                return new QuoteNode($content);
+            }
+
+            $this->logger->warning(sprintf('BlockQuote CONTEXT: I am leaving a %s node', $commonMarkNode::class));
+        }
+
+        throw new RuntimeException('Unexpected end of NodeWalker');
+    }
+
+    public function supports(NodeWalkerEvent $event): bool
+    {
+        return $event->isEntering() && $event->getNode() instanceof BlockQuote;
+    }
+}

--- a/packages/guides-markdown/src/Markdown/Parsers/CodeBlockParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/CodeBlockParser.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Markdown\Parsers;
+
+use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
+use League\CommonMark\Extension\CommonMark\Node\Block\IndentedCode;
+use League\CommonMark\Node\Node as CommonMarkNode;
+use League\CommonMark\Node\NodeWalker;
+use League\CommonMark\Node\NodeWalkerEvent;
+use phpDocumentor\Guides\MarkupLanguageParser;
+use phpDocumentor\Guides\Nodes\CodeNode;
+
+use function assert;
+use function explode;
+
+/** @extends AbstractBlockParser<CodeNode> */
+final class CodeBlockParser extends AbstractBlockParser
+{
+    public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): CodeNode
+    {
+        assert($current instanceof IndentedCode || $current instanceof FencedCode);
+        $walker->next();
+        $codeNode = new CodeNode(explode("\n", $current->getLiteral()));
+        if ($current instanceof FencedCode && $current->getInfo() !== null) {
+            $codeNode = $codeNode->withOptions(['caption' => $current->getInfo()]);
+        }
+
+        return $codeNode;
+    }
+
+    public function supports(NodeWalkerEvent $event): bool
+    {
+        return $event->getNode() instanceof IndentedCode || $event->getNode() instanceof FencedCode;
+    }
+}

--- a/packages/guides-markdown/src/Markdown/Parsers/HeaderParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/HeaderParser.php
@@ -58,7 +58,7 @@ final class HeaderParser extends AbstractBlockParser
                 );
             }
 
-            $this->logger->warning(sprintf('Header CONTEXT: I am leaving a %s node', $commonMarkNode::class));
+            $this->logger->warning(sprintf('"%s" node is not yet supported in context %s. ', $commonMarkNode::class, 'Header'));
         }
 
         throw new RuntimeException('Unexpected end of NodeWalker');

--- a/packages/guides-markdown/src/Markdown/Parsers/HeaderParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/HeaderParser.php
@@ -4,33 +4,34 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\Markdown\Parsers;
 
-use League\CommonMark\Node\Block\Paragraph as CommonMarkParagraph;
+use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
 use League\CommonMark\Node\Node as CommonMarkNode;
 use League\CommonMark\Node\NodeWalker;
 use League\CommonMark\Node\NodeWalkerEvent;
 use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\AbstractInlineParser;
 use phpDocumentor\Guides\MarkupLanguageParser;
-use phpDocumentor\Guides\Nodes\CompoundNode;
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
 use phpDocumentor\Guides\Nodes\InlineCompoundNode;
-use phpDocumentor\Guides\Nodes\ParagraphNode;
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\Nodes\TitleNode;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use Symfony\Component\String\Slugger\AsciiSlugger;
 
 use function sprintf;
 
-/** @extends AbstractBlockParser<ParagraphNode> */
-final class ParagraphParser extends AbstractBlockParser
+/** @extends AbstractBlockParser<TitleNode> */
+final class HeaderParser extends AbstractBlockParser
 {
     /** @param iterable<AbstractInlineParser<InlineNode>> $inlineParsers */
     public function __construct(
         private readonly iterable $inlineParsers,
         private readonly LoggerInterface $logger,
+        private readonly AsciiSlugger $idGenerator,
     ) {
     }
 
-    /** @return ParagraphNode */
-    public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): CompoundNode
+    public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): Node
     {
         $content = [];
 
@@ -39,21 +40,25 @@ final class ParagraphParser extends AbstractBlockParser
 
             if ($event->isEntering()) {
                 foreach ($this->inlineParsers as $subParser) {
-                    if (!$subParser->supports($event)) {
-                        continue;
+                    if ($subParser->supports($event)) {
+                        $content[] = $subParser->parse($parser, $walker, $commonMarkNode);
+                        break;
                     }
-
-                    $content[] = $subParser->parse($parser, $walker, $commonMarkNode);
                 }
 
                 continue;
             }
 
-            if ($commonMarkNode instanceof CommonMarkParagraph) {
-                return new ParagraphNode([new InlineCompoundNode($content)]);
+            // leaving the heading node
+            if ($commonMarkNode instanceof Heading) {
+                return new TitleNode(
+                    new InlineCompoundNode($content),
+                    $commonMarkNode->getLevel(),
+                    $this->idGenerator->slug($content[0]->toString() ?? '')->lower()->toString(),
+                );
             }
 
-            $this->logger->warning(sprintf('PARAGRAPH CONTEXT: I am leaving a %s node', $commonMarkNode::class));
+            $this->logger->warning(sprintf('Header CONTEXT: I am leaving a %s node', $commonMarkNode::class));
         }
 
         throw new RuntimeException('Unexpected end of NodeWalker');
@@ -61,6 +66,6 @@ final class ParagraphParser extends AbstractBlockParser
 
     public function supports(NodeWalkerEvent $event): bool
     {
-        return $event->isEntering() && $event->getNode() instanceof CommonMarkParagraph;
+        return $event->isEntering() && $event->getNode() instanceof Heading;
     }
 }

--- a/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/AbstractInlineParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/AbstractInlineParser.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Markdown\Parsers\InlineParsers;
+
+use League\CommonMark\Node\Node as CommonMarkNode;
+use League\CommonMark\Node\NodeWalker;
+use phpDocumentor\Guides\Markdown\ParserInterface;
+use phpDocumentor\Guides\MarkupLanguageParser;
+use phpDocumentor\Guides\Nodes\Inline\InlineNode;
+
+/**
+ * @template TValue as InlineNode
+ * @implements ParserInterface<TValue>
+ */
+abstract class AbstractInlineParser implements ParserInterface
+{
+    abstract public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): InlineNode;
+}

--- a/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/AbstractInlineTextDecoratorParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/AbstractInlineTextDecoratorParser.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Markdown\Parsers\InlineParsers;
+
+use League\CommonMark\Node\Node as CommonMarkNode;
+use League\CommonMark\Node\NodeWalker;
+use League\CommonMark\Node\NodeWalkerEvent;
+use phpDocumentor\Guides\MarkupLanguageParser;
+use phpDocumentor\Guides\Nodes\Inline\InlineNode;
+use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+use function count;
+use function sprintf;
+use function var_export;
+
+/**
+ * @template TValue as InlineNode
+ * @extends AbstractInlineParser<TValue>
+ */
+abstract class AbstractInlineTextDecoratorParser extends AbstractInlineParser
+{
+    /** @param iterable<AbstractInlineParser<InlineNode>> $inlineParsers */
+    public function __construct(
+        private readonly iterable $inlineParsers,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /** @return TValue */
+    public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): InlineNode
+    {
+        $content = [];
+
+        while ($event = $walker->next()) {
+            $commonMarkNode = $event->getNode();
+
+            if ($event->isEntering()) {
+                foreach ($this->inlineParsers as $subParser) {
+                    if (!$subParser->supports($event)) {
+                        continue;
+                    }
+
+                    $content[] = $subParser->parse($parser, $walker, $commonMarkNode);
+                }
+
+                continue;
+            }
+
+            if ($this->supportsCommonMarkNode($commonMarkNode)) {
+                if (count($content) === 1 && $content[0] instanceof PlainTextInlineNode) {
+                    return $this->createInlineNode($commonMarkNode, $content[0]->getValue());
+                }
+
+                $this->logger->warning(sprintf('%s CONTEXT: Content of emphasis could not be interpreted: %s', $this->getType(), var_export($content, true)));
+
+                return $this->createInlineNode($commonMarkNode, null);
+            }
+
+            $this->logger->warning(sprintf('%s context does not allow a %s node', $this->getType(), $commonMarkNode::class));
+        }
+
+        throw new RuntimeException(sprintf('Unexpected end of NodeWalker, %s context was not closed', $this->getType()));
+    }
+
+    abstract protected function getType(): string;
+
+    /** @return TValue */
+    abstract protected function createInlineNode(CommonMarkNode $commonMarkNode, string|null $content): InlineNode;
+
+    abstract protected function supportsCommonMarkNode(CommonMarkNode $commonMarkNode): bool;
+
+    public function supports(NodeWalkerEvent $event): bool
+    {
+        return $event->isEntering() && $this->supportsCommonMarkNode($event->getNode());
+    }
+}

--- a/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/EmphasisParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/EmphasisParser.php
@@ -6,66 +6,33 @@ namespace phpDocumentor\Guides\Markdown\Parsers\InlineParsers;
 
 use League\CommonMark\Extension\CommonMark\Node\Inline\Emphasis;
 use League\CommonMark\Node\Node as CommonMarkNode;
-use League\CommonMark\Node\NodeWalker;
-use League\CommonMark\Node\NodeWalkerEvent;
-use phpDocumentor\Guides\MarkupLanguageParser;
 use phpDocumentor\Guides\Nodes\Inline\EmphasisInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
-use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 use Psr\Log\LoggerInterface;
-use RuntimeException;
 
-use function count;
-use function sprintf;
-use function var_export;
-
-/** @extends AbstractInlineParser<EmphasisInlineNode> */
-final class EmphasisParser extends AbstractInlineParser
+/** @extends AbstractInlineTextDecoratorParser<EmphasisInlineNode> */
+final class EmphasisParser extends AbstractInlineTextDecoratorParser
 {
     /** @param iterable<AbstractInlineParser<InlineNode>> $inlineParsers */
     public function __construct(
-        private readonly iterable $inlineParsers,
-        private readonly LoggerInterface $logger,
+        iterable $inlineParsers,
+        LoggerInterface $logger,
     ) {
+        parent::__construct($inlineParsers, $logger);
     }
 
-    public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): InlineNode
+    protected function getType(): string
     {
-        $content = [];
-
-        while ($event = $walker->next()) {
-            $commonMarkNode = $event->getNode();
-
-            if ($event->isEntering()) {
-                foreach ($this->inlineParsers as $subParser) {
-                    if (!$subParser->supports($event)) {
-                        continue;
-                    }
-
-                    $content[] = $subParser->parse($parser, $walker, $commonMarkNode);
-                }
-
-                continue;
-            }
-
-            if ($commonMarkNode instanceof Emphasis) {
-                if (count($content) > 0 && $content[0] instanceof PlainTextInlineNode) {
-                    return new EmphasisInlineNode($content[0]->getValue());
-                }
-
-                $this->logger->warning(sprintf('Emphasis CONTEXT: Content of emphasis could not be interpreted: %s', var_export($content, true)));
-
-                return new EmphasisInlineNode('');
-            }
-
-            $this->logger->warning(sprintf('Emphasis CONTEXT: I am leaving a %s node', $commonMarkNode::class));
-        }
-
-        throw new RuntimeException('Unexpected end of NodeWalker');
+        return 'Emphasis';
     }
 
-    public function supports(NodeWalkerEvent $event): bool
+    protected function createInlineNode(CommonMarkNode $commonMarkNode, string|null $content): InlineNode
     {
-        return $event->isEntering() && $event->getNode() instanceof Emphasis;
+        return new EmphasisInlineNode($content ?? '');
+    }
+
+    protected function supportsCommonMarkNode(CommonMarkNode $commonMarkNode): bool
+    {
+        return $commonMarkNode instanceof Emphasis;
     }
 }

--- a/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/InlineCodeParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/InlineCodeParser.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Markdown\Parsers\InlineParsers;
+
+use League\CommonMark\Extension\CommonMark\Node\Inline\Code;
+use League\CommonMark\Node\Node as CommonMarkNode;
+use League\CommonMark\Node\NodeWalker;
+use League\CommonMark\Node\NodeWalkerEvent;
+use phpDocumentor\Guides\MarkupLanguageParser;
+use phpDocumentor\Guides\Nodes\Inline\LiteralInlineNode;
+
+use function assert;
+
+/** @extends AbstractInlineParser<LiteralInlineNode> */
+final class InlineCodeParser extends AbstractInlineParser
+{
+    public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): LiteralInlineNode
+    {
+        assert($current instanceof Code);
+
+        return new LiteralInlineNode($current->getLiteral());
+    }
+
+    public function supports(NodeWalkerEvent $event): bool
+    {
+        return $event->getNode() instanceof Code;
+    }
+}

--- a/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/InlineImageParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/InlineImageParser.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Markdown\Parsers\InlineParsers;
+
+use League\CommonMark\Extension\CommonMark\Node\Inline\Image;
+use League\CommonMark\Node\Node as CommonMarkNode;
+use phpDocumentor\Guides\Nodes\Inline\ImageInlineNode;
+use phpDocumentor\Guides\Nodes\Inline\InlineNode;
+use Psr\Log\LoggerInterface;
+
+use function assert;
+
+/** @extends AbstractInlineTextDecoratorParser<ImageInlineNode> */
+final class InlineImageParser extends AbstractInlineTextDecoratorParser
+{
+    /** @param iterable<AbstractInlineParser<InlineNode>> $inlineParsers */
+    public function __construct(
+        iterable $inlineParsers,
+        LoggerInterface $logger,
+    ) {
+        parent::__construct($inlineParsers, $logger);
+    }
+
+    protected function getType(): string
+    {
+        return 'Image';
+    }
+
+    protected function createInlineNode(CommonMarkNode $commonMarkNode, string|null $content): InlineNode
+    {
+        assert($commonMarkNode instanceof Image);
+
+        return new ImageInlineNode($commonMarkNode->getUrl(), $content ?? '');
+    }
+
+    protected function supportsCommonMarkNode(CommonMarkNode $commonMarkNode): bool
+    {
+        return $commonMarkNode instanceof Image;
+    }
+}

--- a/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/LinkParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/LinkParser.php
@@ -2,25 +2,24 @@
 
 declare(strict_types=1);
 
-namespace phpDocumentor\Guides\Markdown\Parsers;
+namespace phpDocumentor\Guides\Markdown\Parsers\InlineParsers;
 
-use League\CommonMark\Node\Block\Paragraph as CommonMarkParagraph;
+use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
 use League\CommonMark\Node\Node as CommonMarkNode;
 use League\CommonMark\Node\NodeWalker;
 use League\CommonMark\Node\NodeWalkerEvent;
-use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\AbstractInlineParser;
 use phpDocumentor\Guides\MarkupLanguageParser;
-use phpDocumentor\Guides\Nodes\CompoundNode;
+use phpDocumentor\Guides\Nodes\Inline\HyperLinkNode;
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
-use phpDocumentor\Guides\Nodes\InlineCompoundNode;
-use phpDocumentor\Guides\Nodes\ParagraphNode;
+use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 
+use function count;
 use function sprintf;
 
-/** @extends AbstractBlockParser<ParagraphNode> */
-final class ParagraphParser extends AbstractBlockParser
+/** @extends AbstractInlineParser<HyperLinkNode> */
+final class LinkParser extends AbstractInlineParser
 {
     /** @param iterable<AbstractInlineParser<InlineNode>> $inlineParsers */
     public function __construct(
@@ -29,8 +28,7 @@ final class ParagraphParser extends AbstractBlockParser
     ) {
     }
 
-    /** @return ParagraphNode */
-    public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): CompoundNode
+    public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): InlineNode
     {
         $content = [];
 
@@ -49,11 +47,15 @@ final class ParagraphParser extends AbstractBlockParser
                 continue;
             }
 
-            if ($commonMarkNode instanceof CommonMarkParagraph) {
-                return new ParagraphNode([new InlineCompoundNode($content)]);
+            if ($commonMarkNode instanceof Link) {
+                if (count($content) > 0 && $content[0] instanceof PlainTextInlineNode) {
+                    return new HyperLinkNode($content[0]->getValue(), $commonMarkNode->getUrl());
+                }
+
+                return new HyperLinkNode($commonMarkNode->getUrl(), $commonMarkNode->getUrl());
             }
 
-            $this->logger->warning(sprintf('PARAGRAPH CONTEXT: I am leaving a %s node', $commonMarkNode::class));
+            $this->logger->warning(sprintf('Link CONTEXT: I am leaving a %s node', $commonMarkNode::class));
         }
 
         throw new RuntimeException('Unexpected end of NodeWalker');
@@ -61,6 +63,6 @@ final class ParagraphParser extends AbstractBlockParser
 
     public function supports(NodeWalkerEvent $event): bool
     {
-        return $event->isEntering() && $event->getNode() instanceof CommonMarkParagraph;
+        return $event->isEntering() && $event->getNode() instanceof Link;
     }
 }

--- a/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/PlainTextParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/PlainTextParser.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Markdown\Parsers\InlineParsers;
+
+use League\CommonMark\Node\Inline\Text;
+use League\CommonMark\Node\Node as CommonMarkNode;
+use League\CommonMark\Node\NodeWalker;
+use League\CommonMark\Node\NodeWalkerEvent;
+use phpDocumentor\Guides\MarkupLanguageParser;
+use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
+use Psr\Log\LoggerInterface;
+
+use function sprintf;
+
+/** @extends AbstractInlineParser<PlainTextInlineNode> */
+final class PlainTextParser extends AbstractInlineParser
+{
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): PlainTextInlineNode
+    {
+        if (!$current instanceof Text) {
+            $this->logger->warning(sprintf('Expected plaintext, encountered a %s node', $current::class));
+
+            return new PlainTextInlineNode('');
+        }
+
+        return new PlainTextInlineNode($current->getLiteral());
+    }
+
+    public function supports(NodeWalkerEvent $event): bool
+    {
+        return $event->isEntering() && $event->getNode() instanceof Text;
+    }
+}

--- a/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/StrongParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/StrongParser.php
@@ -2,25 +2,25 @@
 
 declare(strict_types=1);
 
-namespace phpDocumentor\Guides\Markdown\Parsers;
+namespace phpDocumentor\Guides\Markdown\Parsers\InlineParsers;
 
-use League\CommonMark\Node\Block\Paragraph as CommonMarkParagraph;
+use League\CommonMark\Extension\CommonMark\Node\Inline\Strong;
 use League\CommonMark\Node\Node as CommonMarkNode;
 use League\CommonMark\Node\NodeWalker;
 use League\CommonMark\Node\NodeWalkerEvent;
-use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\AbstractInlineParser;
 use phpDocumentor\Guides\MarkupLanguageParser;
-use phpDocumentor\Guides\Nodes\CompoundNode;
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
-use phpDocumentor\Guides\Nodes\InlineCompoundNode;
-use phpDocumentor\Guides\Nodes\ParagraphNode;
+use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
+use phpDocumentor\Guides\Nodes\Inline\StrongInlineNode;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 
+use function count;
 use function sprintf;
+use function var_export;
 
-/** @extends AbstractBlockParser<ParagraphNode> */
-final class ParagraphParser extends AbstractBlockParser
+/** @extends AbstractInlineParser<StrongInlineNode> */
+final class StrongParser extends AbstractInlineParser
 {
     /** @param iterable<AbstractInlineParser<InlineNode>> $inlineParsers */
     public function __construct(
@@ -29,8 +29,7 @@ final class ParagraphParser extends AbstractBlockParser
     ) {
     }
 
-    /** @return ParagraphNode */
-    public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): CompoundNode
+    public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): InlineNode
     {
         $content = [];
 
@@ -49,11 +48,17 @@ final class ParagraphParser extends AbstractBlockParser
                 continue;
             }
 
-            if ($commonMarkNode instanceof CommonMarkParagraph) {
-                return new ParagraphNode([new InlineCompoundNode($content)]);
+            if ($commonMarkNode instanceof Strong) {
+                if (count($content) > 0 && $content[0] instanceof PlainTextInlineNode) {
+                    return new StrongInlineNode($content[0]->getValue());
+                }
+
+                $this->logger->warning(sprintf('Strong CONTEXT: Content of strong could not be interpreted: %s', var_export($content, true)));
+
+                return new StrongInlineNode('');
             }
 
-            $this->logger->warning(sprintf('PARAGRAPH CONTEXT: I am leaving a %s node', $commonMarkNode::class));
+            $this->logger->warning(sprintf('Strong CONTEXT: I am leaving a %s node', $commonMarkNode::class));
         }
 
         throw new RuntimeException('Unexpected end of NodeWalker');
@@ -61,6 +66,6 @@ final class ParagraphParser extends AbstractBlockParser
 
     public function supports(NodeWalkerEvent $event): bool
     {
-        return $event->isEntering() && $event->getNode() instanceof CommonMarkParagraph;
+        return $event->isEntering() && $event->getNode() instanceof Strong;
     }
 }

--- a/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/StrongParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/StrongParser.php
@@ -6,66 +6,33 @@ namespace phpDocumentor\Guides\Markdown\Parsers\InlineParsers;
 
 use League\CommonMark\Extension\CommonMark\Node\Inline\Strong;
 use League\CommonMark\Node\Node as CommonMarkNode;
-use League\CommonMark\Node\NodeWalker;
-use League\CommonMark\Node\NodeWalkerEvent;
-use phpDocumentor\Guides\MarkupLanguageParser;
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
-use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\StrongInlineNode;
 use Psr\Log\LoggerInterface;
-use RuntimeException;
 
-use function count;
-use function sprintf;
-use function var_export;
-
-/** @extends AbstractInlineParser<StrongInlineNode> */
-final class StrongParser extends AbstractInlineParser
+/** @extends AbstractInlineTextDecoratorParser<StrongInlineNode> */
+final class StrongParser extends AbstractInlineTextDecoratorParser
 {
     /** @param iterable<AbstractInlineParser<InlineNode>> $inlineParsers */
     public function __construct(
-        private readonly iterable $inlineParsers,
-        private readonly LoggerInterface $logger,
+        iterable $inlineParsers,
+        LoggerInterface $logger,
     ) {
+        parent::__construct($inlineParsers, $logger);
     }
 
-    public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): InlineNode
+    protected function getType(): string
     {
-        $content = [];
-
-        while ($event = $walker->next()) {
-            $commonMarkNode = $event->getNode();
-
-            if ($event->isEntering()) {
-                foreach ($this->inlineParsers as $subParser) {
-                    if (!$subParser->supports($event)) {
-                        continue;
-                    }
-
-                    $content[] = $subParser->parse($parser, $walker, $commonMarkNode);
-                }
-
-                continue;
-            }
-
-            if ($commonMarkNode instanceof Strong) {
-                if (count($content) > 0 && $content[0] instanceof PlainTextInlineNode) {
-                    return new StrongInlineNode($content[0]->getValue());
-                }
-
-                $this->logger->warning(sprintf('Strong CONTEXT: Content of strong could not be interpreted: %s', var_export($content, true)));
-
-                return new StrongInlineNode('');
-            }
-
-            $this->logger->warning(sprintf('Strong CONTEXT: I am leaving a %s node', $commonMarkNode::class));
-        }
-
-        throw new RuntimeException('Unexpected end of NodeWalker');
+        return 'StrongDecorator';
     }
 
-    public function supports(NodeWalkerEvent $event): bool
+    protected function createInlineNode(CommonMarkNode $commonMarkNode, string|null $content): InlineNode
     {
-        return $event->isEntering() && $event->getNode() instanceof Strong;
+        return new StrongInlineNode($content ?? '');
+    }
+
+    protected function supportsCommonMarkNode(CommonMarkNode $commonMarkNode): bool
+    {
+        return $commonMarkNode instanceof Strong;
     }
 }

--- a/packages/guides-markdown/src/Markdown/Parsers/ListBlock.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/ListBlock.php
@@ -10,10 +10,18 @@ use League\CommonMark\Node\NodeWalkerEvent;
 use phpDocumentor\Guides\MarkupLanguageParser;
 use phpDocumentor\Guides\Nodes\CompoundNode;
 use phpDocumentor\Guides\Nodes\ListNode;
+use Psr\Log\LoggerInterface;
+
+use function sprintf;
 
 /** @extends AbstractBlock<ListNode> */
 final class ListBlock extends AbstractBlock
 {
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
     /** @return ListNode */
     public function parse(MarkupLanguageParser $parser, NodeWalker $walker): CompoundNode
     {
@@ -30,12 +38,7 @@ final class ListBlock extends AbstractBlock
                 return $context;
             }
 
-            echo 'LIST CONTEXT: I am '
-                . 'leaving'
-                . ' a '
-                . $node::class
-                . ' node'
-                . "\n";
+            $this->logger->warning(sprintf('LIST CONTEXT: I am leaving a %s node', $node::class));
         }
 
         return $context;

--- a/packages/guides-markdown/src/Markdown/Parsers/ListBlockParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/ListBlockParser.php
@@ -14,8 +14,8 @@ use Psr\Log\LoggerInterface;
 
 use function sprintf;
 
-/** @extends AbstractBlock<ListNode> */
-final class ListBlock extends AbstractBlock
+/** @extends AbstractBlockParser<ListNode> */
+final class ListBlockParser extends AbstractBlockParser
 {
     public function __construct(
         private readonly LoggerInterface $logger,

--- a/packages/guides-markdown/src/Markdown/Parsers/ListBlockParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/ListBlockParser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\Markdown\Parsers;
 
 use League\CommonMark\Extension\CommonMark\Node\Block\ListBlock as CommonMarkListBlock;
+use League\CommonMark\Node\Node as CommonMarkNode;
 use League\CommonMark\Node\NodeWalker;
 use League\CommonMark\Node\NodeWalkerEvent;
 use phpDocumentor\Guides\MarkupLanguageParser;
@@ -23,22 +24,22 @@ final class ListBlockParser extends AbstractBlockParser
     }
 
     /** @return ListNode */
-    public function parse(MarkupLanguageParser $parser, NodeWalker $walker): CompoundNode
+    public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): CompoundNode
     {
         $context = new ListNode([], false);
 
         while ($event = $walker->next()) {
-            $node = $event->getNode();
+            $commonMarkNode = $event->getNode();
 
             if ($event->isEntering()) {
                 continue;
             }
 
-            if ($node instanceof CommonMarkListBlock) {
+            if ($commonMarkNode instanceof CommonMarkListBlock) {
                 return $context;
             }
 
-            $this->logger->warning(sprintf('LIST CONTEXT: I am leaving a %s node', $node::class));
+            $this->logger->warning(sprintf('LIST CONTEXT: I am leaving a %s node', $commonMarkNode::class));
         }
 
         return $context;

--- a/packages/guides-markdown/src/Markdown/Parsers/ListBlockParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/ListBlockParser.php
@@ -43,7 +43,7 @@ final class ListBlockParser extends AbstractBlockParser
                 return new ListNode($content, $content[0]->isOrdered());
             }
 
-            $this->logger->warning(sprintf('List block CONTEXT: I am leaving a %s node', $commonMarkNode::class));
+            $this->logger->warning(sprintf('"%s" node is not yet supported in context %s. ', $commonMarkNode::class, 'List'));
         }
 
         throw new RuntimeException('Unexpected end of NodeWalker in list block');

--- a/packages/guides-markdown/src/Markdown/Parsers/ListItemParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/ListItemParser.php
@@ -52,7 +52,7 @@ final class ListItemParser extends AbstractBlockParser
                 return new ListItemNode($prefix, $ordered, $content);
             }
 
-            $this->logger->warning(sprintf('LIST Item CONTEXT: I am leaving a %s node', $commonMarkNode::class));
+            $this->logger->warning(sprintf('"%s" node is not yet supported in context %s. ', $commonMarkNode::class, 'List'));
         }
 
         throw new RuntimeException('Unexpected end of NodeWalker in list item');

--- a/packages/guides-markdown/src/Markdown/Parsers/ListItemParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/ListItemParser.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Markdown\Parsers;
+
+use League\CommonMark\Extension\CommonMark\Node\Block\ListBlock;
+use League\CommonMark\Extension\CommonMark\Node\Block\ListItem;
+use League\CommonMark\Node\Node as CommonMarkNode;
+use League\CommonMark\Node\NodeWalker;
+use League\CommonMark\Node\NodeWalkerEvent;
+use phpDocumentor\Guides\MarkupLanguageParser;
+use phpDocumentor\Guides\Nodes\ListItemNode;
+use phpDocumentor\Guides\Nodes\Node;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+use function sprintf;
+
+/** @extends AbstractBlockParser<ListItemNode> */
+final class ListItemParser extends AbstractBlockParser
+{
+    /** @param iterable<AbstractBlockParser<Node>> $subParsers */
+    public function __construct(
+        private readonly iterable $subParsers,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): ListItemNode
+    {
+        $content = [];
+
+        while ($event = $walker->next()) {
+            $commonMarkNode = $event->getNode();
+
+            if ($event->isEntering()) {
+                foreach ($this->subParsers as $subParser) {
+                    if ($subParser->supports($event)) {
+                        $content[] = $subParser->parse($parser, $walker, $commonMarkNode);
+                        break;
+                    }
+                }
+
+                continue;
+            }
+
+            if ($commonMarkNode instanceof ListItem) {
+                $prefix = $commonMarkNode->getListData()->bulletChar ?? $commonMarkNode->getListData()->delimiter ?? '';
+                $ordered = $commonMarkNode->getListData()->type === ListBlock::TYPE_ORDERED;
+
+                return new ListItemNode($prefix, $ordered, $content);
+            }
+
+            $this->logger->warning(sprintf('LIST Item CONTEXT: I am leaving a %s node', $commonMarkNode::class));
+        }
+
+        throw new RuntimeException('Unexpected end of NodeWalker in list item');
+    }
+
+    public function supports(NodeWalkerEvent $event): bool
+    {
+        return $event->isEntering() && $event->getNode() instanceof ListItem;
+    }
+}

--- a/packages/guides-markdown/src/Markdown/Parsers/Paragraph.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/Paragraph.php
@@ -4,42 +4,93 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\Markdown\Parsers;
 
+use League\CommonMark\Extension\CommonMark\Node\Inline\Emphasis;
+use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
+use League\CommonMark\Extension\CommonMark\Node\Inline\Strong;
 use League\CommonMark\Node\Block\Paragraph as CommonMarkParagraph;
+use League\CommonMark\Node\Inline\Text;
 use League\CommonMark\Node\NodeWalker;
 use League\CommonMark\Node\NodeWalkerEvent;
 use phpDocumentor\Guides\MarkupLanguageParser;
 use phpDocumentor\Guides\Nodes\CompoundNode;
+use phpDocumentor\Guides\Nodes\Inline\EmphasisInlineNode;
+use phpDocumentor\Guides\Nodes\Inline\HyperLinkNode;
+use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
+use phpDocumentor\Guides\Nodes\Inline\StrongInlineNode;
+use phpDocumentor\Guides\Nodes\InlineCompoundNode;
 use phpDocumentor\Guides\Nodes\ParagraphNode;
-use phpDocumentor\Guides\Nodes\SpanNode;
+use Psr\Log\LoggerInterface;
+
+use function sprintf;
 
 /** @extends AbstractBlock<ParagraphNode> */
 final class Paragraph extends AbstractBlock
 {
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
     /** @return ParagraphNode */
     public function parse(MarkupLanguageParser $parser, NodeWalker $walker): CompoundNode
     {
-        $context = new ParagraphNode([new SpanNode('', [])]);
+        $paragraphContent = [];
 
         while ($event = $walker->next()) {
             $node = $event->getNode();
+
+            if ($node instanceof Text && $node->parent() instanceof CommonMarkParagraph) {
+                // Inline Text Nodes are not shown on the way out
+                $paragraphContent[] = new PlainTextInlineNode($node->getLiteral());
+                continue;
+            }
 
             if ($event->isEntering()) {
                 continue;
             }
 
-            if ($node instanceof CommonMarkParagraph) {
-                return $context;
+            $firstChild = $node->firstChild();
+
+            if ($node instanceof Link) {
+                $text = $node->getUrl();
+                if ($firstChild instanceof Text) {
+                    $text = $firstChild->getLiteral();
+                }
+
+                $paragraphContent[] = new HyperLinkNode($text, $node->getUrl());
+                continue;
             }
 
-            echo 'PARAGRAPH CONTEXT: I am '
-                . 'leaving'
-                . ' a '
-                . $node::class
-                . ' node'
-                . "\n";
+            if ($node instanceof Emphasis) {
+                if (!($firstChild instanceof Text)) {
+                    continue;
+                }
+
+                $text = $firstChild->getLiteral();
+
+                $paragraphContent[] = new EmphasisInlineNode($text);
+                continue;
+            }
+
+            if ($node instanceof Strong) {
+                if (!($firstChild instanceof Text)) {
+                    continue;
+                }
+
+                $text = $firstChild->getLiteral();
+
+                $paragraphContent[] = new StrongInlineNode($text);
+                continue;
+            }
+
+            if ($node instanceof CommonMarkParagraph) {
+                return new ParagraphNode([new InlineCompoundNode($paragraphContent)]);
+            }
+
+            $this->logger->warning(sprintf('PARAGRAPH CONTEXT: I am leaving a %s node', $node::class));
         }
 
-        return $context;
+        return new ParagraphNode([new InlineCompoundNode($paragraphContent)]);
     }
 
     public function supports(NodeWalkerEvent $event): bool

--- a/packages/guides-markdown/src/Markdown/Parsers/ParagraphParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/ParagraphParser.php
@@ -23,8 +23,8 @@ use Psr\Log\LoggerInterface;
 
 use function sprintf;
 
-/** @extends AbstractBlock<ParagraphNode> */
-final class Paragraph extends AbstractBlock
+/** @extends AbstractBlockParser<ParagraphNode> */
+final class ParagraphParser extends AbstractBlockParser
 {
     public function __construct(
         private readonly LoggerInterface $logger,

--- a/packages/guides-markdown/src/Markdown/Parsers/ParagraphParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/ParagraphParser.php
@@ -53,7 +53,7 @@ final class ParagraphParser extends AbstractBlockParser
                 return new ParagraphNode([new InlineCompoundNode($content)]);
             }
 
-            $this->logger->warning(sprintf('PARAGRAPH CONTEXT: I am leaving a %s node', $commonMarkNode::class));
+            $this->logger->warning(sprintf('"%s" node is not yet supported in context %s. ', $commonMarkNode::class, 'Paragraph'));
         }
 
         throw new RuntimeException('Unexpected end of NodeWalker');

--- a/packages/guides-markdown/src/Markdown/Parsers/SeparatorParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/SeparatorParser.php
@@ -4,24 +4,25 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\Markdown\Parsers;
 
-use League\CommonMark\Extension\CommonMark\Node\Block\ThematicBreak as CommonMark;
+use League\CommonMark\Extension\CommonMark\Node\Block\ThematicBreak;
 use League\CommonMark\Node\Node as CommonMarkNode;
 use League\CommonMark\Node\NodeWalker;
 use League\CommonMark\Node\NodeWalkerEvent;
 use phpDocumentor\Guides\MarkupLanguageParser;
-use phpDocumentor\Guides\Nodes\CompoundNode;
 use phpDocumentor\Guides\Nodes\SeparatorNode;
 
 /** @extends AbstractBlockParser<SeparatorNode> */
 final class SeparatorParser extends AbstractBlockParser
 {
-    public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): CompoundNode
+    public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): SeparatorNode
     {
+        $walker->next();
+
         return new SeparatorNode(1);
     }
 
     public function supports(NodeWalkerEvent $event): bool
     {
-        return !$event->isEntering() && $event->getNode() instanceof CommonMark;
+        return $event->getNode() instanceof ThematicBreak;
     }
 }

--- a/packages/guides-markdown/src/Markdown/Parsers/SeparatorParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/SeparatorParser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\Markdown\Parsers;
 
 use League\CommonMark\Extension\CommonMark\Node\Block\ThematicBreak as CommonMark;
+use League\CommonMark\Node\Node as CommonMarkNode;
 use League\CommonMark\Node\NodeWalker;
 use League\CommonMark\Node\NodeWalkerEvent;
 use phpDocumentor\Guides\MarkupLanguageParser;
@@ -14,7 +15,7 @@ use phpDocumentor\Guides\Nodes\SeparatorNode;
 /** @extends AbstractBlockParser<SeparatorNode> */
 final class SeparatorParser extends AbstractBlockParser
 {
-    public function parse(MarkupLanguageParser $parser, NodeWalker $walker): CompoundNode
+    public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): CompoundNode
     {
         return new SeparatorNode(1);
     }

--- a/packages/guides-markdown/src/Markdown/Parsers/SeparatorParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/SeparatorParser.php
@@ -11,8 +11,8 @@ use phpDocumentor\Guides\MarkupLanguageParser;
 use phpDocumentor\Guides\Nodes\CompoundNode;
 use phpDocumentor\Guides\Nodes\SeparatorNode;
 
-/** @extends AbstractBlock<SeparatorNode> */
-final class ThematicBreak extends AbstractBlock
+/** @extends AbstractBlockParser<SeparatorNode> */
+final class SeparatorParser extends AbstractBlockParser
 {
     public function parse(MarkupLanguageParser $parser, NodeWalker $walker): CompoundNode
     {

--- a/packages/guides/resources/template/html/inline/image.html.twig
+++ b/packages/guides/resources/template/html/inline/image.html.twig
@@ -1,0 +1,2 @@
+{% apply spaceless %}<img src="{{- node.url -}}" alt="{{- node.altText -}}"/>
+{% endapply %}

--- a/packages/guides/src/DependencyInjection/Compiler/NodeRendererPass.php
+++ b/packages/guides/src/DependencyInjection/Compiler/NodeRendererPass.php
@@ -24,6 +24,7 @@ use phpDocumentor\Guides\Nodes\Inline\EmphasisInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\FootnoteInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\GenericTextRoleInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\HyperLinkNode;
+use phpDocumentor\Guides\Nodes\Inline\ImageInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\LiteralInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\NewlineInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
@@ -85,6 +86,7 @@ final class NodeRendererPass implements CompilerPassInterface
         FootnoteNode::class => 'body/footnote.html.twig',
         AnnotationListNode::class => 'body/annotation-list.html.twig',
         // Inline
+        ImageInlineNode::class => 'inline/image.html.twig',
         InlineCompoundNode::class => 'inline/inline-node.html.twig',
         AbbreviationInlineNode::class => 'inline/textroles/abbreviation.html.twig',
         CitationInlineNode::class => 'inline/citation.html.twig',

--- a/packages/guides/src/Handlers/ParseFileHandler.php
+++ b/packages/guides/src/Handlers/ParseFileHandler.php
@@ -96,9 +96,10 @@ final class ParseFileHandler
         $document = null;
         try {
             $document = $this->parser->parse($preParseDocumentEvent->getContents(), $extension)->withIsRoot($isRoot);
-        } catch (RuntimeException) {
+        } catch (RuntimeException $e) {
             $this->logger->error(
                 sprintf('Unable to parse %s, input format was not recognized', $path),
+                ['error' => $e],
             );
         }
 

--- a/packages/guides/src/Nodes/DocumentNode.php
+++ b/packages/guides/src/Nodes/DocumentNode.php
@@ -116,6 +116,10 @@ final class DocumentNode extends CompoundNode
             if ($node instanceof SectionNode && $node->getTitle()->getLevel() === 1) {
                 return $node->getTitle();
             }
+
+            if ($node instanceof TitleNode) {
+                return $node;
+            }
         }
 
         return null;

--- a/packages/guides/src/Nodes/Inline/ImageInlineNode.php
+++ b/packages/guides/src/Nodes/Inline/ImageInlineNode.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Nodes\Inline;
+
+/**
+ * In some Markup languages like Markdown Images are always considered inline. They can appear anywhere in a paragraph.
+ */
+final class ImageInlineNode extends InlineNode
+{
+    public const TYPE = 'image';
+
+    public function __construct(private readonly string $url, private readonly string $altText)
+    {
+        parent::__construct(self::TYPE, $url);
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function getAltText(): string
+    {
+        return $this->altText;
+    }
+}

--- a/tests/Integration/tests/markdown/blockquote-md/expected/index.html
+++ b/tests/Integration/tests/markdown/blockquote-md/expected/index.html
@@ -1,16 +1,35 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>Markdown Example - Project Title</title>
+    <title>Markdown Blockquotes - Project Title</title>
 
 </head>
 <body>
-    <h1>Markdown Example</h1>
+    <h1>Markdown Blockquotes</h1>
 
-<p>This is a Markdown document with some basic formatting.</p>
-<h2>Headings</h2>
+<blockquote><p>This is a blockquote.It can span multiple lines.</p></blockquote>
 
-<p>You can create headings using hash symbols.</p>
-<p>This text is part of a paragraph under the "Headings" heading.</p>
+<h2>Blockquotes with Multiple Paragraphs</h2>
+
+<blockquote><p>Dorothy followed her through many of the beautiful rooms in her castle.</p><p>The Witch bade her clean the pots and kettles and sweep the floor and keep the fire fed with wood.</p></blockquote>
+
+<h2>Blockquotes with Other Elements</h2>
+
+<blockquote><p>The quarterly results look great!</p>
+
+<ul>
+    <li class="dash"><p>Revenue was off the chart.</p></li>
+
+    <li class="dash"><p>Profits were higher than ever.</p></li>
+
+</ul>
+<p><em>Everything</em> is going according to <strong>plan</strong>.</p></blockquote>
+
+<h2>Blockquotes Best Practices</h2>
+
+<p>Try to put a blank line before...</p>
+<blockquote><p>This is a blockquote</p></blockquote>
+
+<p>...and after a blockquote.</p>
 </body>
 </html>

--- a/tests/Integration/tests/markdown/blockquote-md/expected/index.html
+++ b/tests/Integration/tests/markdown/blockquote-md/expected/index.html
@@ -11,6 +11,6 @@
 <h2>Headings</h2>
 
 <p>You can create headings using hash symbols.</p>
-<p>This text is part of a paragraph under the &quot;Headings&quot; heading.</p>
+<p>This text is part of a paragraph under the "Headings" heading.</p>
 </body>
 </html>

--- a/tests/Integration/tests/markdown/blockquote-md/input/guides.xml
+++ b/tests/Integration/tests/markdown/blockquote-md/input/guides.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd"
+        input-format="md"
+>
+    <project title="Project Title" version="6.4"/>
+</guides>

--- a/tests/Integration/tests/markdown/blockquote-md/input/index.md
+++ b/tests/Integration/tests/markdown/blockquote-md/input/index.md
@@ -1,0 +1,4 @@
+# Markdown Blockquotes
+
+> This is a blockquote.
+> It can span multiple lines.

--- a/tests/Integration/tests/markdown/blockquote-md/input/index.md
+++ b/tests/Integration/tests/markdown/blockquote-md/input/index.md
@@ -2,3 +2,26 @@
 
 > This is a blockquote.
 > It can span multiple lines.
+
+## Blockquotes with Multiple Paragraphs
+
+> Dorothy followed her through many of the beautiful rooms in her castle.
+>
+> The Witch bade her clean the pots and kettles and sweep the floor and keep the fire fed with wood.
+
+## Blockquotes with Other Elements
+
+> The quarterly results look great!
+>
+> - Revenue was off the chart.
+>- Profits were higher than ever.
+>
+> *Everything* is going according to **plan**.
+
+## Blockquotes Best Practices
+
+Try to put a blank line before...
+
+> This is a blockquote
+
+...and after a blockquote.

--- a/tests/Integration/tests/markdown/blockquote-md/input/skip
+++ b/tests/Integration/tests/markdown/blockquote-md/input/skip
@@ -1,0 +1,1 @@
+Blockquotes in Markdown are not supported yet

--- a/tests/Integration/tests/markdown/blockquote-md/input/skip
+++ b/tests/Integration/tests/markdown/blockquote-md/input/skip
@@ -1,1 +1,0 @@
-Blockquotes in Markdown are not supported yet

--- a/tests/Integration/tests/markdown/code-md/expected/index.html
+++ b/tests/Integration/tests/markdown/code-md/expected/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Markdown with Code Blocks - Project Title</title>
+
+</head>
+<body>
+    <h1>Markdown with Code Blocks</h1>
+
+<pre><code class="language-">&lt;html&gt;
+  &lt;head&gt;
+  &lt;/head&gt;
+&lt;/html&gt;
+</code></pre>
+<h2>Fenced Code Blocks</h2>
+
+<pre><code class="language-">{
+  &quot;firstName&quot;: &quot;John&quot;,
+  &quot;lastName&quot;: &quot;Smith&quot;,
+  &quot;age&quot;: 25
+}
+</code></pre>
+<h2>Fenced Code Block with caption</h2>
+
+<pre><code class="language-">procedure startSwinging(swing, child)
+   while child.isComfortable()
+       swing.giveGentlePush()
+       waitForNextIteration()
+   end while
+end procedure
+</code></pre>
+</body>
+</html>

--- a/tests/Integration/tests/markdown/code-md/input/guides.xml
+++ b/tests/Integration/tests/markdown/code-md/input/guides.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd"
+        input-format="md"
+>
+    <project title="Project Title" version="6.4"/>
+</guides>

--- a/tests/Integration/tests/markdown/code-md/input/index.md
+++ b/tests/Integration/tests/markdown/code-md/input/index.md
@@ -1,0 +1,26 @@
+# Markdown with Code Blocks
+
+    <html>
+      <head>
+      </head>
+    </html>
+
+## Fenced Code Blocks
+
+```
+{
+  "firstName": "John",
+  "lastName": "Smith",
+  "age": 25
+}
+```
+
+## Fenced Code Block with caption
+
+```pseudocode
+procedure startSwinging(swing, child)
+   while child.isComfortable()
+       swing.giveGentlePush()
+       waitForNextIteration()
+   end while
+end procedure

--- a/tests/Integration/tests/markdown/emphasis-md/expected/index.html
+++ b/tests/Integration/tests/markdown/emphasis-md/expected/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Markdown with emphasis - Project Title</title>
+
+</head>
+<body>
+    <h1>Markdown with emphasis</h1>
+
+<p><em>Italic</em> or <em>Italic</em><strong>Bold</strong> or <strong>Bold</strong></p>
+</body>
+</html>

--- a/tests/Integration/tests/markdown/emphasis-md/input/guides.xml
+++ b/tests/Integration/tests/markdown/emphasis-md/input/guides.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd"
+        input-format="md"
+>
+    <project title="Project Title" version="6.4"/>
+</guides>

--- a/tests/Integration/tests/markdown/emphasis-md/input/index.md
+++ b/tests/Integration/tests/markdown/emphasis-md/input/index.md
@@ -1,0 +1,4 @@
+# Markdown with emphasis
+
+*Italic* or _Italic_
+**Bold** or __Bold__

--- a/tests/Integration/tests/markdown/image-md/expected/index.html
+++ b/tests/Integration/tests/markdown/image-md/expected/index.html
@@ -1,16 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>Markdown Example - Project Title</title>
+    <title>Markdown Image - Project Title</title>
 
 </head>
 <body>
-    <h1>Markdown Example</h1>
+    <h1>Markdown Image</h1>
 
-<p>This is a Markdown document with some basic formatting.</p>
-<h2>Headings</h2>
-
-<p>You can create headings using hash symbols.</p>
-<p>This text is part of a paragraph under the "Headings" heading.</p>
+<p><img src="hero-illustration.svg" alt="Hero Illustrations"/></p>
 </body>
 </html>

--- a/tests/Integration/tests/markdown/image-md/expected/index.html
+++ b/tests/Integration/tests/markdown/image-md/expected/index.html
@@ -11,6 +11,6 @@
 <h2>Headings</h2>
 
 <p>You can create headings using hash symbols.</p>
-<p>This text is part of a paragraph under the &quot;Headings&quot; heading.</p>
+<p>This text is part of a paragraph under the "Headings" heading.</p>
 </body>
 </html>

--- a/tests/Integration/tests/markdown/image-md/input/guides.xml
+++ b/tests/Integration/tests/markdown/image-md/input/guides.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd"
+        input-format="md"
+>
+    <project title="Project Title" version="6.4"/>
+</guides>

--- a/tests/Integration/tests/markdown/image-md/input/hero-illustration.svg
+++ b/tests/Integration/tests/markdown/image-md/input/hero-illustration.svg
@@ -1,0 +1,180 @@
+<svg width="517" height="243" viewBox="0 0 517 243" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect x="119.135" y="17.9826" width="269.739" height="224.783" fill="#27331F"/>
+    <path
+        d="M119.135 7.49275C119.135 3.35462 122.489 0 126.628 0H381.381C385.519 0 388.874 3.35462 388.874 7.49275V17.9826H119.135V7.49275Z"
+        fill="#D9D9D9"/>
+    <circle cx="377.421" cy="9.36595" r="4.12101" fill="#C4C4C4"/>
+    <circle cx="365.646" cy="9.36595" r="4.12101" fill="#C4C4C4"/>
+    <circle cx="353.283" cy="9.36595" r="4.12101" fill="#C4C4C4"/>
+    <g clip-path="url(#clip0)">
+        <g clip-path="url(#clip1)">
+            <line x1="211.296" y1="44.2072" x2="259.999" y2="44.2072" stroke="#83CFFC" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+            <line x1="274.984" y1="44.2072" x2="301.209" y2="44.2072" stroke="#EE9949" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+            <line x1="316.194" y1="44.2072" x2="323.687" y2="44.2072" stroke="#EE9949" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+        </g>
+        <g clip-path="url(#clip2)">
+            <line x1="211.296" y1="65.1869" x2="224.033" y2="65.1869" stroke="#83CFFC" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+            <line x1="239.019" y1="65.1869" x2="362.649" y2="65.1869" stroke="#F7FBFB" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+        </g>
+        <g clip-path="url(#clip3)">
+            <line x1="211.296" y1="86.1667" x2="253.255" y2="86.1667" stroke="#83CFFC" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+            <line x1="268.241" y1="86.1667" x2="308.701" y2="86.1667" stroke="#EE9949" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+            <line x1="323.687" y1="86.1667" x2="343.917" y2="86.1667" stroke="#F7FBFB" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+        </g>
+        <g clip-path="url(#clip4)">
+            <line x1="211.296" y1="107.146" x2="281.728" y2="107.146" stroke="#F7FBFB" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+            <line x1="296.713" y1="107.146" x2="304.206" y2="107.146" stroke="#83CFFC" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+            <line x1="319.191" y1="107.146" x2="339.422" y2="107.146" stroke="#EE9949" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+            <line x1="354.407" y1="107.146" x2="364.897" y2="107.146" stroke="#EE9949" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+        </g>
+        <g clip-path="url(#clip5)">
+            <line x1="211.296" y1="128.126" x2="218.788" y2="128.126" stroke="#83CFFC" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+            <line x1="233.774" y1="128.126" x2="254.004" y2="128.126" stroke="#EE9949" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+            <line x1="268.99" y1="128.126" x2="330.43" y2="128.126" stroke="#EE9949" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+        </g>
+        <g clip-path="url(#clip6)">
+            <line x1="211.296" y1="149.106" x2="231.526" y2="149.106" stroke="#83CFFC" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+            <line x1="246.512" y1="149.106" x2="266.742" y2="149.106" stroke="#83CFFC" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+            <line x1="281.728" y1="149.106" x2="353.658" y2="149.106" stroke="#EE9949" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+        </g>
+        <g clip-path="url(#clip7)">
+            <line x1="211.296" y1="170.086" x2="280.978" y2="170.085" stroke="#F7FBFB" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+            <line x1="295.964" y1="170.086" x2="364.897" y2="170.085" stroke="#83CFFC" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+        </g>
+        <g clip-path="url(#clip8)">
+            <line x1="211.296" y1="191.065" x2="250.258" y2="191.065" stroke="#83CFFC" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+            <line x1="265.244" y1="191.065" x2="276.483" y2="191.065" stroke="#F7FBFB" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+            <line x1="291.468" y1="191.065" x2="343.917" y2="191.065" stroke="#F7FBFB" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+        </g>
+        <g clip-path="url(#clip9)">
+            <line x1="211.296" y1="212.045" x2="268.99" y2="212.045" stroke="#83CFFC" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+            <line x1="283.975" y1="212.045" x2="304.206" y2="212.045" stroke="#EE9949" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+            <line x1="319.191" y1="212.045" x2="365.646" y2="212.045" stroke="#EE9949" stroke-width="7.49275"
+                  stroke-linecap="round"/>
+        </g>
+    </g>
+    <path
+        d="M141.613 44.9565C141.613 45.3703 141.278 45.7058 140.864 45.7058H131.123C130.709 45.7058 130.374 45.3703 130.374 44.9565V36.7145C130.374 36.3007 130.709 35.9652 131.123 35.9652H134.005C134.199 35.9652 134.386 36.0403 134.525 36.1748L136.338 37.9202C136.477 38.0547 136.664 38.1298 136.858 38.1298H140.864C141.278 38.1298 141.613 38.4652 141.613 38.8791V44.9565Z"
+        fill="#D9D9D9"/>
+    <path
+        d="M155.849 65.9363C155.849 66.3501 155.514 66.6855 155.1 66.6855H145.359C144.946 66.6855 144.61 66.3501 144.61 65.9363V57.6942C144.61 57.2804 144.946 56.9449 145.359 56.9449H148.242C148.436 56.9449 148.622 57.0201 148.761 57.1545L150.574 58.9C150.714 59.0344 150.9 59.1095 151.094 59.1095H155.1C155.514 59.1095 155.849 59.445 155.849 59.8588V65.9363Z"
+        fill="#D9D9D9"/>
+    <path
+        d="M155.849 87.6652C155.849 88.079 155.514 88.4145 155.1 88.4145H145.359C144.946 88.4145 144.61 88.079 144.61 87.6652V79.4232C144.61 79.0094 144.946 78.6739 145.359 78.6739H148.242C148.436 78.6739 148.622 78.749 148.761 78.8835L150.574 80.6289C150.714 80.7634 150.9 80.8385 151.094 80.8385H155.1C155.514 80.8385 155.849 81.1739 155.849 81.5878V87.6652Z"
+        fill="#D9D9D9"/>
+    <path
+        d="M170.085 108.645C170.085 109.059 169.75 109.394 169.336 109.394H159.596C159.182 109.394 158.846 109.059 158.846 108.645V100.403C158.846 99.9891 159.182 99.6536 159.596 99.6536H162.478C162.672 99.6536 162.858 99.7287 162.998 99.8632L164.81 101.609C164.95 101.743 165.136 101.818 165.33 101.818H169.336C169.75 101.818 170.085 102.154 170.085 102.567V108.645Z"
+        fill="#D9D9D9"/>
+    <path
+        d="M141.613 130.374C141.613 130.788 141.278 131.123 140.864 131.123H131.123C130.709 131.123 130.374 130.788 130.374 130.374V122.132C130.374 121.718 130.709 121.383 131.123 121.383H134.005C134.199 121.383 134.386 121.458 134.525 121.592L136.338 123.338C136.477 123.472 136.664 123.547 136.858 123.547H140.864C141.278 123.547 141.613 123.883 141.613 124.296V130.374Z"
+        fill="#D9D9D9"/>
+    <path
+        d="M155.849 151.354C155.849 151.767 155.514 152.103 155.1 152.103H145.359C144.946 152.103 144.61 151.767 144.61 151.354V143.112C144.61 142.698 144.946 142.362 145.359 142.362H148.242C148.436 142.362 148.622 142.437 148.761 142.572L150.574 144.317C150.714 144.452 150.9 144.527 151.094 144.527H155.1C155.514 144.527 155.849 144.862 155.849 145.276V151.354Z"
+        fill="#D9D9D9"/>
+    <path
+        d="M155.849 172.333C155.849 172.747 155.514 173.083 155.1 173.083H145.359C144.946 173.083 144.61 172.747 144.61 172.333V164.091C144.61 163.677 144.946 163.342 145.359 163.342H148.242C148.436 163.342 148.622 163.417 148.761 163.552L150.574 165.297C150.714 165.431 150.9 165.507 151.094 165.507H155.1C155.514 165.507 155.849 165.842 155.849 166.256V172.333Z"
+        fill="#D9D9D9"/>
+    <path
+        d="M141.613 194.062C141.613 194.476 141.278 194.812 140.864 194.812H131.123C130.709 194.812 130.374 194.476 130.374 194.062V185.82C130.374 185.406 130.709 185.071 131.123 185.071H134.005C134.199 185.071 134.386 185.146 134.525 185.281L136.338 187.026C136.477 187.16 136.664 187.236 136.858 187.236H140.864C141.278 187.236 141.613 187.571 141.613 187.985V194.062Z"
+        fill="#D9D9D9"/>
+    <path
+        d="M155.849 215.042C155.849 215.456 155.514 215.791 155.1 215.791H145.359C144.946 215.791 144.61 215.456 144.61 215.042V206.8C144.61 206.386 144.946 206.051 145.359 206.051H148.242C148.436 206.051 148.622 206.126 148.761 206.26L150.574 208.006C150.714 208.14 150.9 208.215 151.094 208.215H155.1C155.514 208.215 155.849 208.551 155.849 208.965V215.042Z"
+        fill="#D9D9D9"/>
+    <line x1="194.812" y1="31.4696" x2="194.812" y2="232.275" stroke="#83CFFC" stroke-width="1.49855"/>
+    <line x1="133.746" y1="76.8007" x2="133.746" y2="108.27" stroke="#8DD35F" stroke-width="2.24783"
+          stroke-linecap="round"/>
+    <line x1="133.371" y1="93.2848" x2="82.4204" y2="93.2848" stroke="#8DD35F" stroke-width="2.24783"/>
+    <circle cx="82.4202" cy="92.9102" r="5.24493" fill="#8DD35F"/>
+    <line x1="2.62246" y1="66.3109" x2="43.7448" y2="66.3109" stroke="#8DD35F" stroke-width="5.24493"
+          stroke-linecap="round"/>
+    <line x1="2.62246" y1="76.7305" x2="64.063" y2="76.7305" stroke="#8DD35F" stroke-width="5.24493"
+          stroke-linecap="round"/>
+    <line x1="2.62246" y1="87.1501" x2="53.6434" y2="87.1501" stroke="#8DD35F" stroke-width="5.24493"
+          stroke-linecap="round"/>
+    <line x1="2.62246" y1="97.5697" x2="55.2064" y2="97.5697" stroke="#8DD35F" stroke-width="5.24493"
+          stroke-linecap="round"/>
+    <line x1="2.62246" y1="107.989" x2="36.4511" y2="107.989" stroke="#8DD35F" stroke-width="5.24493"
+          stroke-linecap="round"/>
+    <line x1="429.335" y1="65.5616" x2="378.384" y2="65.5616" stroke="#8DD35F" stroke-width="2.24783"/>
+    <circle cx="378.384" cy="65.1869" r="5.24493" fill="#8DD35F"/>
+    <circle cx="430.833" cy="65.1869" r="5.24493" fill="#8DD35F"/>
+    <line x1="452.937" y1="45.3312" x2="494.059" y2="45.3312" stroke="#8DD35F" stroke-width="5.24493"
+          stroke-linecap="round"/>
+    <line x1="452.937" y1="55.7508" x2="514.378" y2="55.7508" stroke="#8DD35F" stroke-width="5.24493"
+          stroke-linecap="round"/>
+    <line x1="452.937" y1="66.1704" x2="503.958" y2="66.1704" stroke="#8DD35F" stroke-width="5.24493"
+          stroke-linecap="round"/>
+    <line x1="452.937" y1="76.59" x2="505.521" y2="76.59" stroke="#8DD35F" stroke-width="5.24493" stroke-linecap="round"/>
+    <line x1="452.937" y1="87.0096" x2="486.766" y2="87.0096" stroke="#8DD35F" stroke-width="5.24493"
+          stroke-linecap="round"/>
+    <line x1="429.335" y1="170.46" x2="378.384" y2="170.46" stroke="#8DD35F" stroke-width="2.24783"/>
+    <circle cx="378.384" cy="170.086" r="5.24493" fill="#8DD35F"/>
+    <circle cx="430.833" cy="170.086" r="5.24493" fill="#8DD35F"/>
+    <line x1="452.937" y1="150.23" x2="494.059" y2="150.23" stroke="#8DD35F" stroke-width="5.24493"
+          stroke-linecap="round"/>
+    <line x1="452.937" y1="160.649" x2="514.378" y2="160.649" stroke="#8DD35F" stroke-width="5.24493"
+          stroke-linecap="round"/>
+    <line x1="452.937" y1="171.069" x2="503.958" y2="171.069" stroke="#8DD35F" stroke-width="5.24493"
+          stroke-linecap="round"/>
+    <line x1="452.937" y1="181.489" x2="505.521" y2="181.489" stroke="#8DD35F" stroke-width="5.24493"
+          stroke-linecap="round"/>
+    <line x1="452.937" y1="191.908" x2="486.766" y2="191.908" stroke="#8DD35F" stroke-width="5.24493"
+          stroke-linecap="round"/>
+    <defs>
+        <clip-path id="clip0">
+            <rect width="161.843" height="182.823" fill="white" transform="translate(207.549 40.4609)"/>
+        </clip-path>
+        <clip-path id="clip1">
+            <rect width="119.884" height="14.9855" fill="white" transform="translate(207.549 40.4609)"/>
+        </clip-path>
+        <clip-path id="clip2">
+            <rect width="158.846" height="14.9855" fill="white" transform="translate(207.549 61.4406)"/>
+        </clip-path>
+        <clip-path id="clip3">
+            <rect width="140.115" height="14.9855" fill="white" transform="translate(207.549 82.4203)"/>
+        </clip-path>
+        <clip-path id="clip4">
+            <rect width="161.094" height="14.9855" fill="white" transform="translate(207.549 103.4)"/>
+        </clip-path>
+        <clip-path id="clip5">
+            <rect width="126.628" height="14.9855" fill="white" transform="translate(207.549 124.38)"/>
+        </clip-path>
+        <clip-path id="clip6">
+            <rect width="149.855" height="14.9855" fill="white" transform="translate(207.549 145.359)"/>
+        </clip-path>
+        <clip-path id="clip7">
+            <rect width="161.094" height="14.9855" fill="white" transform="translate(207.549 166.339)"/>
+        </clip-path>
+        <clip-path id="clip8">
+            <rect width="140.115" height="14.9855" fill="white" transform="translate(207.549 187.319)"/>
+        </clip-path>
+        <clip-path id="clip9">
+            <rect width="161.843" height="14.9855" fill="white" transform="translate(207.549 208.299)"/>
+        </clip-path>
+    </defs>
+</svg>

--- a/tests/Integration/tests/markdown/image-md/input/index.md
+++ b/tests/Integration/tests/markdown/image-md/input/index.md
@@ -1,0 +1,3 @@
+# Markdown Image
+
+![Hero Illustrations](hero-illustration.svg)

--- a/tests/Integration/tests/markdown/image-md/input/skip
+++ b/tests/Integration/tests/markdown/image-md/input/skip
@@ -1,0 +1,1 @@
+Images in Markdown are not supported yet

--- a/tests/Integration/tests/markdown/image-md/input/skip
+++ b/tests/Integration/tests/markdown/image-md/input/skip
@@ -1,1 +1,0 @@
-Images in Markdown are not supported yet

--- a/tests/Integration/tests/markdown/index-md/input/index.md
+++ b/tests/Integration/tests/markdown/index-md/input/index.md
@@ -5,3 +5,5 @@ This is a Markdown document with some basic formatting.
 ## Headings
 
 You can create headings using hash symbols.
+
+This text is part of a paragraph under the "Headings" heading.

--- a/tests/Integration/tests/markdown/index-md/input/skip
+++ b/tests/Integration/tests/markdown/index-md/input/skip
@@ -1,1 +1,0 @@
-Paragraph text is missing in output, there is a warning about the document having no title even though it has a title

--- a/tests/Integration/tests/markdown/inline-code-md/expected/index.html
+++ b/tests/Integration/tests/markdown/inline-code-md/expected/index.html
@@ -8,5 +8,6 @@
     <h1>Markdown with inline Code</h1>
 
 <p>Lorem Ipsum Dolor: <code>$dolor</code>...</p>
+<p><code>Use `code` in your Markdown file.</code></p>
 </body>
 </html>

--- a/tests/Integration/tests/markdown/inline-code-md/expected/index.html
+++ b/tests/Integration/tests/markdown/inline-code-md/expected/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Markdown with inline Code - Project Title</title>
+
+</head>
+<body>
+    <h1>Markdown with inline Code</h1>
+
+<p>Lorem Ipsum Dolor: <code>$dolor</code>...</p>
+</body>
+</html>

--- a/tests/Integration/tests/markdown/inline-code-md/input/guides.xml
+++ b/tests/Integration/tests/markdown/inline-code-md/input/guides.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd"
+        input-format="md"
+>
+    <project title="Project Title" version="6.4"/>
+</guides>

--- a/tests/Integration/tests/markdown/inline-code-md/input/index.md
+++ b/tests/Integration/tests/markdown/inline-code-md/input/index.md
@@ -1,3 +1,5 @@
 # Markdown with inline Code
 
 Lorem Ipsum Dolor: `$dolor`...
+
+``Use `code` in your Markdown file.``

--- a/tests/Integration/tests/markdown/inline-code-md/input/index.md
+++ b/tests/Integration/tests/markdown/inline-code-md/input/index.md
@@ -1,0 +1,3 @@
+# Markdown with inline Code
+
+Lorem Ipsum Dolor: `$dolor`...

--- a/tests/Integration/tests/markdown/inline-code-md/input/skip
+++ b/tests/Integration/tests/markdown/inline-code-md/input/skip
@@ -1,0 +1,1 @@
+Inline Code in Markdown is not supported yet

--- a/tests/Integration/tests/markdown/inline-code-md/input/skip
+++ b/tests/Integration/tests/markdown/inline-code-md/input/skip
@@ -1,1 +1,0 @@
-Inline Code in Markdown is not supported yet

--- a/tests/Integration/tests/markdown/link-md/expected/index.html
+++ b/tests/Integration/tests/markdown/link-md/expected/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Markdown with links - Project Title</title>
+
+</head>
+<body>
+    <h1>Markdown with links</h1>
+
+<p>This is a Markdown document with some basic formatting.</p>
+<p>See also: <a href="https://www.example.com">Link Text</a></p>
+</body>
+</html>

--- a/tests/Integration/tests/markdown/link-md/input/guides.xml
+++ b/tests/Integration/tests/markdown/link-md/input/guides.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd"
+        input-format="md"
+>
+    <project title="Project Title" version="6.4"/>
+</guides>

--- a/tests/Integration/tests/markdown/link-md/input/index.md
+++ b/tests/Integration/tests/markdown/link-md/input/index.md
@@ -1,0 +1,5 @@
+# Markdown with links
+
+This is a Markdown document with some basic formatting. 
+
+See also: [Link Text](https://www.example.com) 

--- a/tests/Integration/tests/markdown/lists-md/expected/index.html
+++ b/tests/Integration/tests/markdown/lists-md/expected/index.html
@@ -11,6 +11,6 @@
 <h2>Headings</h2>
 
 <p>You can create headings using hash symbols.</p>
-<p>This text is part of a paragraph under the &quot;Headings&quot; heading.</p>
+<p>This text is part of a paragraph under the "Headings" heading.</p>
 </body>
 </html>

--- a/tests/Integration/tests/markdown/lists-md/expected/index.html
+++ b/tests/Integration/tests/markdown/lists-md/expected/index.html
@@ -1,16 +1,53 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>Markdown Example - Project Title</title>
+    <title>Markdown Lists - Project Title</title>
 
 </head>
 <body>
-    <h1>Markdown Example</h1>
+    <h1>Markdown Lists</h1>
 
-<p>This is a Markdown document with some basic formatting.</p>
-<h2>Headings</h2>
+<h2>Unordered</h2>
 
-<p>You can create headings using hash symbols.</p>
-<p>This text is part of a paragraph under the "Headings" heading.</p>
+
+
+<ul>
+    <li class="dash"><p>Item 1</p></li>
+
+    <li class="dash"><p>Item 2</p>
+
+<ul>
+    <li class="dash"><p>Subitem A</p></li>
+
+    <li class="dash"><p>Subitem B</p></li>
+
+</ul>
+</li>
+
+    <li class="dash"><p>Item 3</p></li>
+
+</ul>
+
+<h2>Ordered</h2>
+
+
+    
+<ol>
+    <li><p>First item</p></li>
+
+    <li><p>Second item</p>
+    
+<ol>
+    <li><p>Subitem A</p></li>
+
+    <li><p>Subitem B</p></li>
+
+</ol>
+</li>
+
+    <li><p>Third item</p></li>
+
+</ol>
+
 </body>
 </html>

--- a/tests/Integration/tests/markdown/lists-md/input/guides.xml
+++ b/tests/Integration/tests/markdown/lists-md/input/guides.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd"
+        input-format="md"
+>
+    <project title="Project Title" version="6.4"/>
+</guides>

--- a/tests/Integration/tests/markdown/lists-md/input/index.md
+++ b/tests/Integration/tests/markdown/lists-md/input/index.md
@@ -1,0 +1,16 @@
+# Markdown Lists
+## Unordered
+
+- Item 1
+- Item 2
+    - Subitem A
+    - Subitem B
+- Item 3
+
+## Ordered
+
+1. First item
+2. Second item
+    1. Subitem A
+    2. Subitem B
+3. Third item

--- a/tests/Integration/tests/markdown/lists-md/input/skip
+++ b/tests/Integration/tests/markdown/lists-md/input/skip
@@ -1,0 +1,1 @@
+Lists in Markdown are not supported yet

--- a/tests/Integration/tests/markdown/lists-md/input/skip
+++ b/tests/Integration/tests/markdown/lists-md/input/skip
@@ -1,1 +1,0 @@
-Lists in Markdown are not supported yet

--- a/tests/Integration/tests/markdown/readme-md/expected/index.html
+++ b/tests/Integration/tests/markdown/readme-md/expected/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Markdown Example - Project Title</title>
+
+</head>
+<body>
+    <h1>Markdown Example</h1>
+
+<p>This is a Markdown document with some basic formatting.</p>
+<h2>Headings</h2>
+
+<p>You can create headings using hash symbols.</p>
+<p>This text is part of a paragraph under the "Headings" heading.</p>
+</body>
+</html>

--- a/tests/Integration/tests/markdown/readme-md/expected/index.html
+++ b/tests/Integration/tests/markdown/readme-md/expected/index.html
@@ -1,16 +1,122 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>Markdown Example - Project Title</title>
+    <title>Child&#039;s Swing Usage Guide - Project Title</title>
 
 </head>
 <body>
-    <h1>Markdown Example</h1>
+    <h1>Child&#039;s Swing Usage Guide</h1>
 
-<p>This is a Markdown document with some basic formatting.</p>
-<h2>Headings</h2>
+<p>Welcome to the world of fun and laughter with our child&#039;s swing! Follow thesimple steps below to ensure a safe and enjoyable experience for your littleone.</p>
+<h2>Table of Contents</h2>
 
-<p>You can create headings using hash symbols.</p>
-<p>This text is part of a paragraph under the "Headings" heading.</p>
+
+
+<ul>
+    <li class="dash"><p><a href="#installation">Installation</a></p></li>
+
+    <li class="dash"><p><a href="#usage">Usage</a></p></li>
+
+    <li class="dash"><p><a href="#safety-guidelines">Safety Guidelines</a></p></li>
+
+    <li class="dash"><p><a href="#maintenance">Maintenance</a></p></li>
+
+    <li class="dash"><p><a href="#troubleshooting">Troubleshooting</a></p></li>
+
+</ul>
+
+<hr />
+
+<h2>Installation</h2>
+
+<p><img src="https://upload.wikimedia.org/wikipedia/commons/a/a3/Forgiveness_5.gif" alt="Swing Image"/></p>
+
+    
+<ol>
+    <li><p><strong>Choose a Sturdy Location:</strong> Select a location with a sturdy beam or swingset structure capable of supporting the weight of the swing and the child.</p></li>
+
+    <li><p><strong>Securely Attach the Swing:</strong> Use strong and reliable <a href="https://example.com/ropes">ropes</a>or chains to securely attach the swing to the chosen location. Double-checkthe knots or hardware to ensure they are tight and safe.</p></li>
+
+    <li><p><strong>Adjust the Height:</strong> Adjust the height of the swing to a level that iscomfortable for your child. Ensure that it is not too high or too low.</p></li>
+
+</ol>
+
+<h2>Usage</h2>
+
+
+    
+<ol>
+    <li><p><strong>Place the Child in the Swing:</strong> Gently place your child in the swing seat,ensuring they are properly seated and secure.</p></li>
+
+    <li><p><strong>Hold onto the Swing:</strong> Provide support and hold onto the swing until yourchild is comfortably seated and ready to swing.</p></li>
+
+    <li><p><strong>Start Swinging:</strong> Give a gentle push to start the swinging motion. Observeyour child&#039;s comfort level and adjust the swinging speed accordingly.</p><pre><code class="language-">procedure startSwinging(swing, child)
+    while child.isComfortable()
+        swing.giveGentlePush()
+        waitForNextIteration()
+    end while
+end procedure
+
+</code></pre></li>
+
+    <li><p><strong>Supervise Always:</strong> Always supervise your child while they are using theswing. Ensure they are using it safely and within the recommended age and weightlimits.</p></li>
+
+</ol>
+
+<blockquote><p>&quot;Swinging is not just a physical activity; it&#039;s a journey into the world ofimagination and joy.&quot;</p></blockquote>
+
+<h3>Additional Tips:</h3>
+
+
+
+<ul>
+    <li class="dash"><p>Bring your child&#039;s favorite toys to make swinging even more enjoyable.</p></li>
+
+    <li class="dash"><p>Consider creating a soft landing area with cushions or grass underneath the swing.</p></li>
+
+</ul>
+
+<h2>Safety Guidelines</h2>
+
+
+    
+<ol>
+    <li><p><strong>Check Hardware Regularly:</strong> Periodically inspect the ropes or chains, aswell as any hardware used to attach the swing. Replace any damaged or worn-outparts immediately.</p></li>
+
+    <li><p><strong>Set Age and Weight Limits:</strong> Follow the manufacturer&#039;s recommended age andweight limits for the swing. Do not exceed these limits to ensure safety.</p></li>
+
+    <li><p><strong>Use Proper Attire:</strong> Encourage your child to wear appropriate clothing,including closed-toe shoes, to prevent any injuries.</p></li>
+
+    <li><p><strong>No Rough Play:</strong> Instruct your child not to engage in rough play or attemptto stand up in the swing.</p></li>
+
+</ol>
+
+<h2>Maintenance</h2>
+
+
+    
+<ol>
+    <li><p><strong>Clean the Swing:</strong> Wipe down the swing seat regularly to keep it clean andfree from dirt or debris.</p></li>
+
+    <li><p><strong>Inspect for Wear:</strong> Check the swing&#039;s components for signs of wear ordamage. Replace any worn-out parts promptly.</p></li>
+
+    <li><p><strong>Tighten Loose Hardware:</strong> Ensure that all nuts and bolts are securelytightened to maintain stability.</p></li>
+
+</ol>
+
+<h2>Troubleshooting</h2>
+
+
+
+<ul>
+    <li class="dash"><p><strong>Swing Doesn&#039;t Move Smoothly:</strong> Check for any knots or tangles in the ropesor chains. Untangle and ensure a smooth swinging motion.</p></li>
+
+    <li class="dash"><p><strong>Unusual Sounds:</strong> If you hear any creaking or unusual sounds, inspect thehardware for any loose or damaged parts.</p><p>If you hear screaming or crying, untangle the child.</p></li>
+
+    <li class="dash"><p><strong>Uneven Swinging:</strong> Adjust the height of the swing to achieve a balanced andeven swinging motion.</p></li>
+
+</ul>
+
+<p>Remember, safety first! Enjoy your time on the swing with your little one.</p>
 </body>
 </html>

--- a/tests/Integration/tests/markdown/readme-md/input/guides.xml
+++ b/tests/Integration/tests/markdown/readme-md/input/guides.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd"
+        input-format="md"
+>
+    <project title="Project Title" version="6.4"/>
+</guides>

--- a/tests/Integration/tests/markdown/readme-md/input/index.md
+++ b/tests/Integration/tests/markdown/readme-md/input/index.md
@@ -1,0 +1,99 @@
+# Child's Swing Usage Guide
+
+Welcome to the world of fun and laughter with our child's swing! Follow the
+simple steps below to ensure a safe and enjoyable experience for your little
+one.
+
+## Table of Contents
+- [Installation](#installation)
+- [Usage](#usage)
+- [Safety Guidelines](#safety-guidelines)
+- [Maintenance](#maintenance)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Installation
+
+![Swing Image](https://example.com/swing-image.jpg)
+
+1. **Choose a Sturdy Location:** Select a location with a sturdy beam or swing
+   set structure capable of supporting the weight of the swing and the child.
+
+2. **Securely Attach the Swing:** Use strong and reliable [ropes](https://example.com/ropes)
+   or chains to securely attach the swing to the chosen location. Double-check
+   the knots or hardware to ensure they are tight and safe.
+
+3. **Adjust the Height:** Adjust the height of the swing to a level that is
+   comfortable for your child. Ensure that it is not too high or too low.
+
+## Usage
+
+1. **Place the Child in the Swing:** Gently place your child in the swing seat,
+   ensuring they are properly seated and secure.
+
+2. **Hold onto the Swing:** Provide support and hold onto the swing until your
+   child is comfortably seated and ready to swing.
+
+3. **Start Swinging:** Give a gentle push to start the swinging motion. Observe
+   your child's comfort level and adjust the swinging speed accordingly.
+
+   ```pseudocode
+   procedure startSwinging(swing, child)
+       while child.isComfortable()
+           swing.giveGentlePush()
+           waitForNextIteration()
+       end while
+   end procedure
+
+4. **Supervise Always:** Always supervise your child while they are using the
+   swing. Ensure they are using it safely and within the recommended age and weight
+   limits.
+
+> "Swinging is not just a physical activity; it's a journey into the world of
+> imagination and joy."
+
+### Additional Tips:
+- Bring your child's favorite toys to make swinging even more enjoyable.
+- Consider creating a soft landing area with cushions or grass underneath the swing.
+
+## Safety Guidelines
+
+1. **Check Hardware Regularly:** Periodically inspect the ropes or chains, as
+   well as any hardware used to attach the swing. Replace any damaged or worn-out
+   parts immediately.
+
+2. **Set Age and Weight Limits:** Follow the manufacturer's recommended age and
+   weight limits for the swing. Do not exceed these limits to ensure safety.
+
+3. **Use Proper Attire:** Encourage your child to wear appropriate clothing,
+   including closed-toe shoes, to prevent any injuries.
+
+4. **No Rough Play:** Instruct your child not to engage in rough play or attempt
+   to stand up in the swing.
+
+## Maintenance
+
+1. **Clean the Swing:** Wipe down the swing seat regularly to keep it clean and
+   free from dirt or debris.
+
+2. **Inspect for Wear:** Check the swing's components for signs of wear or
+   damage. Replace any worn-out parts promptly.
+
+3. **Tighten Loose Hardware:** Ensure that all nuts and bolts are securely
+   tightened to maintain stability.
+
+## Troubleshooting
+
+- **Swing Doesn't Move Smoothly:** Check for any knots or tangles in the ropes
+  or chains. Untangle and ensure a smooth swinging motion.
+
+- **Unusual Sounds:** If you hear any creaking or unusual sounds, inspect the
+  hardware for any loose or damaged parts.
+
+  If you hear screaming or crying, untangle the child.
+
+- **Uneven Swinging:** Adjust the height of the swing to achieve a balanced and
+  even swinging motion.
+
+Remember, safety first! Enjoy your time on the swing with your little one.

--- a/tests/Integration/tests/markdown/readme-md/input/index.md
+++ b/tests/Integration/tests/markdown/readme-md/input/index.md
@@ -15,7 +15,7 @@ one.
 
 ## Installation
 
-![Swing Image](https://example.com/swing-image.jpg)
+![Swing Image](https://upload.wikimedia.org/wikipedia/commons/a/a3/Forgiveness_5.gif)
 
 1. **Choose a Sturdy Location:** Select a location with a sturdy beam or swing
    set structure capable of supporting the weight of the swing and the child.

--- a/tests/Integration/tests/markdown/readme-md/input/skip
+++ b/tests/Integration/tests/markdown/readme-md/input/skip
@@ -1,0 +1,1 @@
+Lists in Markdown are not supported yet

--- a/tests/Integration/tests/markdown/readme-md/input/skip
+++ b/tests/Integration/tests/markdown/readme-md/input/skip
@@ -1,1 +1,0 @@
-Lists in Markdown are not supported yet


### PR DESCRIPTION
Most basic block and inline formats are covered now.

Markdown - different from rst - allows nested inline elements (a strong text that is also emphasized, link texts with inline code, ...) Our nodes can currently not store such information therefore we cannot support them currently.

Images are considered inline in Markdown and can appear within texts while images in rst are block level elements. I therefore had to introduce a new Node Type for inline images.

League\CommonMark Does not seem to support line-breaks (https://www.markdownguide.org/basic-syntax/#line-breaks) so these are also missing.

I did not implement https://www.markdownguide.org/basic-syntax/#html due to the security concerns.