### PR TITLE
!!![FEATURE] add document iterator

### DIFF
--- a/packages/guides/src/Handlers/RenderCommand.php
+++ b/packages/guides/src/Handlers/RenderCommand.php
@@ -7,22 +7,29 @@ namespace phpDocumentor\Guides\Handlers;
 use League\Flysystem\FilesystemInterface;
 use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\Nodes\ProjectNode;
+use phpDocumentor\Guides\Renderer\DocumentListIterator;
+use phpDocumentor\Guides\Renderer\DocumentTreeIterator;
 
 final class RenderCommand
 {
-    /**
-     * @param DocumentNode[] $documentArray
-     * @param iterable<DocumentNode> $documentIterator
-     */
+    private DocumentListIterator $documentIterator;
+
+    /** @param DocumentNode[] $documentArray */
     public function __construct(
         private readonly string $outputFormat,
         private readonly array $documentArray,
-        private readonly iterable $documentIterator,
         private readonly FilesystemInterface $origin,
         private readonly FilesystemInterface $destination,
         private readonly ProjectNode $projectNode,
         private readonly string $destinationPath = '/',
     ) {
+        $this->documentIterator = new DocumentListIterator(
+            new DocumentTreeIterator(
+                [$this->projectNode->getRootDocumentEntry()],
+                $this->documentArray,
+            ),
+            $this->documentArray,
+        );
     }
 
     public function getOutputFormat(): string
@@ -36,8 +43,7 @@ final class RenderCommand
         return $this->documentArray;
     }
 
-    /** @return iterable<DocumentNode> $documentIterator */
-    public function getDocumentIterator(): iterable
+    public function getDocumentIterator(): DocumentListIterator
     {
         return $this->documentIterator;
     }

--- a/packages/guides/src/RenderContext.php
+++ b/packages/guides/src/RenderContext.php
@@ -29,6 +29,8 @@ class RenderContext
     /** @var DocumentNode[] */
     private array $allDocuments;
 
+    private Renderer\DocumentListIterator $iterator;
+
     private function __construct(
         private readonly string $destinationPath,
         private readonly string|null $currentFileName,
@@ -75,6 +77,14 @@ class RenderContext
             $this->outputFormat,
             $this->projectNode,
         );
+    }
+
+    public function withIterator(Renderer\DocumentListIterator $iterator): self
+    {
+        $that = clone $this;
+        $that->iterator = $iterator;
+
+        return $that;
     }
 
     /** @param DocumentNode[] $allDocumentNodes */
@@ -191,5 +201,10 @@ class RenderContext
     public function getOutputFormat(): string
     {
         return $this->outputFormat;
+    }
+
+    public function getIterator(): Renderer\DocumentListIterator
+    {
+        return $this->iterator;
     }
 }

