### PR TITLE
FEAT: only set default command with signle command app

### DIFF
--- a/packages/guides-cli/src/Application.php
+++ b/packages/guides-cli/src/Application.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 
+use function count;
 use function getcwd;
 
 final class Application extends BaseApplication
@@ -20,6 +21,10 @@ final class Application extends BaseApplication
 
         foreach ($commands as $command) {
             $this->add($command);
+        }
+
+        if (count($commands) !== 1) {
+            return;
         }
 
         $this->setDefaultCommand($defaultCommand, true);


### PR DESCRIPTION
Extensions can provide extra commands, in that case we do not want to be a single command application. So do not configure that when multiple commands are set.