### PR TITLE
[BUGFIX] Allow tabs in line indentations

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Parser/LinesIterator.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/LinesIterator.php
@@ -183,6 +183,11 @@ class LinesIterator implements Iterator
      */
     public static function isIndented(string $line, int $minIndent): bool
     {
-        return mb_strpos($line, str_repeat(' ', max(1, $minIndent))) === 0;
+        return self::isIndentedBy($line, $minIndent, ' ') || self::isIndentedBy($line, $minIndent, "\t");
+    }
+
+    private static function isIndentedBy(string $line, int $minIndent, string $indentationChar): bool
+    {
+        return mb_strpos($line, str_repeat($indentationChar, max(1, $minIndent))) === 0;
     }
 }

--- a/tests/Integration/tests/code/code-block-with-underscore/expected/index.html
+++ b/tests/Integration/tests/code/code-block-with-underscore/expected/index.html
@@ -1,0 +1,12 @@
+<!-- content start -->
+    <div class="section" id="underscores-in-code-indented-with-tabs">
+    <h1>Underscores in code indented with tabs</h1>
+
+            <pre><code class="language-typoscript">split {
+	token = frontend__
+	1.current = 1
+	1.wrap = |
+}</code></pre>
+    </div>
+
+<!-- content end -->

--- a/tests/Integration/tests/code/code-block-with-underscore/input/index.rst
+++ b/tests/Integration/tests/code/code-block-with-underscore/input/index.rst
@@ -1,0 +1,10 @@
+Underscores in code indented with tabs
+======================================
+
+..  code-block:: typoscript
+
+				split {
+					token = frontend__
+					1.current = 1
+					1.wrap = |
+				}


### PR DESCRIPTION
In some legacy rst files in TYPO3 this is still being used. Currently it leads to a large amount of warnings