--- a/packages/guides/src/Renderer/BaseTypeRenderer.php
+++ b/packages/guides/src/Renderer/BaseTypeRenderer.php
@@ -17,19 +17,20 @@ abstract class BaseTypeRenderer implements TypeRenderer
 
     public function render(RenderCommand $renderCommand): void
     {
-        foreach ($renderCommand->getDocumentIterator() as $document) {
+        $context = RenderContext::forProject(
+            $renderCommand->getProjectNode(),
+            $renderCommand->getDocumentArray(),
+            $renderCommand->getOrigin(),
+            $renderCommand->getDestination(),
+            $renderCommand->getDestinationPath(),
+            $renderCommand->getOutputFormat(),
+        )->withIterator($renderCommand->getDocumentIterator());
+
+        foreach ($context->getIterator() as $document) {
             $this->commandBus->handle(
                 new RenderDocumentCommand(
                     $document,
-                    RenderContext::forDocument(
-                        $document,
-                        $renderCommand->getDocumentArray(),
-                        $renderCommand->getOrigin(),
-                        $renderCommand->getDestination(),
-                        $renderCommand->getDestinationPath(),
-                        $renderCommand->getOutputFormat(),
-                        $renderCommand->getProjectNode(),
-                    ),
+                    $context->withDocument($document),
                 ),
             );
         }

--- a/packages/guides/src/Renderer/DocumentListIterator.php
+++ b/packages/guides/src/Renderer/DocumentListIterator.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Renderer;
+
+use AppendIterator;
+use Generator;
+use Iterator;
+use phpDocumentor\Guides\Nodes\DocumentNode;
+use RecursiveIteratorIterator;
+use WeakMap;
+use WeakReference;
+
+/** @implements Iterator<array-key, DocumentNode> */
+final class DocumentListIterator implements Iterator
+{
+    /** @var WeakReference<DocumentNode>|null */
+    private WeakReference|null $previousDocument;
+
+    /** @var WeakReference<DocumentNode>|null */
+    private WeakReference|null $nextDocument;
+
+    /** @var WeakMap<DocumentNode, bool> */
+    private WeakMap $unseenDocuments;
+
+    /** @var Iterator<array-key, DocumentNode> */
+    private Iterator $innerIterator;
+
+    /** @param DocumentNode[] $documents */
+    public function __construct(
+        DocumentTreeIterator $iterator,
+        array $documents,
+    ) {
+        $this->unseenDocuments = new WeakMap();
+        $this->previousDocument = null;
+        $this->nextDocument = null;
+        $this->innerIterator = new AppendIterator();
+        $this->innerIterator->append(
+            new RecursiveIteratorIterator($iterator, RecursiveIteratorIterator::SELF_FIRST),
+        );
+        $this->innerIterator->append($this->unseenIterator());
+        foreach ($documents as $document) {
+            $this->unseenDocuments[$document] = true;
+        }
+    }
+
+    public function next(): void
+    {
+        if ($this->innerIterator->valid()) {
+            $this->previousDocument = WeakReference::create($this->current());
+        } else {
+            $this->previousDocument = null;
+        }
+
+        if ($this->nextDocument === null) {
+            $this->innerIterator->next();
+        }
+
+        $this->nextDocument = null;
+    }
+
+    public function previousNode(): DocumentNode|null
+    {
+        return $this->previousDocument?->get();
+    }
+
+    public function valid(): bool
+    {
+        if ($this->nextDocument !== null) {
+            return true;
+        }
+
+        return $this->innerIterator->valid();
+    }
+
+    public function nextNode(): DocumentNode|null
+    {
+        $this->innerIterator->next();
+
+        if ($this->innerIterator->valid()) {
+            $this->nextDocument = WeakReference::create($this->current());
+        }
+
+        return $this->nextDocument?->get();
+    }
+
+    public function current(): mixed
+    {
+        $document = $this->innerIterator->current();
+        if ($document instanceof DocumentNode) {
+            $this->unseenDocuments[$document] = false;
+        }
+
+        return $document;
+    }
+
+    public function key(): mixed
+    {
+        return $this->innerIterator->key();
+    }
+
+    public function rewind(): void
+    {
+        foreach ($this->unseenDocuments as $document => $seen) {
+            $this->unseenDocuments[$document] = true;
+        }
+
+        $this->innerIterator->rewind();
+    }
+
+    /** @return Generator<DocumentNode> */
+    private function unseenIterator(): Generator
+    {
+        foreach ($this->unseenDocuments as $document => $seen) {
+            if ($seen === false) {
+                continue;
+            }
+
+            yield $document;
+        }
+    }
+}

--- a/packages/guides/src/Renderer/DocumentTreeIterator.php
+++ b/packages/guides/src/Renderer/DocumentTreeIterator.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Renderer;
+
+use LogicException;
+use phpDocumentor\Guides\Nodes\DocumentNode;
+use phpDocumentor\Guides\Nodes\DocumentTree\DocumentEntryNode;
+use RecursiveIterator;
+
+/**
+ * Iterates over the document tree and returns the documents in the table of contents order.
+ *
+ * @internal This class is not part of the public API of this package and should not be used outside of this package.
+ *
+ * @implements RecursiveIterator<int, DocumentNode>
+ */
+final class DocumentTreeIterator implements RecursiveIterator
+{
+    private int $position = 0;
+
+    /**
+     * @param DocumentEntryNode[] $levelNodes
+     * @param DocumentNode[] $documents
+     */
+    public function __construct(
+        private readonly array $levelNodes,
+        private readonly array $documents,
+    ) {
+    }
+
+    public function current(): DocumentNode
+    {
+        foreach ($this->documents as $document) {
+            if ($document->getDocumentEntry() === $this->levelNodes[$this->position]) {
+                return $document;
+            }
+        }
+
+        throw new LogicException('Could not find document for node');
+    }
+
+    public function next(): void
+    {
+        ++$this->position;
+    }
+
+    public function key(): int
+    {
+        return $this->position;
+    }
+
+    public function valid(): bool
+    {
+        return isset($this->levelNodes[$this->position]);
+    }
+
+    public function rewind(): void
+    {
+        $this->position = 0;
+    }
+
+    public function hasChildren(): bool
+    {
+        return empty($this->levelNodes[$this->position]->getChildren()) === false;
+    }
+
+    public function getChildren(): self|null
+    {
+        return new self($this->levelNodes[$this->position]->getChildren(), $this->documents);
+    }
+}

--- a/packages/guides/src/Renderer/LatexRenderer.php
+++ b/packages/guides/src/Renderer/LatexRenderer.php
@@ -25,7 +25,7 @@ class LatexRenderer implements TypeRenderer
             $renderCommand->getDestination(),
             $renderCommand->getDestinationPath(),
             'tex',
-        );
+        )->withIterator($renderCommand->getDocumentIterator());
 
         $context->getDestination()->put(
             $renderCommand->getDestinationPath() . '/index.tex',
@@ -34,7 +34,7 @@ class LatexRenderer implements TypeRenderer
                 'structure/project.tex.twig',
                 [
                     'project' => $projectNode,
-                    'documents' => $renderCommand->getDocumentIterator(),
+                    'documents' => $context->getIterator(),
                 ],
             ),
         );

