### PR TITLE
Fix using < or > in a reference name

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Parser/EmbeddedUriParser.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/EmbeddedUriParser.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\RestructuredText\Parser;
+
+use function preg_match;
+
+trait EmbeddedUriParser
+{
+    /** @return array{text:?string,uri:string} */
+    private function extractEmbeddedUri(string $text): array
+    {
+        preg_match('/^(.*?)(?:(?:\s|^)<([^<]+)>)?$/s', $text, $matches);
+
+        $text = $matches[1] === '' ? null : $matches[1];
+        $uri = $matches[1];
+
+        if (isset($matches[2])) {
+            // there is an embedded URI, text and URI are different
+            $uri = $matches[2];
+        } else {
+            $text = null;
+        }
+
+        return ['text' => $text, 'uri' => $uri];
+    }
+}

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/InlineLexer.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/InlineLexer.php
@@ -23,8 +23,6 @@ final class InlineLexer extends AbstractLexer
     public const ANONYMOUS_END = 3;
     public const LITERAL = 5;
     public const BACKTICK = 6;
-    public const EMBEDED_URL_START = 9;
-    public const EMBEDED_URL_END = 10;
     public const NAMED_REFERENCE = 11;
     public const ANONYMOUSE_REFERENCE = 12;
     public const COLON = 13;
@@ -62,8 +60,6 @@ final class InlineLexer extends AbstractLexer
             '``.+?``(?!`)',
             '_{2}',
             '_',
-            '<',
-            '>',
             '`',
             ':',
             '|',
@@ -138,8 +134,6 @@ final class InlineLexer extends AbstractLexer
             '**' => self::STRONG_DELIMITER,
             '*' => self::EMPHASIS_DELIMITER,
             '|' => self::VARIABLE_DELIMITER,
-            '<' => self::EMBEDED_URL_START,
-            '>' => self::EMBEDED_URL_END,
             '_' => self::UNDERSCORE,
             '__' => self::ANONYMOUS_END,
             ':' => self::COLON,

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/ReferenceRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/ReferenceRule.php
@@ -8,7 +8,6 @@ use phpDocumentor\Guides\Nodes\Inline\AbstractLinkInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\DocReferenceNode;
 use phpDocumentor\Guides\Nodes\Inline\HyperLinkNode;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
-use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
 use function filter_var;
 use function preg_replace;
@@ -40,36 +39,5 @@ abstract class ReferenceRule extends AbstractInlineRule
         }
 
         return new HyperLinkNode($link, $targetLink);
