### PR TITLE
Fix usage of ref text role

### DIFF
--- a/tests/Integration/tests/references/reference-with-escape/expected/index.html
+++ b/tests/Integration/tests/references/reference-with-escape/expected/index.html
@@ -10,7 +10,7 @@
     <h1>the &lt;head&gt;</h1>
 
             <a id="anchor"></a>
-        <p>See also <a href="/index.html#anchor">the &lt;head&gt; of this file</a> or <a href="/index.html#anchor">the &lt;head&gt;</a>.</p>
+        <p>See also <a href="/index.html#anchor">the &lt;head&gt; of this file</a> or <a href="/index.html#the-head">the &lt;head&gt;</a>.</p>
     </div>
 
 <!-- content end -->

--- a/tests/Integration/tests/references/reference-with-escape/input/index.rst
+++ b/tests/Integration/tests/references/reference-with-escape/input/index.rst
@@ -1,6 +1,6 @@
-..  _anchor:
+.. _anchor:
 
 the \<head\>
 ============
 
-See also :ref:`the \<head\> of this file <_anchor>` or :ref:`the \<head\>`.
+See also :ref:`the \<head\> of this file <anchor>` or `the \<head\>`_.

--- a/tests/Integration/tests/references/reference-with-escape/input/skip
+++ b/tests/Integration/tests/references/reference-with-escape/input/skip
@@ -1,1 +1,0 @@
-Escaping of references does not work properly


### PR DESCRIPTION
A ref role can only reference anchors, not implement references. Besides, the `_` is not part of the anchor name, but part of the syntax to define an anchor.

Fixing the syntax in the test case shows that references work as expected using escape characters, but there is an issue in the rendering of the section title in the reference when using named phrases. I can look into this next week, if needed.