### PR TITLE
[BUGFIX] Check Document EntryRoot respecting case sensitivity on macOS

### DIFF
--- a/packages/guides/src/Handlers/ParseDirectoryHandler.php
+++ b/packages/guides/src/Handlers/ParseDirectoryHandler.php
@@ -62,9 +62,10 @@ final class ParseDirectoryHandler
         // from the filesystem.
         $contentFromFilesystem = $filesystem->listContents($directory);
         $hashedContentFromFilesystem = [];
-        foreach($contentFromFilesystem AS $itemFromFilesystem) {
+        foreach ($contentFromFilesystem as $itemFromFilesystem) {
             $hashedContentFromFilesystem[$itemFromFilesystem['basename']] = true;
         }
+
         foreach (self::INDEX_FILE_NAMES as $indexName) {
             $indexFilename = sprintf('%s.%s', $indexName, $extension);
             if (isset($hashedContentFromFilesystem[$indexFilename])) {


### PR DESCRIPTION
On macOS filesystems, a file-check against "index.rst" using $filesystem->has() would return TRUE, when in fact a file might be stored as "Index.rst". Thus, at this point we fetch the whole directory list and compare the contents with if the INDEX_FILE_NAMES entry matches. This ensures that we get the file with exactly the casing that is returned from the filesystem.

Background:

Given a file called "Index.rst" exists on macOS, executing this script:

```
<?php
echo (file_exists('Index.rst') ? 'Index.rst exists!' : 'Index.rst missing.') . "\n";
echo (file_exists('index.rst') ? 'index.rst exists!' : 'index.rst missing') . "\n";
```

will yield:

```
Index.rst exists!
index.rst exists!
```

but in fact, "index.rst" does not exist. macOS does this by default to prevent case sensitivity issues on the Application-level. In macOS, if a "index.rst" exists, another file called "Index.rst" may NOT exist.

Sadly, also PHP's realpath() does not yield the "true" filename of a saved file, so there is no way to deduce the real casing of a file, unless the directory contents are read.

I made a performance benchmark to test the implications of this change.

Funnily, it does not affect speed in a negative way - in fact it sped up the process for me. I created 27.000 directories with one file in them, one directory with 16.000 files and one with 6.000 files.

Average runtime on 5 executions on a macBook M1, no other tasks running:

* Without patch (baseline): 419.67s user 10.27s system 99% cpu 7:13.64 total
* With path:                419.38s user 11.07s system 98% cpu 7:14.98 total

So the impact seems to be within usual fault tolerance.

Resolves: https://github.com/TYPO3-Documentation/render-guides/issues/53