### PR TITLE
[BUGFIX] Allow underscore and minus in interlink names

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/TextRoles/AbstractReferenceTextRole.php
+++ b/packages/guides-restructured-text/src/RestructuredText/TextRoles/AbstractReferenceTextRole.php
@@ -15,6 +15,8 @@ use function trim;
 /** @see https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#embedded-uris-and-aliases */
 abstract class AbstractReferenceTextRole implements TextRole
 {
+    /** @see https://regex101.com/r/htMn5p/1 */
+    public const INTERLINK_REGEX = '/^([a-zA-Z0-9-_]+):(.*$)/';
     private readonly InlineLexer $lexer;
 
     public function __construct(

--- a/packages/guides-restructured-text/src/RestructuredText/TextRoles/DocReferenceTextRole.php
+++ b/packages/guides-restructured-text/src/RestructuredText/TextRoles/DocReferenceTextRole.php
@@ -34,7 +34,7 @@ class DocReferenceTextRole extends AbstractReferenceTextRole
     /** @return DocReferenceNode */
     protected function createNode(string $referenceTarget, string|null $referenceName, string $role): AbstractLinkInlineNode
     {
-        $pattern = '/^([a-zA-Z0-9]+):(.*$)/';
+        $pattern =  AbstractReferenceTextRole::INTERLINK_REGEX;
         if (preg_match($pattern, $referenceTarget, $matches)) {
             $interlinkDomain = $matches[1];
             $path = $matches[2];

--- a/packages/guides-restructured-text/src/RestructuredText/TextRoles/GenericReferenceTextRole.php
+++ b/packages/guides-restructured-text/src/RestructuredText/TextRoles/GenericReferenceTextRole.php
@@ -38,7 +38,7 @@ class GenericReferenceTextRole extends AbstractReferenceTextRole
     {
         $linkType = $this->genericLinkProvider->getLinkType($role);
         $pattern = '/^([a-zA-Z0-9]+):(.*$)/';
-        if (preg_match($pattern, $referenceTarget, $matches)) {
+        if (preg_match(AbstractReferenceTextRole::INTERLINK_REGEX, $referenceTarget, $matches)) {
             $interlinkDomain = $matches[1];
             $id = $this->anchorReducer->reduceAnchor($matches[2]);
         } else {

--- a/packages/guides/src/Interlink/InventoryRepository.php
+++ b/packages/guides/src/Interlink/InventoryRepository.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\Interlink;
 
+use phpDocumentor\Guides\ReferenceResolvers\AnchorReducer;
 use RuntimeException;
 
 use function array_key_exists;
-use function strtolower;
 
 class InventoryRepository
 {
@@ -16,36 +16,37 @@ class InventoryRepository
 
     /** @param array<int, array<string, string>> $inventoryConfigs */
     public function __construct(
+        private readonly AnchorReducer $anchorReducer,
         private readonly InventoryLoader $inventoryLoader,
         array $inventoryConfigs,
     ) {
         foreach ($inventoryConfigs as $inventory) {
-            $this->inventories[$inventory['id']] = new Inventory($inventory['url']);
+            $this->inventories[$this->anchorReducer->reduceAnchor($inventory['id'])] = new Inventory($inventory['url']);
         }
     }
 
     public function hasInventory(string $key): bool
     {
-        $lowerCaseKey = strtolower($key);
+        $reducedKey = $this->anchorReducer->reduceAnchor($key);
 
-        return array_key_exists($lowerCaseKey, $this->inventories);
+        return array_key_exists($reducedKey, $this->inventories);
     }
 
     public function getInventory(string $key): Inventory
     {
-        $lowerCaseKey = strtolower($key);
-        if (!$this->hasInventory($lowerCaseKey)) {
-            throw new RuntimeException('Inventory with key ' . $lowerCaseKey . ' not found. ', 1_671_398_986);
+        $reducedKey = $this->anchorReducer->reduceAnchor($key);
+        if (!$this->hasInventory($reducedKey)) {
+            throw new RuntimeException('Inventory with key ' . $reducedKey . ' not found. ', 1_671_398_986);
         }
 
-        $this->inventoryLoader->loadInventory($this->inventories[$lowerCaseKey]);
+        $this->inventoryLoader->loadInventory($this->inventories[$reducedKey]);
 
-        return $this->inventories[$lowerCaseKey];
+        return $this->inventories[$reducedKey];
     }
 
     public function addInventory(string $key, Inventory $inventory): void
     {
-        $lowerCaseKey                     = strtolower($key);
-        $this->inventories[$lowerCaseKey] = $inventory;
+        $reducedKey = $this->anchorReducer->reduceAnchor($key);
+        $this->inventories[$reducedKey] = $inventory;
     }
 }

--- a/tests/Integration/tests/interlink/interlink-to-doc-in-path/expected/Index.html
+++ b/tests/Integration/tests/interlink/interlink-to-doc-in-path/expected/Index.html
@@ -2,7 +2,8 @@
     <div class="section" id="document-title">
     <h1>Document Title</h1>
 
-            <p>See <a href="https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.1/Feature-89010-IntroduceSiteConfigForDistributionPackages.html">Feature: #89010 - Introduce Site Configuration for Distribution Packages</a></p>
+            <p>See <a href="https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.1/Feature-89010-IntroduceSiteConfigForDistributionPackages.html">Feature: #89010 - Introduce Site Configuration for Distribution Packages</a>.</p>
+            <p>See <a href="https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.1/Feature-89010-IntroduceSiteConfigForDistributionPackages.html">Feature: #89010 - Introduce Site Configuration for Distribution Packages</a>.</p>
     </div>
 
 <!-- content end -->

--- a/tests/Integration/tests/interlink/interlink-to-doc-in-path/expected/Index.html
+++ b/tests/Integration/tests/interlink/interlink-to-doc-in-path/expected/Index.html
@@ -1,0 +1,8 @@
+<!-- content start -->
+    <div class="section" id="document-title">
+    <h1>Document Title</h1>
+
+            <p>See <a href="https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.1/Feature-89010-IntroduceSiteConfigForDistributionPackages.html">Feature: #89010 - Introduce Site Configuration for Distribution Packages</a></p>
+    </div>
+
+<!-- content end -->

--- a/tests/Integration/tests/interlink/interlink-to-doc-in-path/input/Index.rst
+++ b/tests/Integration/tests/interlink/interlink-to-doc-in-path/input/Index.rst
@@ -1,0 +1,5 @@
+==============
+Document Title
+==============
+
+See :doc:`ext_core:Changelog/10.1/Feature-89010-IntroduceSiteConfigForDistributionPackages`

--- a/tests/Integration/tests/interlink/interlink-to-doc-in-path/input/Index.rst
+++ b/tests/Integration/tests/interlink/interlink-to-doc-in-path/input/Index.rst
@@ -2,4 +2,8 @@
 Document Title
 ==============
 
-See :doc:`ext_core:Changelog/10.1/Feature-89010-IntroduceSiteConfigForDistributionPackages`
+See :doc:`ext_core:Changelog/10.1/Feature-89010-IntroduceSiteConfigForDistributionPackages`.
+
+
+See :doc:`ext-core:Changelog/10.1/Feature-89010-IntroduceSiteConfigForDistributionPackages`.
+

--- a/tests/Integration/tests/interlink/interlink-to-doc-in-path/input/guides.xml
+++ b/tests/Integration/tests/interlink/interlink-to-doc-in-path/input/guides.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides xmlns="https://www.phpdoc.org/guides"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd"
+>
+    <project title="My Project" version="main (development)" />
+    <inventory id="ext_core" url="https://docs.typo3.org/c/typo3/cms-core/main/en-us/"/>
+</guides>


### PR DESCRIPTION
So does Sphinx and we use it frequently in TYPO3. Additionally Better document the regex and use a central one instead of copying it twice