### PR TITLE
[TASK] Replace Integration tests with xmllint

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -91,3 +91,17 @@ jobs:
     with:
       php-versions: "['8.1', '8.2']"
       test-suite: "integration"
+
+  xml-lint:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+
+      - name: "Install libxml2-utils"
+        run: |
+          sudo apt-get update
+          sudo apt -y install libxml2-utils
+
+      - name: "Lint xml configs"
+        run: "tools/xmllint.sh"

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ psalm:
 	$(PHP_BIN) vendor/bin/psalm --update-baseline
 
 .PHONY: test
-test: test-unit test-functional test-integration test-docs## Runs all test suites with phpunit/phpunit
+test: test-unit test-functional test-integration test-xml test-docs## Runs all test suites with phpunit/phpunit
 
 .PHONY: test-unit
 test-unit: ## Runs unit tests with phpunit/phpunit
@@ -41,6 +41,10 @@ test-functional: ## Runs functional tests with phpunit/phpunit
 .PHONY: test-integration
 test-integration: ## Runs integration tests with phpunit/phpunit
 	$(PHP_BIN) vendor/bin/phpunit --testsuite=integration
+
+.PHONY: test-xml
+test-xml: ## Lint all guides.xml
+	./tools/xmllint.sh
 
 .PHONY: test-docs
 test-docs: ## Generate projects docs without warnings

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\Integration;
 
-use DOMDocument;
 use phpDocumentor\Guides\ApplicationTestCase;
 use phpDocumentor\Guides\Cli\Command\Run;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -22,11 +21,7 @@ use function explode;
 use function file_exists;
 use function file_get_contents;
 use function implode;
-use function libxml_clear_errors;
-use function libxml_get_errors;
-use function libxml_use_internal_errors;
 use function setlocale;
-use function sprintf;
 use function str_ends_with;
 use function str_replace;
 use function system;
@@ -172,65 +167,6 @@ class IntegrationTest extends ApplicationTestCase
     public static function getTestsForLatex(): array
     {
         return self::getTestsForDirectory(__DIR__ . '/tests-latex');
-    }
-
-    #[DataProvider('getTestsWithGuidesXmlForDirectoryTest')]
-    public function testXmlValidation(string $xmlFile): void
-    {
-        $xsdFile = 'packages/guides-cli/resources/schema/guides.xsd';
-        libxml_use_internal_errors(true);
-        // Create a DOMDocument for XML validation
-        $dom = new DOMDocument();
-        $dom->load($xmlFile);
-
-        // Validate against XSD schema
-        $isValid = $dom->schemaValidate($xsdFile);
-        $errorString = '';
-
-        if (!$isValid) {
-            $errors = libxml_get_errors();
-
-            foreach ($errors as $error) {
-                $errorString .= sprintf("Validation Error at line %s: %s\n", $error->line, $error->message);
-            }
-
-            libxml_clear_errors();
-        }
-
-        self::assertTrue($isValid, 'XML of ' . $xmlFile . ' does not validate against the schema: ' . $errorString);
-    }
-
-    /** @return mixed[] */
-    public static function getTestsWithGuidesXmlForDirectoryTest(): array
-    {
-        return self::getTestsWithGuidesXmlForSubDirectoryTest('tests/Integration/tests');
-    }
-
-    /** @return mixed[] */
-    private static function getTestsWithGuidesXmlForSubDirectoryTest(string $directory = 'tests'): array
-    {
-        $finder = new SymfonyFinder();
-        $finder
-            ->directories()
-            ->in($directory)
-            ->depth('== 0');
-
-        $tests = [];
-
-        foreach ($finder as $dir) {
-            if (!file_exists($dir->getPathname() . '/input')) {
-                $tests = array_merge($tests, self::getTestsWithGuidesXmlForSubDirectoryTest($dir->getPathname()));
-                continue;
-            }
-
-            if (!file_exists($dir->getPathname() . '/input/guides.xml')) {
-                continue;
-            }
-
-            $tests[$dir->getRelativePathname()] = [$dir->getPathname() . '/input/guides.xml'];
-        }
-
-        return $tests;
     }
 
     /** @return mixed[] */

--- a/tools/xmllint.sh
+++ b/tools/xmllint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+schema="packages/guides-cli/resources/schema/guides.xsd"
+directory="."
+
+for file in $(find "$directory" -type f -name "guides.xml"); do
+    xmllint --noout --schema "$schema" "$file"
+done


### PR DESCRIPTION
Linting xml files is not really the responsibility of integration tests.

As a plus using xmllint works on all guides.xml including those in our doc directly and the basic one