### PR TITLE
[FIX] support single document rendering

### DIFF
--- a/packages/guides/resources/config/guides.php
+++ b/packages/guides/resources/config/guides.php
@@ -17,7 +17,6 @@ use phpDocumentor\Guides\NodeRenderers\Html\DocumentNodeRenderer;
 use phpDocumentor\Guides\NodeRenderers\Html\MenuEntryRenderer;
 use phpDocumentor\Guides\NodeRenderers\Html\MenuNodeRenderer;
 use phpDocumentor\Guides\NodeRenderers\Html\TableNodeRenderer;
-use phpDocumentor\Guides\NodeRenderers\NodeRendererFactoryAware;
 use phpDocumentor\Guides\NodeRenderers\OutputAwareDelegatingNodeRenderer;
 use phpDocumentor\Guides\Parser;
 use phpDocumentor\Guides\ReferenceResolvers\AnchorReducer;
@@ -68,9 +67,6 @@ return static function (ContainerConfigurator $container): void {
         ->autowire()
         ->autoconfigure()
 
-        ->instanceof(NodeRendererFactoryAware::class)
-        ->tag('phpdoc.guides.noderendererfactoryaware')
-
         ->instanceof(CompilerPass::class)
         ->tag('phpdoc.guides.compiler.passes')
 
@@ -88,11 +84,6 @@ return static function (ContainerConfigurator $container): void {
         ->load(
             'phpDocumentor\\Guides\\Compiler\\Passes\\',
             '%vendor_dir%/phpdocumentor/guides/src/Compiler/Passes/*Pass.php',
-        )
-
-        ->load(
-            'phpDocumentor\\Guides\\NodeRenderers\\',
-            '%vendor_dir%/phpdocumentor/guides/src/NodeRenderers',
         )
 
         ->set(AbsoluteUrlGenerator::class)

--- a/packages/guides/src/DependencyInjection/Compiler/RendererPass.php
+++ b/packages/guides/src/DependencyInjection/Compiler/RendererPass.php
@@ -20,22 +20,7 @@ final class RendererPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        //Node Renderer factory
-
-        //Inject node renderer factory into node renderer factory aware services
-
-
         $definitions = [];
-
-        foreach ($container->findTaggedServiceIds('phpdoc.guides.noderendererfactoryaware') as $id => $tags) {
-            $definition = $container->getDefinition($id);
-            $definition->addMethodCall(
-                'setNodeRendererFactory',
-                [new Reference('phpdoc.guides.noderenderer.factory.html')],
-            );
-            $definition->clearTag('phpdoc.guides.noderendererfactoryaware');
-        }
-
         foreach ($container->findTaggedServiceIds('phpdoc.renderer.typerenderer') as $id => $tags) {
             foreach ($tags as $tag) {
                 if (isset($tag['noderender_tag']) === false) {
@@ -46,7 +31,8 @@ final class RendererPass implements CompilerPassInterface
                 $definitions[sprintf('phpdoc.guides.noderenderer.prefactory.%s', $tag['format'])] = $this->createPreNodeRendererFactory($tag);
                 $definitions[sprintf('phpdoc.guides.noderenderer.delegating.%s', $tag['format'])] = $this->createDelegatingNodeRender($tag);
                 $definitions[sprintf('phpdoc.guides.noderenderer.default.%s', $tag['format'])] = (new Definition(DefaultNodeRenderer::class))->setAutowired(true)
-                    ->addTag('phpdoc.guides.noderenderer.html');
+                    ->addMethodCall('setNodeRendererFactory', [new Reference(sprintf('phpdoc.guides.noderenderer.factory.%s', $tag['format']))])
+                    ->addTag(sprintf('phpdoc.guides.noderenderer.%s', $tag['format']));
             }
         }
 

--- a/packages/guides/src/NodeRenderers/DelegatingNodeRenderer.php
+++ b/packages/guides/src/NodeRenderers/DelegatingNodeRenderer.php
@@ -14,6 +14,10 @@ final class DelegatingNodeRenderer implements NodeRenderer, NodeRendererFactoryA
 
     public function setNodeRendererFactory(NodeRendererFactory $nodeRendererFactory): void
     {
+        if (isset($this->nodeRendererFactory)) {
+            return;
+        }
+
         $this->nodeRendererFactory = $nodeRendererFactory;
     }
 

--- a/packages/guides/src/RenderContext.php
+++ b/packages/guides/src/RenderContext.php
@@ -64,6 +64,19 @@ class RenderContext
         return $self;
     }
 
+    public function withDocument(DocumentNode $documentNode): self
+    {
+        return self::forDocument(
+            $documentNode,
+            $this->allDocuments,
+            $this->origin,
+            $this->destination,
+            $this->destinationPath,
+            $this->outputFormat,
+            $this->projectNode,
+        );
+    }
+
     /** @param DocumentNode[] $allDocumentNodes */
     public static function forProject(
         ProjectNode $projectNode,


### PR DESCRIPTION
To make it possible to extend the html rendering with a single document we should allow customization of the html rending stack. The easiest way to do this this to add a new renderer that is reusing the delegating renderer from the html part. By allowing extensions to define their own delegating renderer with a factory set, we can switch towards another stack.

This is a rather complex use case, which we do not support out of the box but needed for typo3.