### PR TITLE
Fix vendor directory discovery if it is more than 1 level deep

### DIFF
--- a/packages/guides-cli/bin/guides
+++ b/packages/guides-cli/bin/guides
@@ -21,13 +21,14 @@ if (file_exists($autoloadDirectory)){
         throw new \RuntimeException("Error while determining the current directory.", 1636451407);
     }
 
-    $vendorDir = __DIR__ . '/vendor';
-    while (!file_exists($vendorDir . '/autoload.php')) {
-        if ($vendorDir === $rootPath) {
+    $vendorDirParent = __DIR__;
+    while (!file_exists($vendorDirParent . '/vendor/autoload.php')) {
+        if ($vendorDirParent === $rootPath) {
             throw new \RuntimeException("Could not find autoload.php", 1636451408);
         }
-        $vendorDir = \dirname($vendorDir);
+        $vendorDirParent = \dirname($vendorDirParent);
     }
+    $vendorDir = $vendorDirParent . '/vendor';
     require $vendorDir . '/autoload.php';
 }
 


### PR DESCRIPTION
I've been applying this patch consistently the past year in my test project. Due to the submodule/symlink structure of the project, the vendor directory was 4 levels deep. The while loop actually didn't work on anything other than a `vendor` directory in the `guides-cli/bin` directory.