--- a/packages/guides/tests/unit/Renderer/DocumentListIteratorTest.php
+++ b/packages/guides/tests/unit/Renderer/DocumentListIteratorTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Renderer;
+
+final class DocumentListIteratorTest extends IteratorTestCase
+{
+    public function testNormalIteration(): void
+    {
+        $iterator = new DocumentListIterator(
+            new DocumentTreeIterator([$this->entry1, $this->entry2], $this->randomOrderedDocuments),
+            $this->randomOrderedDocuments,
+        );
+        $result = [];
+        foreach ($iterator as $document) {
+            $result[] = $document;
+            $iterator->nextNode();
+        }
+
+        self::assertSame(self::documentsToTitle($this->flatDocumentList), self::documentsToTitle($result));
+        self::assertNull($iterator->nextNode());
+        self::assertNull($iterator->previousNode());
+    }
+
+    public function testPreviousStepsBackAtSameLevel(): void
+    {
+        $iterator = new DocumentListIterator(
+            new DocumentTreeIterator([$this->entry1, $this->entry2], $this->randomOrderedDocuments),
+            $this->randomOrderedDocuments,
+        );
+
+        $iterator->next(); // 1
+        $iterator->next(); // 1.1
+        $iterator->next(); // 1.1.1
+
+        self::assertSame('1.1.2', $iterator->current()->getTitle()?->toString());
+        self::assertSame('1.1.1', $iterator->previousNode()?->getTitle()?->toString());
+    }
+
+    public function testNextStepsAtSameLevel(): void
+    {
+        $iterator = new DocumentListIterator(
+            new DocumentTreeIterator([$this->entry1, $this->entry2], $this->randomOrderedDocuments),
+            $this->randomOrderedDocuments,
+        );
+
+        $iterator->next(); // 1
+        $iterator->next(); // 1.1
+
+        self::assertSame('1.1.1', $iterator->current()->getTitle()?->toString());
+        self::assertSame('1.1.2', $iterator->nextNode()?->getTitle()?->toString());
+    }
+
+    public function testPreviousStepsBackToLevelAbove(): void
+    {
+        $iterator = new DocumentListIterator(
+            new DocumentTreeIterator([$this->entry1, $this->entry2], $this->randomOrderedDocuments),
+            $this->randomOrderedDocuments,
+        );
+
+        $iterator->next(); // 1
+        $iterator->next(); // 1.1
+
+        self::assertSame('1.1.1', $iterator->current()->getTitle()?->toString());
+        self::assertSame('1.1', $iterator->previousNode()?->getTitle()?->toString());
+    }
+
+    public function testPreviousStepsBackToDeepestLevelInPreviousNode(): void
+    {
+        $iterator = new DocumentListIterator(
+            new DocumentTreeIterator([$this->entry1, $this->entry2], $this->randomOrderedDocuments),
+            $this->randomOrderedDocuments,
+        );
+
+        $iterator->next(); // 1
+        $iterator->next(); // 1.1
+        $iterator->next(); // 1.1.1
+        $iterator->next(); // 1.1.2
+
+        self::assertSame('2', $iterator->current()->getTitle()?->toString());
+        self::assertSame('1.1.2', $iterator->previousNode()?->getTitle()?->toString());
+    }
+
+    public function testPreviousReturnsNullWhenNoPrevious(): void
+    {
+        $iterator = new DocumentListIterator(
+            new DocumentTreeIterator([$this->entry1, $this->entry2], $this->randomOrderedDocuments),
+            $this->randomOrderedDocuments,
+        );
+
+        self::assertNull($iterator->previousNode()?->getTitle()?->toString());
+    }
+}

