### PR TITLE
Move section anchors before the section title

### DIFF
--- a/packages/guides/resources/template/html/structure/section.html.twig
+++ b/packages/guides/resources/template/html/structure/section.html.twig
@@ -1,5 +1,4 @@
 <div class="section{% if node.classes %} {{ node.classesString }}{% endif %}" id="{{ node.title.id }}">
-    {{ renderNode(node.title) }}
     {% for childNode in node.children %}
         {{ renderNode(childNode) }}
     {% endfor %}

--- a/packages/guides/resources/template/tex/structure/section.tex.twig
+++ b/packages/guides/resources/template/tex/structure/section.tex.twig
@@ -1,5 +1,3 @@
-{{ renderNode(node.title) }}
-
 {% for childNode in node.children %}
     {{ renderNode(childNode) }}
 {% endfor %}

--- a/packages/guides/src/Nodes/SectionNode.php
+++ b/packages/guides/src/Nodes/SectionNode.php
@@ -13,7 +13,7 @@ final class SectionNode extends CompoundNode implements LinkTargetNode
 
     public function __construct(private readonly TitleNode $title)
     {
-        parent::__construct();
+        parent::__construct([$title]);
     }
 
     public function getTitle(): TitleNode

--- a/packages/guides/tests/unit/Compiler/NodeTransformers/MoveAnchorTransformerTest.php
+++ b/packages/guides/tests/unit/Compiler/NodeTransformers/MoveAnchorTransformerTest.php
@@ -50,7 +50,7 @@ final class MoveAnchorTransformerTest extends TestCase
         $this->documentNodeTraverser->traverse($document, $context);
 
         self::assertCount(1, $context->getDocumentNode()->getChildren());
-        self::assertCount(1, $section->getChildren());
+        self::assertCount(2, $section->getChildren());
         self::assertSame($node, $section->getChildren()[0]);
     }
 
@@ -74,7 +74,7 @@ final class MoveAnchorTransformerTest extends TestCase
         $this->documentNodeTraverser->traverse($document, $context);
 
         self::assertCount(1, $context->getDocumentNode()->getChildren());
-        self::assertCount(4, $section->getChildren());
+        self::assertCount(5, $section->getChildren());
         self::assertEquals($node4, $section->getChildren()[0]);
         self::assertEquals($node3, $section->getChildren()[1]);
         self::assertEquals($node2, $section->getChildren()[2]);
@@ -84,8 +84,10 @@ final class MoveAnchorTransformerTest extends TestCase
     public function testAnchorShouldNotBeMovedTwice(): void
     {
         $node1 = new AnchorNode('foo');
-        $section = new SectionNode(new TitleNode(InlineCompoundNode::getPlainTextInlineNode('foo'), 1, 'id'));
-        $subSection = new SectionNode(new TitleNode(InlineCompoundNode::getPlainTextInlineNode('foo'), 1, 'id'));
+        $sectionTitle = new TitleNode(InlineCompoundNode::getPlainTextInlineNode('foo'), 1, 'id');
+        $section = new SectionNode($sectionTitle);
+        $subSectionTitle = new TitleNode(InlineCompoundNode::getPlainTextInlineNode('sub foo'), 2, 'sub-id');
+        $subSection = new SectionNode($subSectionTitle);
         $section->addChildNode(new AnchorNode('bar'));
         $section->addChildNode($subSection);
 
@@ -100,10 +102,10 @@ final class MoveAnchorTransformerTest extends TestCase
         self::assertCount(1, $context->getDocumentNode()->getChildren());
         $updatedSection = $context->getDocumentNode()->getChildren()[0];
         self::assertInstanceOf(SectionNode::class, $updatedSection);
-        self::assertEquals([$node1, $subSection], $updatedSection->getChildren());
-        $updatedSubSection = $updatedSection->getChildren()[1];
+        self::assertEquals([$node1, $sectionTitle, $subSection], $updatedSection->getChildren());
+        $updatedSubSection = $updatedSection->getChildren()[2];
         self::assertInstanceOf(SectionNode::class, $updatedSubSection);
-        self::assertEquals([new AnchorNode('bar')], $updatedSubSection->getChildren());
+        self::assertEquals([new AnchorNode('bar'), $subSectionTitle], $updatedSubSection->getChildren());
     }
 
     public function testNoMoveWhenAnchorIsOnlyChild(): void
@@ -143,8 +145,8 @@ final class MoveAnchorTransformerTest extends TestCase
         [$firstChild, $secondChild] = $context->getDocumentNode()->getChildren();
         self::assertInstanceOf(SectionNode::class, $firstChild);
         self::assertInstanceOf(SectionNode::class, $secondChild);
-        self::assertCount(0, $firstChild->getChildren());
-        self::assertCount(2, $secondChild->getChildren());
+        self::assertCount(1, $firstChild->getChildren());
+        self::assertCount(3, $secondChild->getChildren());
     }
 
     public function testMoveAnchorsAtTheEndOfSectionToNextParentNeighbourSection(): void
