### PR TITLE
[TASK] Make configuration less complex

### DIFF
--- a/packages/guides-cli/resources/schema/guides.xsd
+++ b/packages/guides-cli/resources/schema/guides.xsd
@@ -13,6 +13,8 @@
             <xsd:element name="theme" type="theme" minOccurs="0" maxOccurs="unbounded"/>
             <xsd:element name="extension" type="extension" minOccurs="0" maxOccurs="unbounded"/>
             <xsd:element name="output-format" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element name="inventory" type="inventory" minOccurs="1" maxOccurs="unbounded"/>
+            <xsd:element name="template" type="template" minOccurs="1" maxOccurs="unbounded"/>
         </xsd:choice>
 
         <xsd:attribute name="input" type="xsd:string"/>
@@ -24,6 +26,7 @@
         <xsd:attribute name="show-progress" type="xsd:string"/>
         <xsd:attribute name="theme" type="xsd:string"/>
         <xsd:attribute name="default-code-language" type="xsd:string"/>
+
     </xsd:complexType>
 
     <xsd:complexType name="extension">
@@ -50,15 +53,9 @@
         <xsd:attribute name="extends" type="xsd:string"/>
     </xsd:complexType>
 
-    <xsd:complexType name="inventories">
-        <xsd:sequence>
-            <xsd:element name="inventory" type="inventory" minOccurs="1" maxOccurs="unbounded"/>
-        </xsd:sequence>
-    </xsd:complexType>
-
     <xsd:complexType name="inventory">
-        <xsd:attribute name="name" type="xsd:string" use="required"/>
-        <xsd:attribute name="path" type="xsd:string" use="required"/>
+        <xsd:attribute name="id" type="xsd:string" use="required"/>
+        <xsd:attribute name="url" type="xsd:string" use="required"/>
     </xsd:complexType>
 
     <xsd:complexType name="template">

--- a/packages/guides-cli/src/Command/Run.php
+++ b/packages/guides-cli/src/Command/Run.php
@@ -17,7 +17,6 @@ use phpDocumentor\Guides\Handlers\CompileDocumentsCommand;
 use phpDocumentor\Guides\Handlers\ParseDirectoryCommand;
 use phpDocumentor\Guides\Handlers\ParseFileCommand;
 use phpDocumentor\Guides\Handlers\RenderCommand;
-use phpDocumentor\Guides\Interlink\InventoryRepository;
 use phpDocumentor\Guides\Nodes\ProjectNode;
 use phpDocumentor\Guides\Settings\ProjectSettings;
 use phpDocumentor\Guides\Settings\SettingsManager;
@@ -50,7 +49,6 @@ final class Run extends Command
         private readonly Logger $logger,
         private readonly ThemeManager $themeManager,
         private readonly SettingsManager $settingsManager,
-        private readonly InventoryRepository $inventoryRepository,
     ) {
         parent::__construct('run');
 
@@ -175,7 +173,6 @@ final class Run extends Command
             $settings->getTitle() === '' ? null : $settings->getTitle(),
             $settings->getVersion() === '' ? null : $settings->getVersion(),
         );
-        $this->inventoryRepository->initialize($settings->getInventories());
 
         $outputDir = $this->getAbsolutePath($settings->getOutput());
         $sourceFileSystem = new Filesystem(new Local($settings->getInput()));