--- a/packages/guides/tests/unit/Renderer/DocumentTreeIteratorTest.php
+++ b/packages/guides/tests/unit/Renderer/DocumentTreeIteratorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Renderer;
+
+use phpDocumentor\Guides\Nodes\DocumentNode;
+use RecursiveIteratorIterator;
+
+use function assert;
+
+class DocumentTreeIteratorTest extends IteratorTestCase
+{
+    public function testIterateDocumentStructure(): void
+    {
+        $iterator = new DocumentTreeIterator([$this->entry1, $this->entry2], $this->randomOrderedDocuments);
+        $result = [];
+        foreach (new RecursiveIteratorIterator($iterator, RecursiveIteratorIterator::SELF_FIRST) as $doc) {
+            assert($doc instanceof DocumentNode);
+            $result[] = $doc;
+        }
+
+        self::assertSame(
+            [
+                '1',
+                '1.1',
+                '1.1.1',
+                '1.1.2',
+                '2',
+                '2.1',
+                '2.1.1',
+                '2.1.2',
+                '2.2',
+                '2.3',
+            ],
+            self::documentsToTitle($result),
+        );
+    }
+}

--- a/packages/guides/tests/unit/Renderer/IteratorTestCase.php
+++ b/packages/guides/tests/unit/Renderer/IteratorTestCase.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Renderer;
+
+use phpDocumentor\Guides\Nodes\DocumentNode;
+use phpDocumentor\Guides\Nodes\DocumentTree\DocumentEntryNode;
+use phpDocumentor\Guides\Nodes\InlineCompoundNode;
+use phpDocumentor\Guides\Nodes\SectionNode;
+use phpDocumentor\Guides\Nodes\TitleNode;
+use PHPUnit\Framework\TestCase;
+
+use function array_map;
+use function md5;
+use function shuffle;
+
+abstract class IteratorTestCase extends TestCase
+{
+    protected DocumentEntryNode $entry1;
+    protected DocumentEntryNode $entry2;
+
+    /** @var DocumentNode[] */
+    protected array $flatDocumentList;
+
+    /** @var array|DocumentNode[] */
+    protected array $randomOrderedDocuments;
+
+    protected function setUp(): void
+    {
+        [$this->entry1, $doc1] = $this->createDocumentEntryAndNode('1.rst', '1');
+        [$entry1_1, $doc1_1] = $this->createDocumentEntryAndNode('1/1.rst', '1.1');
+        [$entry1_1_1, $doc1_1_1] = $this->createDocumentEntryAndNode('1/1/1.rst', '1.1.1');
+        [$entry1_1_2, $doc1_1_2] = $this->createDocumentEntryAndNode('1/1/2.rst', '1.1.2');
+        [$this->entry2, $doc2] = $this->createDocumentEntryAndNode('2.rst', '2');
+        [$entry2_1, $doc2_1] = $this->createDocumentEntryAndNode('2/1.rst', '2.1');
+        [$entry2_1_1, $doc2_1_1] = $this->createDocumentEntryAndNode('2/1/1.rst', '2.1.1');
+        [$entry2_1_2, $doc2_1_2] = $this->createDocumentEntryAndNode('2/1/2.rst', '2.1.2');
+        [$entry2_2, $doc2_2] = $this->createDocumentEntryAndNode('2/2.rst', '2.2');
+        [$entry2_3, $doc2_3] = $this->createDocumentEntryAndNode('2/3.rst', '2.3');
+        [$orphant_entry, $orphant] = $this->createDocumentEntryAndNode('orphant.rst', 'orphant');
+
+
+        $this->entry1->addChild($entry1_1);
+        $entry1_1->addChild($entry1_1_1);
+        $entry1_1->addChild($entry1_1_2);
+        $this->entry2->addChild($entry2_1);
+        $entry2_1->addChild($entry2_1_1);
+        $entry2_1->addChild($entry2_1_2);
+        $this->entry2->addChild($entry2_2);
+        $this->entry2->addChild($entry2_3);
+
+        $this->flatDocumentList = [
+            $doc1,
+            $doc1_1,
+            $doc1_1_1,
+            $doc1_1_2,
+            $doc2,
+            $doc2_1,
+            $doc2_1_1,
+            $doc2_1_2,
+            $doc2_2,
+            $doc2_3,
+            $orphant,
+        ];
+
+        //We shuffle the array, because input order should not matter
+        $this->randomOrderedDocuments = $this->flatDocumentList;
+        shuffle($this->randomOrderedDocuments);
+    }
+
+    /** @return array{DocumentEntryNode, DocumentNode} */
+    private function createDocumentEntryAndNode(string $fileName, string $title): array
+    {
+        $titleNode = $this->createTitle($title);
+        $subDocumentEntry = new DocumentEntryNode($fileName, $titleNode);
+        $subDocumentNode = new DocumentNode(md5($title), $fileName);
+        $subDocumentNode->setValue([new SectionNode($titleNode)]);
+        $subDocumentNode->setDocumentEntry($subDocumentEntry);
+
+        return [$subDocumentEntry, $subDocumentNode];
+    }
+
+    private function createTitle(string $title): TitleNode
+    {
+        return new TitleNode(InlineCompoundNode::getPlainTextInlineNode($title), 1, '1');
+    }
+
+    /**
+     * @param DocumentNode[] $result
+     *
+     * @return (string|null)[]
+     */
+    protected static function documentsToTitle(array $result): array
+    {
+        return array_map(static fn (DocumentNode $doc) => $doc->getTitle()?->toString(), $result);
+    }
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -44,4 +44,8 @@
     <rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
           <exclude-pattern>*/tests/*/*.php</exclude-pattern>
     </rule>
+
+    <rule ref="Squiz.NamingConventions.ValidVariableName.NotCamelCaps">
+        <exclude-pattern>*/tests/unit/Renderer/IteratorTestCase.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,11 +21,6 @@ parameters:
 			path: packages/guides-cli/src/Command/Run.php
 
 		-
-			message: "#^Parameter \\#1 \\$iterable of method Symfony\\\\Component\\\\Console\\\\Helper\\\\ProgressBar\\:\\:iterate\\(\\) expects iterable, mixed given\\.$#"
-			count: 1
-			path: packages/guides-cli/src/Command/Run.php
-
-		-
 			message: "#^Parameter \\#1 \\$outputFormats of method phpDocumentor\\\\Guides\\\\Settings\\\\ProjectSettings\\:\\:setOutputFormats\\(\\) expects array\\<string\\>, mixed given\\.$#"
 			count: 1
 			path: packages/guides-cli/src/Command/Run.php
@@ -37,16 +32,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
-			count: 1
+			count: 2
 			path: packages/guides-cli/src/Command/Run.php
 
 		-
 			message: "#^Parameter \\#2 \\$documentArray of class phpDocumentor\\\\Guides\\\\Handlers\\\\RenderCommand constructor expects array\\<phpDocumentor\\\\Guides\\\\Nodes\\\\DocumentNode\\>, mixed given\\.$#"
-			count: 1
-			path: packages/guides-cli/src/Command/Run.php
-
-		-
-			message: "#^Parameter \\#3 \\$documentIterator of class phpDocumentor\\\\Guides\\\\Handlers\\\\RenderCommand constructor expects iterable\\<phpDocumentor\\\\Guides\\\\Nodes\\\\DocumentNode\\>, mixed given\\.$#"
 			count: 1
 			path: packages/guides-cli/src/Command/Run.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -50,4 +50,9 @@
       <code>[new SectionNode(TitleNode::emptyNode())]</code>
     </InvalidArgument>
   </file>
+  <file src="packages/guides/tests/unit/Renderer/IteratorTestCase.php">
+    <InvalidArgument>
+      <code>[new SectionNode($titleNode)]</code>
+    </InvalidArgument>
+  </file>
 </files>


### PR DESCRIPTION
The newly added iterators do iterate the toc tree to find the order of rendering of documents. This is required to have single page outputs in the correct order. The downside of this new approach is that only documents that are in a toc-tree are rendered.