@@ -171,7 +173,7 @@ final class MoveAnchorTransformerTest extends TestCase
         [$firstChild, $secondChild] = $context->getDocumentNode()->getChildren();
         self::assertInstanceOf(SectionNode::class, $firstChild);
         self::assertInstanceOf(SectionNode::class, $secondChild);
-        self::assertCount(1, $firstChild->getChildren());
-        self::assertCount(2, $secondChild->getChildren());
+        self::assertCount(2, $firstChild->getChildren());
+        self::assertCount(3, $secondChild->getChildren());
     }
 }

--- a/packages/guides/tests/unit/Compiler/ShadowTree/TreeNodeTest.php
+++ b/packages/guides/tests/unit/Compiler/ShadowTree/TreeNodeTest.php
@@ -75,9 +75,9 @@ final class TreeNodeTest extends TestCase
 
         $treeNode->getChildren()[0]->removeChild($nodeToRemove);
 
-        self::assertCount(0, $treeNode->getChildren()[0]->getChildren());
+        self::assertCount(1, $treeNode->getChildren()[0]->getChildren());
         self::assertInstanceOf(CompoundNode::class, $treeNode->getChildren()[0]->getNode());
-        self::assertCount(0, $treeNode->getChildren()[0]->getNode()->getChildren());
+        self::assertCount(1, $treeNode->getChildren()[0]->getNode()->getChildren());
         self::assertInstanceOf(CompoundNode::class, $treeNode->getNode());
         self::assertSame($treeNode->getNode()->getChildren()[0], $treeNode->getChildren()[0]->getNode());
         self::assertSame($treeNode->getNode(), $treeNode->getRoot()->getNode());

--- a/tests/Integration/tests/anchor/anchor-ref-title-equals-title/expected/overview.html
+++ b/tests/Integration/tests/anchor/anchor-ref-title-equals-title/expected/overview.html
@@ -3,16 +3,16 @@
     <h1>Overview</h1>
 
             <div class="section" id="overview-1">
+            <a id="rst-overview"></a>
     <h2>Overview 1</h2>
 
-            <a id="rst-overview"></a>
             <p>RST Overview content</p>
     </div>
 
             <div class="section" id="overview-2">
+            <a id="sphinx-overview"></a>
     <h2>Overview 2</h2>
 
-            <a id="sphinx-overview"></a>
             <p>Sphinx Overview content</p>
     </div>
 

--- a/tests/Integration/tests/anchor/anchor-title-overriden-by-ref-title/expected/index.html
+++ b/tests/Integration/tests/anchor/anchor-title-overriden-by-ref-title/expected/index.html
@@ -1,15 +1,15 @@
 <!-- content start -->
     <div class="section" id="overview">
+            <a id="rst-overview"></a>
     <h1>Overview</h1>
 
-            <a id="rst-overview"></a>
             <p>RST Overview content</p>
     </div>
 
 <div class="section" id="overview-1">
+            <a id="sphinx-overview"></a>
     <h1>Overview</h1>
 
-            <a id="sphinx-overview"></a>
             <p>Sphinx Overview content</p>
             <div class="section" id="somewhere-else">
     <h2>Somewhere else</h2>

--- a/tests/Integration/tests/anchor/anchor-to-title/expected/index.html
+++ b/tests/Integration/tests/anchor/anchor-to-title/expected/index.html
@@ -1,15 +1,15 @@
 <!-- content start -->
     <div class="section" id="overview">
+            <a id="rst-overview"></a>
     <h1>Overview</h1>
 
-            <a id="rst-overview"></a>
             <p>RST Overview content</p>
     </div>
 
 <div class="section" id="overview-1">
+            <a id="sphinx-overview"></a>
     <h1>Overview</h1>
 
-            <a id="sphinx-overview"></a>
             <p>Sphinx Overview content</p>
             <div class="section" id="somewhere-else">
     <h2>Somewhere else</h2>

--- a/tests/Integration/tests/anchor/anchor-whitespace/expected/index.html
+++ b/tests/Integration/tests/anchor/anchor-whitespace/expected/index.html
@@ -1,15 +1,15 @@
 <!-- content start -->
     <div class="section" id="overview">
+            <a id="rst-overview"></a>
     <h1>Overview</h1>
 
-            <a id="rst-overview"></a>
             <p>RST Overview content</p>
     </div>
 
 <div class="section" id="overview-1">
+            <a id="sphinx-overview"></a>
     <h1>Overview</h1>
 
-            <a id="sphinx-overview"></a>
             <p>Sphinx Overview content</p>
             <div class="section" id="somewhere-else">
     <h2>Somewhere else</h2>

