### PR TITLE
Build docs when the source code change

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -7,12 +7,14 @@ on: # yamllint disable-line rule:truthy
     paths:
       - ".github/workflows/documentation.yml"
       - "docs/**"
+      - "packages/**"
   push:
     branches:
       - "main"
     paths:
       - ".github/workflows/documentation.yml"
       - "docs/**"
+      - "packages/**"
 
 jobs:
   validate-with-guides:

--- a/docs/rst-reference/text-roles.rst
+++ b/docs/rst-reference/text-roles.rst
@@ -6,7 +6,7 @@ Text Roles
 
 Text roles can be used to style content inline. Some text roles have advanced processing such as reference resolving.
 
-You can also :doc:`add your own custom text roles</extension/text-roles>`.
+You can also :doc:`add your own custom text roles </extension/text-roles>`.
 
 Currently the following text roles are implemented:
 


### PR DESCRIPTION
This project is a rare exception of a project that actually needs to build its docs when the code changes, because it is using itself to build those docs.