### PR TITLE
Render inline nodes in sidebar title

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Directives/SidebarDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/SidebarDirective.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 use phpDocumentor\Guides\Nodes\CollectionNode;
+use phpDocumentor\Guides\Nodes\InlineCompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Nodes\SidebarNode;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
@@ -41,7 +42,7 @@ class SidebarDirective extends SubDirective
         Directive $directive,
     ): Node|null {
         return new SidebarNode(
-            $directive->getData(),
+            $directive->getDataNode() ?? InlineCompoundNode::getPlainTextInlineNode($directive->getData()),
             $collectionNode->getChildren(),
         );
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Nodes/SidebarNode.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Nodes/SidebarNode.php
@@ -14,18 +14,19 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Nodes;
 
 use phpDocumentor\Guides\Nodes\CompoundNode;
+use phpDocumentor\Guides\Nodes\InlineCompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
 
 /** @extends CompoundNode<Node> */
 final class SidebarNode extends CompoundNode
 {
     /** {@inheritDoc} */
-    public function __construct(private readonly string $title, array $value)
+    public function __construct(private readonly InlineCompoundNode $title, array $value)
     {
         parent::__construct($value);
     }
 
-    public function getTitle(): string
+    public function getTitle(): InlineCompoundNode
     {
         return $this->title;
     }

--- a/packages/guides/resources/template/html/structure/sidebar.html.twig
+++ b/packages/guides/resources/template/html/structure/sidebar.html.twig
@@ -1,5 +1,5 @@
 <div class="admonition-wrapper">
-    <div class="admonition admonition-sidebar"><p class="sidebar-title">{{ title }}</p>
+    <div class="admonition admonition-sidebar"><p class="sidebar-title">{{ renderNode(title) }}</p>
         {{ renderNode(node) }}
     </div>
 </div>

--- a/tests/Functional/tests/sidebar/sidebar.html
+++ b/tests/Functional/tests/sidebar/sidebar.html
@@ -1,0 +1,8 @@
+<div class="admonition-wrapper">
+    <div class="admonition admonition-sidebar">
+        <p class="sidebar-title">More about the <code>&lt;aside&gt;</code> element</p>
+        <p>The <code>&lt;aside&gt;</code> HTML element represents a portion of a document whose
+content is only indirectly related to the document&#039;s main content.
+Asides are frequently presented as sidebars or call-out boxes.</p>
+    </div>
+</div>

--- a/tests/Functional/tests/sidebar/sidebar.rst
+++ b/tests/Functional/tests/sidebar/sidebar.rst
@@ -1,0 +1,5 @@
+.. sidebar:: More about the ``<aside>`` element
+
+    The ``<aside>`` HTML element represents a portion of a document whose
+    content is only indirectly related to the document's main content.
+    Asides are frequently presented as sidebars or call-out boxes.


### PR DESCRIPTION
Sidebar titles are allowed to contain inline markup.

This is a small BC break, as we change the property of the section node.