### PR TITLE
[POC] Cachable inline rule match

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Parser/InlineParser.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/InlineParser.php
@@ -8,6 +8,7 @@ use Exception;
 use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 use phpDocumentor\Guides\Nodes\InlineCompoundNode;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules\InlineRule;
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules\MatchCachable;
 
 use function usort;
 
@@ -15,27 +16,45 @@ class InlineParser
 {
     /** @var InlineRule[] */
     private array $rules;
+    private $lexer;
+
+    /** @var InlineRule[] */
+    private array $cachedRules = [];
 
     /** @param iterable<InlineRule> $inlineRules */
     public function __construct(iterable $inlineRules)
     {
+        $this->lexer = new InlineLexer();
         $this->rules = [...$inlineRules];
         usort($this->rules, static fn (InlineRule $a, InlineRule $b): int => $a->getPriority() > $b->getPriority() ? -1 : 1);
     }
 
     public function parse(string $content, BlockContext $blockContext): InlineCompoundNode
     {
-        $lexer = new InlineLexer();
-        $lexer->setInput($content);
-        $lexer->moveNext();
-        $lexer->moveNext();
+        $this->lexer->setInput($content);
+        $this->lexer->moveNext();
+        $this->lexer->moveNext();
         $nodes = [];
         $previous = null;
-        while ($lexer->token !== null) {
-            foreach ($this->rules as $inlineRule) {
+        while ($this->lexer->token !== null) {
+            if (isset($this->cachedRules[$this->lexer->token->type])) {
+                $node = $this->cachedRules[$this->lexer->token->type]->apply($blockContext, $this->lexer);
+                if ($node !== null) {
+                    $nodes[] = $node;
+                    $previous = $node;
+                    continue;
+                }
+            }
+
+            foreach ($this->rules as $key => $inlineRule) {
                 $node = null;
-                if ($inlineRule->applies($lexer)) {
-                    $node = $inlineRule->apply($blockContext, $lexer);
+                if ($inlineRule->applies($this->lexer)) {
+                    if ($inlineRule instanceof MatchCachable && $inlineRule->isCacheable()) {
+                        $this->cachedRules[$this->lexer->token->type] = $inlineRule;
+                        unset($this->rules[$key]);
+                    }
+
+                    $node = $inlineRule->apply($blockContext, $this->lexer);
                 }
 
                 if ($node === null) {

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/LiteralRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/LiteralRule.php
@@ -14,7 +14,7 @@ use function substr;
 /**
  * Rule for literals such as ``something``
  */
-class LiteralRule extends AbstractInlineRule
+class LiteralRule extends AbstractInlineRule implements MatchCachable
 {
     public function applies(InlineLexer $lexer): bool
     {
@@ -37,5 +37,10 @@ class LiteralRule extends AbstractInlineRule
     {
         // Should be executed first as any other rules within may not be interpreted
         return 10_000;
+    }
+
+    public function isCacheable(): bool
+    {
+        return true;
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/MatchCachable.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/MatchCachable.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
+
+interface MatchCachable
+{
+    public function isCacheable(): bool;
+}

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/NamedReferenceRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/NamedReferenceRule.php
@@ -19,7 +19,7 @@ use function rtrim;
  *
  * @see https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#hyperlink-references
  */
-class NamedReferenceRule extends ReferenceRule
+class NamedReferenceRule extends ReferenceRule implements MatchCachable
 {
     public function applies(InlineLexer $lexer): bool
     {
@@ -39,5 +39,10 @@ class NamedReferenceRule extends ReferenceRule
     public function getPriority(): int
     {
         return 1000;
+    }
+
+    public function isCacheable(): bool
+    {
+        return true;
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/NbspRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/NbspRule.php
@@ -11,7 +11,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 /**
  * Rule to parse for non-breaking spaces: a~b
  */
-class NbspRule extends ReferenceRule
+final class NbspRule extends AbstractInlineRule implements MatchCachable
 {
     public function applies(InlineLexer $lexer): bool
     {
@@ -28,5 +28,10 @@ class NbspRule extends ReferenceRule
     public function getPriority(): int
     {
         return 1000;
+    }
+
+    public function isCacheable(): bool
+    {
+        return true;
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/StandaloneEmailRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/StandaloneEmailRule.php
@@ -17,7 +17,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
  *
  * @see https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#standalone-hyperlinks
  */
-class StandaloneEmailRule extends ReferenceRule
+class StandaloneEmailRule extends ReferenceRule implements MatchCachable
 {
     public function applies(InlineLexer $lexer): bool
     {
@@ -37,5 +37,10 @@ class StandaloneEmailRule extends ReferenceRule
     public function getPriority(): int
     {
         return 100;
+    }
+
+    public function isCacheable(): bool
+    {
+        return true;
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/StandaloneHyperlinkRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/StandaloneHyperlinkRule.php
@@ -17,7 +17,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
  *
  * @see https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#standalone-hyperlinks
  */
-class StandaloneHyperlinkRule extends ReferenceRule
+class StandaloneHyperlinkRule extends ReferenceRule implements MatchCachable
 {
     public function applies(InlineLexer $lexer): bool
     {
@@ -37,5 +37,10 @@ class StandaloneHyperlinkRule extends ReferenceRule
     public function getPriority(): int
     {
         return 100;
+    }
+
+    public function isCacheable(): bool
+    {
+        return true;
     }
 }


### PR DESCRIPTION
This is an attempt to cut down the parser duration. This change already stripped of 300ms on a total of 5.6 seconds on the symfony docs on just the parsing. (~6%) 

I do not really like the current implementation of the cache so I would like to get some feedback from you. 