-    }
-
-    protected function parseEmbeddedUrl(InlineLexer $lexer): string|null
-    {
-        if ($lexer->token === null) {
-            return null;
-        }
-
-        $startPosition = $lexer->token->position;
-        $text = '';
-
-        while ($lexer->moveNext()) {
-            $token = $lexer->token;
-            switch ($token->type) {
-                case InlineLexer::BACKTICK:
-                    //We did not find the expected SpanLexer::EMBEDED_URL_END
-                    $this->rollback($lexer, $startPosition);
-
-                    return null;
-
-                case InlineLexer::EMBEDED_URL_END:
-                    return $text;
-
-                default:
-                    $text .= $token->value;
-            }
-        }
-
-        $this->rollback($lexer, $startPosition);
-
-        return null;
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/TextRoles/DocReferenceTextRole.php
+++ b/packages/guides-restructured-text/src/RestructuredText/TextRoles/DocReferenceTextRole.php
@@ -6,18 +6,11 @@ namespace phpDocumentor\Guides\RestructuredText\TextRoles;
 
 use phpDocumentor\Guides\Nodes\Inline\AbstractLinkInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\DocReferenceNode;
-use Psr\Log\LoggerInterface;
 
 use function preg_match;
 
 class DocReferenceTextRole extends AbstractReferenceTextRole
 {
-    public function __construct(
-        protected readonly LoggerInterface $logger,
-    ) {
-        parent::__construct($this->logger);
-    }
-
     final public const NAME = 'doc';
 
     public function getName(): string

--- a/packages/guides-restructured-text/src/RestructuredText/TextRoles/GenericReferenceTextRole.php
+++ b/packages/guides-restructured-text/src/RestructuredText/TextRoles/GenericReferenceTextRole.php
@@ -7,7 +7,6 @@ namespace phpDocumentor\Guides\RestructuredText\TextRoles;
 use phpDocumentor\Guides\Nodes\Inline\AbstractLinkInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\ReferenceNode;
 use phpDocumentor\Guides\ReferenceResolvers\AnchorReducer;
-use Psr\Log\LoggerInterface;
 
 use function array_keys;
 use function preg_match;
@@ -15,11 +14,9 @@ use function preg_match;
 class GenericReferenceTextRole extends AbstractReferenceTextRole
 {
     public function __construct(
-        protected readonly LoggerInterface $logger,
         private readonly GenericLinkProvider $genericLinkProvider,
         private readonly AnchorReducer $anchorReducer,
     ) {
-        parent::__construct($this->logger);
     }
 
     public function getName(): string

--- a/packages/guides-restructured-text/tests/unit/Parser/InlineTokenParserTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/InlineTokenParserTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Parser;
 
-use Monolog\Logger;
 use phpDocumentor\Guides\Nodes\Inline\CitationInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\DocReferenceNode;
 use phpDocumentor\Guides\Nodes\Inline\EmphasisInlineNode;
@@ -43,20 +42,18 @@ use PHPUnit\Framework\TestCase;
 
 final class InlineTokenParserTest extends TestCase
 {
-    public Logger $logger;
     private DocumentParserContext $documentParserContext;
     private InlineParser $inlineTokenParser;
     private DefaultTextRoleFactory $textRoleFactory;
 
     public function setUp(): void
     {
-        $this->logger = new Logger('test');
         $this->textRoleFactory = new DefaultTextRoleFactory(
             new GenericTextRole(),
             new LiteralTextRole(),
             [
-                new ReferenceTextRole($this->logger),
-                new DocReferenceTextRole($this->logger),
+                new ReferenceTextRole(),
+                new DocReferenceTextRole(),
             ],
         );
         $this->documentParserContext = new DocumentParserContext(
@@ -167,19 +164,19 @@ final class InlineTokenParserTest extends TestCase
                 new InlineCompoundNode([new HyperLinkNode('myref', 'myref')]),
             ],
             'Named Reference, Phrased, With URL' => [
-                '`myref<https://test.com>`_',
+                '`myref <https://test.com>`_',
                 new InlineCompoundNode([new HyperLinkNode('myref', 'https://test.com')]),
             ],
             'Named Reference, Phrased, With URL not ended' => [
-                '`myref<https://test.com`_',
-                new InlineCompoundNode([new HyperLinkNode('myref<https://test.com', 'myref<https://test.com')]),
+                '`myref <https://test.com`_',
+                new InlineCompoundNode([new HyperLinkNode('myref <https://test.com', 'myref <https://test.com')]),
             ],
             'Anonymous Reference, Phrased' => [
                 '`myref`__',
                 new InlineCompoundNode([new HyperLinkNode('myref', 'myref')]),
             ],
             'Anonymous Reference, Phrased, With URL' => [
-                '`myref<https://test.com>`__',
+                '`myref <https://test.com>`__',
                 new InlineCompoundNode([new HyperLinkNode('myref', 'https://test.com')]),
             ],
             'Footnote' => [

--- a/packages/guides-restructured-text/tests/unit/TextRoles/DocReferenceTextRoleTest.php
+++ b/packages/guides-restructured-text/tests/unit/TextRoles/DocReferenceTextRoleTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\TextRoles;
 
-use Monolog\Logger;
 use phpDocumentor\Guides\Nodes\Inline\DocReferenceNode;
 use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -13,15 +12,13 @@ use PHPUnit\Framework\TestCase;
 
 class DocReferenceTextRoleTest extends TestCase
 {
-    private Logger $logger;
     private DocReferenceTextRole $docReferenceTextRole;
     private DocumentParserContext&MockObject $documentParserContext;
 
     public function setUp(): void
     {
-        $this->logger = new Logger('test');
         $this->documentParserContext = $this->createMock(DocumentParserContext::class);
-        $this->docReferenceTextRole = new DocReferenceTextRole($this->logger);
+        $this->docReferenceTextRole = new DocReferenceTextRole();
     }
 
     #[DataProvider('docReferenceProvider')]

--- a/packages/guides-restructured-text/tests/unit/TextRoles/ReferenceTextRoleTest.php
+++ b/packages/guides-restructured-text/tests/unit/TextRoles/ReferenceTextRoleTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\TextRoles;
 
-use Monolog\Logger;
 use phpDocumentor\Guides\Nodes\Inline\ReferenceNode;
 use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -13,15 +12,13 @@ use PHPUnit\Framework\TestCase;
 
 class ReferenceTextRoleTest extends TestCase
 {
-    private Logger $logger;
     private ReferenceTextRole $referenceTextRole;
     private DocumentParserContext&MockObject $documentParserContext;
 
     public function setUp(): void
     {
-        $this->logger = new Logger('test');
         $this->documentParserContext = $this->createMock(DocumentParserContext::class);
-        $this->referenceTextRole = new ReferenceTextRole($this->logger);
+        $this->referenceTextRole = new ReferenceTextRole();
     }
 
     #[DataProvider('referenceProvider')]

--- a/tests/Functional/tests/links/links.html
+++ b/tests/Functional/tests/links/links.html
@@ -10,3 +10,5 @@ pick it up from <a href="ftp://foo.example.com/rfc/">ftp://foo.example.com/rfc/<
 <a href="http://www.ics.uci.edu/pub/ietf/uri/historical.html#WARNING">http://www.ics.uci.edu/pub/ietf/uri/historical.html#WARNING</a>.</p>
 <p>You can read more on the features of Embeddables objects <a href="http://docs.doctrine-project.org/en/latest/tutorials/embeddables.html">in the documentation</a>.</p>
 <p>Doctrine has a few links that are between brackets (<a href="https://www.doctrine-project.org/projects/doctrine-orm/en/2.16/reference/dql-doctrine-query-language.html#query-hints">such as here</a>)</p>
+<p>Links may use reserved characters as name like <a href="https://html.spec.whatwg.org/#the-head-element">this one linking to the &lt;head&gt; element</a>.
+But this <code>&lt;</code> is not a link <code>&gt;</code>.</p>

--- a/tests/Functional/tests/links/links.rst
+++ b/tests/Functional/tests/links/links.rst
@@ -25,5 +25,9 @@ You can read more on the features of Embeddables objects `in the documentation
 Doctrine has a few links that are between brackets (`such as here
 <https://www.doctrine-project.org/projects/doctrine-orm/en/2.16/reference/dql-doctrine-query-language.html#query-hints>`_)
 
+Links may use reserved characters as name like `this one linking to the <head> element`_.
+But this :code:`<` is not a link :code:`>`.
+
 .. _`xkcd`: http://xkcd.com/
 .. _something: http://something.com/
+.. _`this one linking to the <head> element`: https://html.spec.whatwg.org/#the-head-element


### PR DESCRIPTION
These characters are valid and only the last `<...>` must be treated as the embedded URL.

This PR removes using the inline lexer inside references, reSt doesn't allow nested inline nodes and the only thing required is getting the embedded URL (if there is any). This reduces a lot of complexity