### PR TITLE
[BUGFIX] Limit inline variables to Alphanumeric + Underscore

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/VariableInlineRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/VariableInlineRule.php
@@ -38,8 +38,15 @@ class VariableInlineRule extends AbstractInlineRule
 
                     return new VariableInlineNode($text);
 
-                default:
+                case $token->type === InlineLexer::WORD:
+                case $token->type === InlineLexer::UNDERSCORE:
                     $text .= $token->value;
+                    break;
+
+                default:
+                    $this->rollback($lexer, $initialPosition ?? 0);
+
+                    return null;
             }
 
             if ($lexer->moveNext() === false && $lexer->token === null) {

--- a/tests/Integration/tests/text-with-pipe/expected/index.html
+++ b/tests/Integration/tests/text-with-pipe/expected/index.html
@@ -1,0 +1,8 @@
+<!-- content start -->
+    <div class="section" id="some-title">
+    <h1>Some Title</h1>
+
+            <p>string | array | object</p>
+    </div>
+
+<!-- content end -->

--- a/tests/Integration/tests/text-with-pipe/input/index.rst
+++ b/tests/Integration/tests/text-with-pipe/input/index.rst
@@ -1,0 +1,4 @@
+Some Title
+==========
+
+string | array | object


### PR DESCRIPTION
Other variable names are not possible and this prevents so many false positives in texts with pipes.