--- a/packages/guides/resources/config/guides.php
+++ b/packages/guides/resources/config/guides.php
@@ -114,6 +114,7 @@ return static function (ContainerConfigurator $container): void {
         ->set(DocumentNodeTraverser::class)
 
         ->set(InventoryRepository::class)
+        ->arg('$inventoryConfigs', param('phpdoc.guides.inventories'))
 
         ->set(InventoryLoader::class)
 

--- a/packages/guides/src/DependencyInjection/GuidesExtension.php
+++ b/packages/guides/src/DependencyInjection/GuidesExtension.php
@@ -41,6 +41,7 @@ class GuidesExtension extends Extension implements CompilerPassInterface, Config
 
         $rootNode
             ->fixXmlConfig('template')
+            ->fixXmlConfig('inventory', 'inventories')
             ->children()
                 ->arrayNode('project')
                     ->children()
@@ -49,13 +50,13 @@ class GuidesExtension extends Extension implements CompilerPassInterface, Config
                     ->end()
                 ->end()
                 ->arrayNode('inventories')
-                    ->children()
-                        ->arrayNode('inventory')
-                            ->arrayPrototype()
-                                ->children()
-                                    ->scalarNode('id')->end()
-                                    ->scalarNode('url')->end()
-                                ->end()
+                    ->arrayPrototype()
+                        ->children()
+                            ->scalarNode('id')
+                                ->isRequired()
+                            ->end()
+                                ->scalarNode('url')
+                                ->isRequired()
                             ->end()
                         ->end()
                     ->end()
@@ -144,7 +145,7 @@ class GuidesExtension extends Extension implements CompilerPassInterface, Config
         }
 
         if (isset($config['inventories'])) {
-            $projectSettings->setInventories($config['inventories']['inventory']);
+            $projectSettings->setInventories($config['inventories']);
         }
 
         if (isset($config['theme'])) {
@@ -199,6 +200,7 @@ class GuidesExtension extends Extension implements CompilerPassInterface, Config
         $config['base_template_paths'][] = dirname(__DIR__, 2) . '/resources/template/tex';
         $container->setParameter('phpdoc.guides.base_template_paths', $config['base_template_paths']);
         $container->setParameter('phpdoc.guides.node_templates', $config['templates']);
+        $container->setParameter('phpdoc.guides.inventories', $config['inventories']);
 
         foreach ($config['themes'] as $themeName => $themeConfig) {
             $container->getDefinition(ThemeManager::class)

--- a/packages/guides/src/Interlink/InventoryRepository.php
+++ b/packages/guides/src/Interlink/InventoryRepository.php
@@ -14,14 +14,11 @@ class InventoryRepository
     /** @var array<string, Inventory>  */
     private array $inventories = [];
 
-    public function __construct(private readonly InventoryLoader $inventoryLoader)
-    {
-    }
-
     /** @param array<int, array<string, string>> $inventoryConfigs */
-    public function initialize(array $inventoryConfigs): void
-    {
-        $this->inventories = [];
+    public function __construct(
+        private readonly InventoryLoader $inventoryLoader,
+        array $inventoryConfigs,
+    ) {
         foreach ($inventoryConfigs as $inventory) {
             $this->inventories[$inventory['id']] = new Inventory($inventory['url']);
         }

--- a/packages/guides/tests/unit/Interlink/InventoryLoaderTest.php
+++ b/packages/guides/tests/unit/Interlink/InventoryLoaderTest.php
@@ -26,7 +26,7 @@ final class InventoryLoaderTest extends TestCase
     {
         $this->jsonLoader = $this->createMock(JsonLoader::class);
         $this->inventoryLoader = new InventoryLoader($this->jsonLoader);
-        $this->inventoryRepository = new InventoryRepository($this->inventoryLoader);
+        $this->inventoryRepository = new InventoryRepository($this->inventoryLoader, []);
         $jsonString = file_get_contents(__DIR__ . '/input/objects.inv.json');
         assertIsString($jsonString);
         $this->json = (array) json_decode($jsonString, true, 512, JSON_THROW_ON_ERROR);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,11 +21,6 @@ parameters:
 			path: packages/guides-cli/src/Command/Run.php
 
 		-
-			message: "#^Parameter \\#1 \\$inventoryConfigs of method phpDocumentor\\\\Guides\\\\Interlink\\\\InventoryRepository\\:\\:initialize\\(\\) expects array\\<int, array\\<string, string\\>\\>, array\\<string, string\\> given\\.$#"
-			count: 1
-			path: packages/guides-cli/src/Command/Run.php
-
-		-
 			message: "#^Parameter \\#1 \\$iterable of method Symfony\\\\Component\\\\Console\\\\Helper\\\\ProgressBar\\:\\:iterate\\(\\) expects iterable, mixed given\\.$#"
 			count: 1
 			path: packages/guides-cli/src/Command/Run.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.15.0@5c774aca4746caf3d239d9c8cadb9f882ca29352">
-  <file src="packages/guides-cli/src/Command/Run.php">
-    <InvalidArgument>
-      <code><![CDATA[$settings->getInventories()]]></code>
-    </InvalidArgument>
-  </file>
   <file src="packages/guides-cli/src/Config/Configuration.php">
     <UndefinedMethod>
       <code>ignoreExtraKeys</code>

--- a/tests/Integration/tests/meta/settings/input/guides.xml
+++ b/tests/Integration/tests/meta/settings/input/guides.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <guides>
     <project title="My Project" version="3.1.4" />
-    <inventories>
-        <inventory id="t3coreapi" url="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/" />
-        <inventory id="t3home" url="https://docs.typo3.org/" />
-    </inventories>
+    <inventory id="t3coreapi" url="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/" />
+    <inventory id="t3home" url="https://docs.typo3.org/" />
 </guides>

--- a/tests/Integration/tests/navigation/intersphinx-link/input/guides.xml
+++ b/tests/Integration/tests/navigation/intersphinx-link/input/guides.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <guides>
     <project title="My Project" version="main (development)" />
-    <inventories>
-        <inventory id="t3coreapi" url="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/" />
-        <inventory id="someapi" url="https://docs.typo3.org/m/typo3/reference-someapi/main/en-us/" />
-    </inventories>
+    <inventory id="t3coreapi" url="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/" />
+    <inventory id="someapi" url="https://docs.typo3.org/m/typo3/reference-someapi/main/en-us/" />
 </guides>

--- a/tests/Integration/tests/navigation/intersphinx-numeric/input/guides.xml
+++ b/tests/Integration/tests/navigation/intersphinx-numeric/input/guides.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <guides>
     <project title="My Project" version="main (development)" />
-    <inventories>
-        <inventory id="t3coreapi" url="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/" />
-        <inventory id="t3home" url="https://docs.typo3.org/" />
-    </inventories>
+    <inventory id="t3coreapi" url="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/" />
+    <inventory id="t3home" url="https://docs.typo3.org/" />
 </guides>


### PR DESCRIPTION
By allowing the inventories at the root of our configuration we are more following the standard way of configuring an application in symfony. This will help us to support other configuration formats if we want to.

By moving the initialization of the inventory repository to a parameter extensions can now provide inventories. This could be usefull for non sphinx documentation sets, but still using the interlink functionality. For example when we create a extension that links to the php documentation.