### PR TITLE
[BUGFIX] Use output filename with path in relative path calculations

### DIFF
--- a/packages/guides/src/RenderContext.php
+++ b/packages/guides/src/RenderContext.php
@@ -29,6 +29,8 @@ class RenderContext
     /** @var DocumentNode[] */
     private array $allDocuments;
 
+    private string $outputFilePath = '';
+
     private Renderer\DocumentListIterator $iterator;
 
     private function __construct(
@@ -62,6 +64,7 @@ class RenderContext
 
         $self->document = $documentNode;
         $self->allDocuments = $allDocumentNodes;
+        $self->outputFilePath =  $documentNode->getFilePath() . '.' . $ouputFormat;
 
         return $self;
     }
@@ -206,5 +209,18 @@ class RenderContext
     public function getIterator(): Renderer\DocumentListIterator
     {
         return $this->iterator;
+    }
+
+    public function getOutputFilePath(): string
+    {
+        return $this->outputFilePath;
+    }
+
+    public function withOutputFilePath(string $outputFilePath): RenderContext
+    {
+        $that = clone$this;
+        $that->outputFilePath = $outputFilePath;
+
+        return $that;
     }
 }

--- a/packages/guides/src/Renderer/InterlinkObjectsRenderer.php
+++ b/packages/guides/src/Renderer/InterlinkObjectsRenderer.php
@@ -36,7 +36,7 @@ class InterlinkObjectsRenderer implements TypeRenderer
             $renderCommand->getDestination(),
             $renderCommand->getDestinationPath(),
             'html',
-        );
+        )->withOutputFilePath('objects.inv.json');
 
         foreach ($renderCommand->getProjectNode()->getAllDocumentEntries() as $key => $documentEntry) {
             $url = $this->documentNameResolver->canonicalUrl(

--- a/packages/guides/src/Renderer/UrlGenerator/RelativeUrlGenerator.php
+++ b/packages/guides/src/Renderer/UrlGenerator/RelativeUrlGenerator.php
@@ -30,7 +30,7 @@ final class RelativeUrlGenerator extends AbstractUrlGenerator
         RenderContext $renderContext,
         string $canonicalUrl,
     ): string {
-        $currentPathUri = Uri::createFromString($this->createFileUrl($renderContext, $renderContext->getCurrentFileName()));
+        $currentPathUri = Uri::createFromString($renderContext->getOutputFilePath());
         $canonicalUrlUri = Uri::createFromString($canonicalUrl);
 
         $canonicalAnchor = $canonicalUrlUri->getFragment();

--- a/packages/guides/tests/unit/Renderer/UrlGenerator/RelativeUrlGeneratorTest.php
+++ b/packages/guides/tests/unit/Renderer/UrlGenerator/RelativeUrlGeneratorTest.php
@@ -12,12 +12,11 @@ use PHPUnit\Framework\TestCase;
 final class RelativeUrlGeneratorTest extends TestCase
 {
     #[DataProvider('generateRelativeInternalUrlProvider')]
-    public function testGenerateRelativeInternalUrl(string $expected, string $canonicalUrl, string $currentFileName): void
+    public function testGenerateRelativeInternalUrl(string $expected, string $canonicalUrl, string $outputFilePath): void
     {
         $urlGenerator = new RelativeUrlGenerator(self::createStub(DocumentNameResolverInterface::class));
         $renderContext = $this->createMock(RenderContext::class);
-        $renderContext->method('getCurrentFileName')->willReturn($currentFileName);
-        $renderContext->method('getOutputFormat')->willReturn('html');
+        $renderContext->method('getOutputFilePath')->willReturn($outputFilePath);
         self::assertSame($expected, $urlGenerator->generateInternalUrl($renderContext, $canonicalUrl));
     }
 
@@ -28,37 +27,37 @@ final class RelativeUrlGeneratorTest extends TestCase
             'Same File' => [
                 'expected' => '#',
                 'canonicalUrl' => 'directory/file.html',
-                'currentPath' => 'directory/file',
+                'outputFilePath' => 'directory/file.html',
             ],
             'Same File with anchor' => [
                 'expected' => '#anchor',
                 'canonicalUrl' => 'directory/file.html#anchor',
-                'currentPath' => 'directory/file',
+                'outputFilePath' => 'directory/file.html',
             ],
             'File in same directory' => [
                 'expected' => 'file.html',
                 'canonicalUrl' => 'directory/file.html',
-                'currentPath' => 'directory/anotherFile',
+                'outputFilePath' => 'directory/anotherFile.html',
             ],
             'File in subdirectory' => [
                 'expected' => 'subdirectory/file.html',
                 'canonicalUrl' => 'directory/subdirectory/file.html',
-                'currentPath' => 'directory/anotherFile',
+                'outputFilePath' => 'directory/anotherFile.html',
             ],
             'File in directory above' => [
                 'expected' => '../file.html',
                 'canonicalUrl' => 'file.html',
-                'currentPath' => 'directory/anotherFile',
+                'outputFilePath' => 'directory/anotherFile.html',
             ],
             'File in two directory above' => [
                 'expected' => '../../file.html',
                 'canonicalUrl' => 'file.html',
-                'currentPath' => 'directory/subdirectory/anotherFile',
+                'outputFilePath' => 'directory/subdirectory/anotherFile',
             ],
             'File in other subdirectory above' => [
                 'expected' => '../subdirectory/file.html',
                 'canonicalUrl' => 'directory/subdirectory/file.html',
-                'currentPath' => 'directory/othersubdirectory/anotherFile',
+                'outputFilePath' => 'directory/othersubdirectory/anotherFile.html',
             ],
         ];
     }


### PR DESCRIPTION
This enables single file renderers like singlehtml to also calculate relative paths.

Needed for https://github.com/TYPO3-Documentation/render-guides/pull/130