--- a/tests/Integration/tests/hyperlink-to-page/expected/subpages/index.html
+++ b/tests/Integration/tests/hyperlink-to-page/expected/subpages/index.html
@@ -1,8 +1,8 @@
 <!-- content start -->
     <div class="section" id="some-file">
+            <a id="page1"></a>
     <h1>Some file</h1>
 
-            <a id="page1"></a>
             
 
 <ul>

--- a/tests/Integration/tests/navigation/reference-not-found/expected/index.html
+++ b/tests/Integration/tests/navigation/reference-not-found/expected/index.html
@@ -1,15 +1,15 @@
 <!-- content start -->
     <div class="section" id="overview">
+            <a id="RST Overview"></a>
     <h1>Overview</h1>
 
-            <a id="RST Overview"></a>
             <p>RST Overview content</p>
     </div>
 
 <div class="section" id="overview-1">
+            <a id="Other Overview"></a>
     <h1>Overview</h1>
 
-            <a id="Other Overview"></a>
             <p>Other Overview content</p>
             <p>This is a link to the RST Overview: alternative</p>
             <p>This is a link to the Other Overview: </p>

--- a/tests/Integration/tests/navigation/references/expected/index.html
+++ b/tests/Integration/tests/navigation/references/expected/index.html
@@ -1,15 +1,15 @@
 <!-- content start -->
     <div class="section" id="overview">
+            <a id="RST Overview"></a>
     <h1>Overview</h1>
 
-            <a id="RST Overview"></a>
             <p>RST Overview content</p>
     </div>
 
 <div class="section" id="overview-1">
+            <a id="Other Overview"></a>
     <h1>Overview</h1>
 
-            <a id="Other Overview"></a>
             <p>Other Overview content</p>
             <p>This is a link to the RST Overview: <a href="/index.html#RST Overview">alternative</a></p>
             <p>This is a link to the Other Overview: <a href="/index.html#Other Overview">Overview</a></p>

--- a/tests/Integration/tests/references/reference-level-3-relative/expected/level-1-1/level-2-1/subpage1.html
+++ b/tests/Integration/tests/references/reference-level-3-relative/expected/level-1-1/level-2-1/subpage1.html
@@ -1,8 +1,8 @@
 <!-- content start -->
     <div class="section" id="subpage-1-level-2-1">
+            <a id="level-2-1-subpage1"></a>
     <h1>Subpage 1, Level 2-1</h1>
 
-            <a id="level-2-1-subpage1"></a>
             <p>Lorem Ipsum Dolor.</p>
 
 

--- a/tests/Integration/tests/references/reference-level-3-relative/expected/level-1-2/subpage2.html
+++ b/tests/Integration/tests/references/reference-level-3-relative/expected/level-1-2/subpage2.html
@@ -1,8 +1,8 @@
 <!-- content start -->
     <div class="section" id="subpage-2-level-1-2">
+            <a id="level-1-2-subpage2"></a>
     <h1>Subpage 2, Level 1-2</h1>
 
-            <a id="level-1-2-subpage2"></a>
             <p>Lorem Ipsum Dolor.</p>
 
 

--- a/tests/Integration/tests/references/reference-level-3/expected/level-1-1/level-2-1/subpage1.html
+++ b/tests/Integration/tests/references/reference-level-3/expected/level-1-1/level-2-1/subpage1.html
@@ -1,8 +1,8 @@
 <!-- content start -->
     <div class="section" id="subpage-1-level-2-1">
+            <a id="level-2-1-subpage1"></a>
     <h1>Subpage 1, Level 2-1</h1>
 
-            <a id="level-2-1-subpage1"></a>
             <p>Lorem Ipsum Dolor.</p>
 
 

--- a/tests/Integration/tests/references/reference-level-3/expected/level-1-2/subpage2.html
+++ b/tests/Integration/tests/references/reference-level-3/expected/level-1-2/subpage2.html
@@ -1,8 +1,8 @@
 <!-- content start -->
     <div class="section" id="subpage-2-level-1-2">
+            <a id="level-1-2-subpage2"></a>
     <h1>Subpage 2, Level 1-2</h1>
 
-            <a id="level-1-2-subpage2"></a>
             <p>Lorem Ipsum Dolor.</p>
 
 


### PR DESCRIPTION
Hyperlink targets (or Anchor nodes) of a section are currently parsed as child nodes. This is alright, but causes a rendering issue as the anchors are placed below the title node. This means that referencing such anchors scrolls the section title outside of the view.

I don't like my solution in this PR, but it at least fixes the bug by placing the anchor nodes before the title node (which is how Sphinx does it). If anyone has a better suggestion, please tell me :)

| *Before* | *After*
| --- | ---
| ![image](https://github.com/phpDocumentor/guides/assets/749025/d6b333af-2de5-46ef-b546-0650a4eff464) | ![image](https://github.com/phpDocumentor/guides/assets/749025/e9a4e76a-a63c-4c26-980f-6de1ad3aa2c3)
