### PR TITLE
[BUGFIX] Fix parsing and rendering of code-block with line numbers

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Directives/CodeBlockDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/CodeBlockDirective.php
@@ -70,15 +70,19 @@ class CodeBlockDirective extends BaseDirective
         return $node;
     }
 
-    /** @param mixed[] $options */
+    /** @param array<string, DirectiveOption> $options */
     private function setStartingLineNumberBasedOnOptions(array $options, CodeNode $node): void
     {
         $startingLineNumber = null;
-        if (isset($options['linenos'])) {
+        if (isset($options['linenos']) || isset($options['number-lines'])) {
             $startingLineNumber = 1;
         }
 
-        $startingLineNumber = $options['number-lines'] ?? $options['lineno-start'] ?? $startingLineNumber;
+        if (isset($options['number-lines'])) {
+            $startingLineNumber = $options['number-lines']->getValue() ?? $startingLineNumber;
+        } elseif (isset($options['lineno-start'])) {
+            $startingLineNumber = $options['lineno-start']->getValue() ?? $startingLineNumber;
+        }
 
         if ($startingLineNumber === null) {
             return;

--- a/packages/guides/resources/template/html/body/code.html.twig
+++ b/packages/guides/resources/template/html/body/code.html.twig
@@ -7,5 +7,5 @@
             <span class="caption-text">{{ node.caption }}</span>
         </div>
     {%- endif -%}
-    <pre{% if node.classes %} class="{{ node.classesString }}"{% endif %}><code class="language-{{ node.language }}{{ node.startingLineNumber ? ' line-numbers' }}" {{- node.startingLineNumber ? ' data-start=' ~ node.startingLineNumber }}>{{ node.value }}</code></pre>
+    <pre{% if node.classes %} class="{{ node.classesString }}"{% endif %}><code class="language-{{ node.language }}{{ node.startingLineNumber ? ' line-numbers' }}" {%- if node.startingLineNumber %} data-start="{{ node.startingLineNumber }}"{% endif %}>{{ node.value }}</code></pre>
 {%- endif -%}

--- a/tests/Integration/tests/class/literalincludeLineNos/expected/index.html
+++ b/tests/Integration/tests/class/literalincludeLineNos/expected/index.html
@@ -7,7 +7,7 @@
 <div class="section" id="index">
     <h1>index</h1>
 
-    <pre><code class="language-php line-numbers" data-start=2>&lt;?php
+    <pre><code class="language-php line-numbers" data-start="2">&lt;?php
 
 declare(strict_types=1);
 

--- a/tests/Integration/tests/code/code-block-lineno/expected/index.html
+++ b/tests/Integration/tests/code/code-block-lineno/expected/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Title</title>
+
+</head>
+<body>
+    <div class="section" id="title">
+    <h1>Title</h1>
+
+            <pre><code class="language-ruby line-numbers" data-start="10">Some more Ruby code, with line numbering starting at 10.</code></pre>
+    </div>
+
+</body>
+</html>

--- a/tests/Integration/tests/code/code-block-lineno/input/index.rst
+++ b/tests/Integration/tests/code/code-block-lineno/input/index.rst
@@ -1,0 +1,7 @@
+Title
+=====
+
+..  code-block:: ruby
+    :lineno-start: 10
+
+    Some more Ruby code, with line numbering starting at 10.


### PR DESCRIPTION
- There was an error triggered by using `lineno-start` option.
- the data-start attribute was output without quotes
- integration tests were missing

resolves #684