### PR TITLE
[BUGFIX] Ignore .git and .cache directories on xml lint

### DIFF
--- a/tools/xmllint.sh
+++ b/tools/xmllint.sh
@@ -5,6 +5,6 @@ set -e
 schema="packages/guides-cli/resources/schema/guides.xsd"
 directory="."
 
-for file in $(find "$directory" -type f -name "guides.xml"); do
+for file in $(find "$directory" -type f -name "guides.xml" -not \( -path "./.git*" -o -path "./.cache*" \)); do
     xmllint --noout --schema "$schema" "$file"
 done


### PR DESCRIPTION
Just had an issue where he found some files in the .git area, however those must not be checked