### PR TITLE
Fix usage of ref text role

### DIFF
--- a/tests/Integration/tests/references/reference-with-escape/expected/index.html
+++ b/tests/Integration/tests/references/reference-with-escape/expected/index.html
@@ -10,7 +10,7 @@
     <h1>the &lt;head&gt;</h1>
 
             <a id="anchor"></a>
-        <p>See also <a href="/index.html#anchor">the &lt;head&gt; of this file</a> or <a href="/index.html#anchor">the &lt;head&gt;</a>.</p>
+        <p>See also <a href="/index.html#anchor">the &lt;head&gt; of this file</a> or <a href="/index.html#the-head">the &lt;head&gt;</a>.</p>
     </div>
 
 <!-- content end -->

--- a/tests/Integration/tests/references/reference-with-escape/input/index.rst
+++ b/tests/Integration/tests/references/reference-with-escape/input/index.rst
@@ -1,6 +1,6 @@
-..  _anchor:
+.. _anchor:
 
 the \<head\>
 ============
 
-See also :ref:`the \<head\> of this file <_anchor>` or :ref:`the \<head\>`.
+See also :ref:`the \<head\> of this file <anchor>` or `the \<head\>`_.

--- a/tests/Integration/tests/references/reference-with-escape/input/skip
+++ b/tests/Integration/tests/references/reference-with-escape/input/skip
@@ -1,1 +1,1 @@
-Escaping of references does not work properly
+Named phrases don't render escape characters correctly


### PR DESCRIPTION
References work correctly, but somehow we rendering the escape slashes in named phrases.

```
--- Expected
+++ Actual
@@ @@
 '<div class="section" id="the-head">\n
 <h1>the &lt;head&gt;</h1>\n
 <a id="anchor"></a>\n
-<p>See also <a href="/index.html#anchor">the &lt;head&gt; of this file</a> or <a href="/index.html#the-head">the &lt;head&gt;</a>.</p>\n
+<p>See also <a href="/index.html#anchor">the &lt;head&gt; of this file</a> or <a href="/index.html#the-head">the \&lt;head\&gt;</a>.</p>\n
 </div>'
```