### PR TITLE
[BUGFIX] Prevent false positives in Lexer

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Parser/InlineLexer.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/InlineLexer.php
@@ -69,7 +69,7 @@ final class InlineLexer extends AbstractLexer
             '|',
             '\\*\\*',
             '\\*',
-            '\b(?<!:)[a-z0-9\\.\-+]{2,}:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*[-a-zA-Z0-9()@%_\\+~#&\\/=]', // standalone hyperlinks
+            '\b(?<!:)[a-z0-9\\.\-+]{2,}:\\/\\/[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*[-a-zA-Z0-9()@%_\\+~#&\\/=]', // standalone hyperlinks
         ];
     }
 
@@ -104,11 +104,12 @@ final class InlineLexer extends AbstractLexer
     /** @inheritDoc */
     protected function getType(string &$value)
     {
-        if (preg_match('/^\\\\[\s\S]/i', $value)) {
+        // $value is already a tokenized part. Therefore, we have to match against the complete String here.
+        if (preg_match('/^\\\\[\s\S]$/i', $value)) {
             return self::ESCAPED_SIGN;
         }
 
-        if (preg_match('/``.+``(?!`)/i', $value)) {
+        if (preg_match('/^``.+``(?!`)$/i', $value)) {
             return self::LITERAL;
         }
 
@@ -116,19 +117,19 @@ final class InlineLexer extends AbstractLexer
             return self::HYPERLINK;
         }
 
-        if (preg_match('/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}/i', $value)) {
+        if (preg_match('/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$/i', $value)) {
             return self::EMAIL;
         }
 
-        if (preg_match('/[a-z0-9-]+_{2}/i', $value)) {
+        if (preg_match('/^[a-z0-9-]+_{2}$/i', $value)) {
             return self::ANONYMOUSE_REFERENCE;
         }
 
-        if (preg_match('/[a-z0-9-]+_{1}(?=\s|$)/i', $value)) {
+        if (preg_match('/^[a-z0-9-]+_{1}$/i', $value)) {
             return self::NAMED_REFERENCE;
         }
 
-        if (preg_match('/\s/i', $value)) {
+        if (preg_match('/^\s$/i', $value)) {
             return self::WHITESPACE;
         }
 
@@ -146,6 +147,7 @@ final class InlineLexer extends AbstractLexer
             '[' => self::ANNOTATION_START,
             ']' => self::ANNOTATION_END,
             '~' => self::NBSP,
+            '\\``' => self::ESCAPED_SIGN,
             default => self::WORD,
         };
     }

--- a/packages/guides-restructured-text/tests/unit/Parser/InlineLexerTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/InlineLexerTest.php
@@ -40,6 +40,14 @@ class InlineLexerTest extends TestCase
                 'https://www.test.com',
                 [InlineLexer::HYPERLINK],
             ],
+            'Not HTTPS Url' => [
+                'https:// somthing else',
+                [InlineLexer::WORD],
+            ],
+            'Not an url' => [
+                'er::anchor_',
+                [InlineLexer::WORD],
+            ],
             'String with underscore' => [
                 'EXT:css_styled_content/static/v6.2',
                 [InlineLexer::WORD],
@@ -59,6 +67,10 @@ class InlineLexerTest extends TestCase
             'Email in backticks' => [
                 '`git@github.com`',
                 [InlineLexer::BACKTICK],
+            ],
+            'Escaped double backtick' => [
+                '\\``git@github.com`',
+                [InlineLexer::ESCAPED_SIGN],
             ],
         ];
     }

--- a/tests/Functional/tests/guilabel/guilabel.html
+++ b/tests/Functional/tests/guilabel/guilabel.html
@@ -1,3 +1,3 @@
 <p>Lorem ipsum dolor sit amet <span class="guilabel">Foo Bar</span>.</p>
-<p>Lorem ipsum dolor sit amet:guilabel:<code>Foo Bar</code>.</p>
+<p>Lorem ipsum dolor sit amet<span class="guilabel">Foo Bar</span>.</p>
 <p>Lorem ipsum dolor sit amet <span class="guilabel">Foo-Bar</span>.</p>

--- a/tests/Functional/tests/links/links.html
+++ b/tests/Functional/tests/links/links.html
@@ -3,8 +3,8 @@
 <p>This is an <a href="http://anonymous.com/">anonymous link</a></p>
 <p>I love <a href="http://www.github.com/">GitHub</a></p>
 <p>This is a under_score that is not supposed to be used</p>
-<p>You can send mail to <a href="mailto:jane@example.com">mailto:jane@example.com</a> or use the news group at
-<a href="news:comp.lang.php">news:comp.lang.php</a>.</p>
+<p>You can send mail to mailto:<a href="mailto:jane@example.com">jane@example.com</a> or use the news group at
+news:comp.lang.php.</p>
 <p>Yes, Jim, I found it under &quot;<a href="http://www.w3.org/Addressing/">http://www.w3.org/Addressing/</a>&quot;, but you can probably
 pick it up from <a href="ftp://foo.example.com/rfc/">ftp://foo.example.com/rfc/</a>. Note the warning in
 <a href="http://www.ics.uci.edu/pub/ietf/uri/historical.html#WARNING">http://www.ics.uci.edu/pub/ietf/uri/historical.html#WARNING</a>.</p>


### PR DESCRIPTION
We had strange bugs where String like "Icon::SIZE_*" where interpreted as named refernce without having any reason to be so.

This was due to two problems:

The catchable pattern for external hyperlinks was also catching this pattern, so it was treated as a complete token.

The interpretation of the tokens in InlineLexer::gettype interpreted PART of the resulting string as named reference and marked the complete token as named_reference

I changed the catchable pattern to not catch these tokens. I am still not happy with the regex here but cannot dive into it.

I made sure that in InlineLexer::gettype() we test against the complete string as the $value passed to it is already tokenized.

This also changed the output from two functional tests that stemmed form strings with a double point beeing wrongly interpreted as hyperlinks.