### PR TITLE
Upgrade to latest league/csv

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -401,35 +401,36 @@
         },
         {
             "name": "league/csv",
-            "version": "9.11.0",
+            "version": "9.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/csv.git",
-                "reference": "33149c4bea4949aa4fa3d03fb11ed28682168b39"
+                "reference": "3690cc71bfe8dc3b6daeef356939fac95348f0a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/csv/zipball/33149c4bea4949aa4fa3d03fb11ed28682168b39",
-                "reference": "33149c4bea4949aa4fa3d03fb11ed28682168b39",
+                "url": "https://api.github.com/repos/thephpleague/csv/zipball/3690cc71bfe8dc3b6daeef356939fac95348f0a8",
+                "reference": "3690cc71bfe8dc3b6daeef356939fac95348f0a8",
                 "shasum": ""
             },
             "require": {
+                "ext-filter": "*",
                 "ext-json": "*",
                 "ext-mbstring": "*",
                 "php": "^8.1.2"
             },
             "require-dev": {
-                "doctrine/collections": "^2.1.3",
+                "doctrine/collections": "^2.1.4",
                 "ext-dom": "*",
                 "ext-xdebug": "*",
                 "friendsofphp/php-cs-fixer": "^v3.22.0",
-                "phpbench/phpbench": "^1.2.14",
-                "phpstan/phpstan": "^1.10.26",
-                "phpstan/phpstan-deprecation-rules": "^1.1.3",
-                "phpstan/phpstan-phpunit": "^1.3.13",
-                "phpstan/phpstan-strict-rules": "^1.5.1",
-                "phpunit/phpunit": "^10.3.1",
-                "symfony/var-dumper": "^6.3.3"
+                "phpbench/phpbench": "^1.2.15",
+                "phpstan/phpstan": "^1.10.50",
+                "phpstan/phpstan-deprecation-rules": "^1.1.4",
+                "phpstan/phpstan-phpunit": "^1.3.15",
+                "phpstan/phpstan-strict-rules": "^1.5.2",
+                "phpunit/phpunit": "^10.5.3",
+                "symfony/var-dumper": "^6.4.0"
             },
             "suggest": {
                 "ext-dom": "Required to use the XMLConverter and the HTMLConverter classes",
@@ -485,7 +486,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-23T10:09:54+00:00"
+            "time": "2023-12-16T11:03:20+00:00"
         },
         {
             "name": "league/flysystem",

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/CsvTableDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/CsvTableDirective.php
@@ -18,9 +18,11 @@ use Psr\Log\LoggerInterface;
 
 use function array_filter;
 use function array_map;
+use function assert;
 use function count;
 use function explode;
 use function implode;
+use function is_string;
 use function strval;
 use function trim;
 
@@ -93,6 +95,7 @@ final class CsvTableDirective extends BaseDirective
         foreach ($csv->getRecords() as $record) {
             $tableRow = new TableRow();
             foreach ($record as $column) {
+                assert(is_string($column) || $column === null);
                 $columnNode = new TableColumn($column ?? '', 1, []);
                 $tableRow->addColumn($this->buildColumn($columnNode, $blockContext, $this->productions));
             }


### PR DESCRIPTION
That version adds more insight on what is returned by `League\Csv::getRecords()`, which is now documented as an `Iterator<array<mixed>>`. Since we are using strict types, we are already assuming that mixed will in fact always be a string or null. Let's make the assumption clear to static analysis tools.