### PR TITLE
[BUGFIX] Do not use local resolvers for interlinks

### DIFF
--- a/packages/guides/src/ReferenceResolvers/AnchorReferenceResolver.php
+++ b/packages/guides/src/ReferenceResolvers/AnchorReferenceResolver.php
@@ -28,6 +28,10 @@ class AnchorReferenceResolver implements ReferenceResolver
     {
         $reducedAnchor = $this->anchorReducer->reduceAnchor($node->getTargetReference());
         if ($node instanceof ReferenceNode) {
+            if ($node->getInterlinkDomain() !== '') {
+                return false;
+            }
+
             $target = $renderContext->getProjectNode()->getInternalTarget($reducedAnchor, $node->getLinkType());
         } else {
             // Todo: move this to a separate resolver?

--- a/packages/guides/src/ReferenceResolvers/DocReferenceResolver.php
+++ b/packages/guides/src/ReferenceResolvers/DocReferenceResolver.php
@@ -25,6 +25,10 @@ class DocReferenceResolver implements ReferenceResolver
             return false;
         }
 
+        if ($node->getInterlinkDomain() !== '') {
+            return false;
+        }
+
         $document = $renderContext->getProjectNode()->findDocumentEntry(
             $this->documentNameResolver->canonicalUrl($renderContext->getDirName(), $node->getTargetReference()),
         );

--- a/tests/Integration/tests/navigation/interlink-to-index/expected/Index.html
+++ b/tests/Integration/tests/navigation/interlink-to-index/expected/Index.html
@@ -1,0 +1,9 @@
+<!-- content start -->
+    <div class="section" id="document-title">
+    <h1>Document Title</h1>
+
+            <p>Lorem Ipsum Dolor.</p>
+            <p>See the <a href="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/Index.html">TYPO3 documentation</a></p>
+    </div>
+
+<!-- content end -->

--- a/tests/Integration/tests/navigation/interlink-to-index/input/Index.rst
+++ b/tests/Integration/tests/navigation/interlink-to-index/input/Index.rst
@@ -1,0 +1,7 @@
+==============
+Document Title
+==============
+
+Lorem Ipsum Dolor.
+
+See the :doc:`TYPO3 documentation <t3coreapi:Index>`

--- a/tests/Integration/tests/navigation/interlink-to-index/input/guides.xml
+++ b/tests/Integration/tests/navigation/interlink-to-index/input/guides.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides xmlns="https://www.phpdoc.org/guides"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd"
+>
+    <project title="My Project" version="main (development)" />
+    <inventory id="t3coreapi" url="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/" />
+    <inventory id="someapi" url="https://docs.typo3.org/m/typo3/reference-someapi/main/en-us/" />
+</guides>


### PR DESCRIPTION
DocumentReferenceResolver at times tried to resolve intersphinx links leading to strange unexpected behaviour.