### PR TITLE
[BUGFIX] Add missing symfony/clock dependency

### DIFF
--- a/packages/guides/composer.json
+++ b/packages/guides/composer.json
@@ -28,6 +28,7 @@
         "league/uri": "^6.5 || ^7.0",
         "phpdocumentor/flyfinder": "^1.1",
         "psr/event-dispatcher": "^1.0",
+        "symfony/clock": "^6.3",
         "symfony/string": "^5.4 || ^6.3",
         "symfony/translation-contracts": "^3.4.0",
         "symfony/http-client": "^6.3.8",


### PR DESCRIPTION
DependencyInjection/TestExtension.php uses the symfony/clock package, but it is not defined as a dependency.