### PR TITLE
[BUGFIX] Allow empty lines between field list items

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldListRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldListRule.php
@@ -55,6 +55,14 @@ final class FieldListRule implements Rule
         while ($iterator->valid() && $this->isFieldLine($iterator->current())) {
             $fieldListItemNodes[] = $this->createListItem($blockContext);
             $iterator->next();
+            while ($iterator->valid() && LinesIterator::isEmptyLine($iterator->current())) {
+                $peek = $iterator->peek();
+                if (!LinesIterator::isEmptyLine($peek) && !$this->isFieldLine($peek)) {
+                    break;
+                }
+
+                $iterator->next();
+            }
         }
 
         if ($on instanceof DocumentNode && !$on->isTitleFound()) {
@@ -173,8 +181,12 @@ final class FieldListRule implements Rule
         }
     }
 
-    private function isFieldLine(string $currentLine): bool
+    private function isFieldLine(string|null $currentLine): bool
     {
+        if ($currentLine === null) {
+            return false;
+        }
+
         if (LinesIterator::isEmptyLine($currentLine)) {
             return false;
         }

--- a/tests/Integration/tests/lists/field-list-empty-lines/expected/index.html
+++ b/tests/Integration/tests/lists/field-list-empty-lines/expected/index.html
@@ -1,0 +1,35 @@
+<!-- content start -->
+    <div class="section" id="test">
+    <h1>Test</h1>
+
+            <table>
+            <tr>
+            <th>Version</th>
+
+            <td>
+                            </td>
+        </tr>
+            <tr>
+            <th>Language</th>
+
+            <td>
+                <p>en</p>            </td>
+        </tr>
+            <tr>
+            <th>Author</th>
+
+            <td>
+                <p>Contributors</p>            </td>
+        </tr>
+            <tr>
+            <th>Rendered</th>
+
+            <td>
+                <p>Sun, 01 Jan 2023 12:00:00 +0000</p>            </td>
+        </tr>
+    </table>
+
+            <p>Something else.</p>
+    </div>
+
+<!-- content end -->

--- a/tests/Integration/tests/lists/field-list-empty-lines/input/index.rst
+++ b/tests/Integration/tests/lists/field-list-empty-lines/input/index.rst
@@ -1,0 +1,21 @@
+====
+Test
+====
+
+:Version:
+   |release|
+
+:Language:
+   en
+
+
+:Author:
+   Contributors
+
+
+
+
+:Rendered:
+   |today|
+
+Something else.


### PR DESCRIPTION
They are also allowed in Sphinx and we frequently have them in TYPO3.