### PR TITLE
[BUGFIX] Allow angled content in references

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/TextRoles/AbstractReferenceTextRole.php
+++ b/packages/guides-restructured-text/src/RestructuredText/TextRoles/AbstractReferenceTextRole.php
@@ -53,13 +53,16 @@ abstract class AbstractReferenceTextRole implements TextRole
                     }
 
                     if ($this->lexer->peek() !== null) {
-                        $this->logger->warning(
+                        $this->logger->debug(
                             sprintf(
-                                'Reference contains unexpected content after closing `>`: "%s"',
-                                $content,
+                                'Reference contains unexpected content after closing `>`, treating it as text like sphinx does: "%s"',
+                                $rawContent,
                             ),
                             $documentParserContext->getLoggerInformation(),
                         );
+                        $part = $value . '<' . $part . '>';
+                        $value = null;
+                        break;
                     }
 
                     $referenceTarget = $part;

--- a/tests/Integration/tests/navigation/reference-with-angle-bracket/expected/index.html
+++ b/tests/Integration/tests/navigation/reference-with-angle-bracket/expected/index.html
@@ -1,0 +1,17 @@
+<!-- content start -->
+    <div class="section" id="overview">
+    <h1>Overview</h1>
+
+            <p>The uid must be given as a positive integer.
+For new records, use the <a href="/page.html#typo3-backend-link-newrecord">&lt;be:link.newRecordViewHelper&gt;</a>
+.</p>
+            <div class="toc">
+    <ul class="menu-level">
+    <li class="toc-item"><a href="/page.html#link-newrecord">link.newRecord</a></li>
+
+    </ul>
+</div>
+
+    </div>
+
+<!-- content end -->

--- a/tests/Integration/tests/navigation/reference-with-angle-bracket/input/index.rst
+++ b/tests/Integration/tests/navigation/reference-with-angle-bracket/input/index.rst
@@ -1,0 +1,10 @@
+========
+Overview
+========
+
+The uid must be given as a positive integer.
+For new records, use the :ref:`<be:link.newRecordViewHelper> <typo3-backend-link-newrecord>`.
+
+..  toctree::
+
+    page

--- a/tests/Integration/tests/navigation/reference-with-angle-bracket/input/page.rst
+++ b/tests/Integration/tests/navigation/reference-with-angle-bracket/input/page.rst
@@ -1,0 +1,9 @@
+.. _typo3-backend-link-newrecord:
+
+==============
+link.newRecord
+==============
+
+
+Use this ViewHelper to provide 'create new record' links.
+The ViewHelper will pass the command to FormEngine.


### PR DESCRIPTION
Sphinx allows this too, even though it is not nice, for example:

```
:ref:`<be:link.newRecordViewHelper> <typo3-backend-link-newrecord>`
```