### PR TITLE
Do not add anchor to URL for document (root) titles

### DIFF
--- a/packages/guides/src/Compiler/NodeTransformers/MenuNodeAddEntryTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/MenuNodeAddEntryTransformer.php
@@ -73,7 +73,7 @@ class MenuNodeAddEntryTransformer implements NodeTransformer
                     $documentEntry->getFile(),
                     $documentEntry->getTitle(),
                     [],
-                    false,
+                    true,
                     1,
                     '',
                     $this->isInRootline($documentEntry, $compilerContext->getDocumentNode()->getDocumentEntry()),

--- a/packages/guides/src/Compiler/NodeTransformers/MenuNodeAddSubDocumentsTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/MenuNodeAddSubDocumentsTransformer.php
@@ -57,7 +57,7 @@ class MenuNodeAddSubDocumentsTransformer implements NodeTransformer
                 $subDocumentEntryNode->getFile(),
                 $subDocumentEntryNode->getTitle(),
                 [],
-                false,
+                true,
                 $currentLevel,
                 '',
                 self::isInRootline($subDocumentEntryNode, $compilerContext->getDocumentNode()->getDocumentEntry()),

--- a/packages/guides/src/NodeRenderers/Html/BreadCrumbNodeRenderer.php
+++ b/packages/guides/src/NodeRenderers/Html/BreadCrumbNodeRenderer.php
@@ -100,7 +100,7 @@ class BreadCrumbNodeRenderer implements NodeRenderer
             $documentEntry->getFile(),
             $documentEntry->getTitle(),
             [],
-            false,
+            true,
             $level,
             '',
             true,

--- a/packages/guides/src/NodeRenderers/Html/MenuEntryRenderer.php
+++ b/packages/guides/src/NodeRenderers/Html/MenuEntryRenderer.php
@@ -11,6 +11,8 @@ use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\Renderer\UrlGenerator\UrlGeneratorInterface;
 use phpDocumentor\Guides\TemplateRenderer;
 
+use function assert;
+
 /** @implements NodeRenderer<MenuEntryNode> */
 final class MenuEntryRenderer implements NodeRenderer
 {
@@ -27,11 +29,13 @@ final class MenuEntryRenderer implements NodeRenderer
 
     public function render(Node $node, RenderContext $renderContext): string
     {
+        assert($node instanceof MenuEntryNode);
+
         return $this->renderer->renderTemplate(
             $renderContext,
             'body/menu/menu-item.html.twig',
             [
-                'url' => $this->urlGenerator->generateCanonicalOutputUrl($renderContext, $node->getUrl(), $node->getValue()->getId()),
+                'url' => $this->urlGenerator->generateCanonicalOutputUrl($renderContext, $node->getUrl(), !$node->isDocumentRoot() ? $node->getValue()->getId() : null),
                 'node' => $node,
             ],
         );

--- a/tests/Integration/tests-full/bootstrap/bootstrap-default-menu-several/expected/index.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-default-menu-several/expected/index.html
@@ -124,14 +124,14 @@
             <div class="toc">
             <p class="caption">Main Menu</p>
     <ul class="menu-level">
-    <li class="toc-item"><a href="anotherPage.html#another-page">Another Page</a></li>
+    <li class="toc-item"><a href="anotherPage.html">Another Page</a></li>
 
-    <li class="toc-item"><a href="somePage.html#some-page">Some Page</a></li>
+    <li class="toc-item"><a href="somePage.html">Some Page</a></li>
 
-    <li class="toc-item"><a href="subpages/index.html#subpages">Subpages</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="subpages/subpage1.html#subpages-1">Subpages 1</a></li>
+    <li class="toc-item"><a href="subpages/index.html">Subpages</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="subpages/subpage1.html">Subpages 1</a></li>
 
-            <li class="toc-item"><a href="subpages/subpage2.html#subpages-2">Subpages 2</a></li>
+            <li class="toc-item"><a href="subpages/subpage2.html">Subpages 2</a></li>
 
                     </ul></li>
 
@@ -141,7 +141,7 @@
             <div class="toc">
             <p class="caption">Additional Menu</p>
     <ul class="menu-level">
-    <li class="toc-item"><a href="yetAnotherPage.html#yet-another-page">Yet Another Page</a></li>
+    <li class="toc-item"><a href="yetAnotherPage.html">Yet Another Page</a></li>
 
     </ul>
 </div>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-default-menu-several/expected/subpages/index.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-default-menu-several/expected/subpages/index.html
@@ -121,9 +121,9 @@
 
             <div class="toc">
     <ul class="menu-level">
-    <li class="toc-item"><a href="subpage1.html#subpages-1">Subpages 1</a></li>
+    <li class="toc-item"><a href="subpage1.html">Subpages 1</a></li>
 
-    <li class="toc-item"><a href="subpage2.html#subpages-2">Subpages 2</a></li>
+    <li class="toc-item"><a href="subpage2.html">Subpages 2</a></li>
 
     </ul>
 </div>

--- a/tests/Integration/tests/graphs/plantuml-external/expected/index.html
+++ b/tests/Integration/tests/graphs/plantuml-external/expected/index.html
@@ -14,7 +14,7 @@
         <figcaption>Figure 1-1: Application flow</figcaption></figure>
     <div class="toc">
         <ul class="menu-level">
-            <li class="toc-item"><a href="/Plantuml/index.html#uml-directive">Uml Directive</a></li>
+            <li class="toc-item"><a href="/Plantuml/index.html">Uml Directive</a></li>
 
         </ul>
     </div>

--- a/tests/Integration/tests/navigation/breadcrumb/expected/index.html
+++ b/tests/Integration/tests/navigation/breadcrumb/expected/index.html
@@ -9,35 +9,35 @@
             <p>Lorem Ipsum Dolor.</p>
             <div class="toc">
     <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
+    <li class="toc-item"><a href="/page1.html">Page 1</a></li>
 
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
+    <li class="toc-item"><a href="/page2.html">Page 2</a></li>
 
-    <li class="toc-item"><a href="/level-1-1/index.html#level-1-1">Level 1-1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a></li>
+    <li class="toc-item"><a href="/level-1-1/index.html">Level 1-1</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="/level-1-1/subpage1.html">Subpage 1, Level 1-1</a></li>
 
-            <li class="toc-item"><a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a></li>
+            <li class="toc-item"><a href="/level-1-1/subpage2.html">Subpage 2, Level 1-1</a></li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a></li>
+            <li class="toc-item"><a href="/level-1-1/level-2-1/index.html">Level 2-1</a>        <ul class="menu-level-2">
+            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage1.html">Subpage 1, Level 2-1</a></li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a></li>
+            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage2.html">Subpage 2, Level 2-1</a></li>
 
                     </ul></li>
 
+            <li class="toc-item"><a href="/level-1-1/level-2-2/index.html">Level 2-2</a>        <ul class="menu-level-2">
+            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage1.html">Subpage 1, Level 2-2</a></li>
+
+            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage2.html">Subpage 2, Level 2-2</a></li>
+
                     </ul></li>
 
-    <li class="toc-item"><a href="/level-1-2/index.html#level-1-2">Level 1-2</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
+                    </ul></li>
 
-            <li class="toc-item"><a href="/level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a></li>
+    <li class="toc-item"><a href="/level-1-2/index.html">Level 1-2</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="/level-1-2/subpage1.html">Subpage 1, Level 1-2</a></li>
+
+            <li class="toc-item"><a href="/level-1-2/subpage2.html">Subpage 2, Level 1-2</a></li>
 
                     </ul></li>
 

--- a/tests/Integration/tests/navigation/breadcrumb/expected/page1.html
+++ b/tests/Integration/tests/navigation/breadcrumb/expected/page1.html
@@ -11,35 +11,35 @@
             <p>Lorem Ipsum Dolor.</p>
             <div class="menu">
     <ul class="menu-level">
-    <li class="toc-item current active"><a href="/page1.html#page-1">Page 1</a></li>
+    <li class="toc-item current active"><a href="/page1.html">Page 1</a></li>
 
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
+    <li class="toc-item"><a href="/page2.html">Page 2</a></li>
 
-    <li class="toc-item"><a href="/level-1-1/index.html#level-1-1">Level 1-1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a></li>
+    <li class="toc-item"><a href="/level-1-1/index.html">Level 1-1</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="/level-1-1/subpage1.html">Subpage 1, Level 1-1</a></li>
 
-            <li class="toc-item"><a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a></li>
+            <li class="toc-item"><a href="/level-1-1/subpage2.html">Subpage 2, Level 1-1</a></li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a></li>
+            <li class="toc-item"><a href="/level-1-1/level-2-1/index.html">Level 2-1</a>        <ul class="menu-level-2">
+            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage1.html">Subpage 1, Level 2-1</a></li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a></li>
+            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage2.html">Subpage 2, Level 2-1</a></li>
 
                     </ul></li>
 
+            <li class="toc-item"><a href="/level-1-1/level-2-2/index.html">Level 2-2</a>        <ul class="menu-level-2">
+            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage1.html">Subpage 1, Level 2-2</a></li>
+
+            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage2.html">Subpage 2, Level 2-2</a></li>
+
                     </ul></li>
 
-    <li class="toc-item"><a href="/level-1-2/index.html#level-1-2">Level 1-2</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
+                    </ul></li>
 
-            <li class="toc-item"><a href="/level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a></li>
+    <li class="toc-item"><a href="/level-1-2/index.html">Level 1-2</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="/level-1-2/subpage1.html">Subpage 1, Level 1-2</a></li>
+
+            <li class="toc-item"><a href="/level-1-2/subpage2.html">Subpage 2, Level 1-2</a></li>
 
                     </ul></li>
 

--- a/tests/Integration/tests/navigation/menu-level-3/expected/level-1-1/level-2-2/subpage1.html
+++ b/tests/Integration/tests/navigation/menu-level-3/expected/level-1-1/level-2-2/subpage1.html
@@ -5,35 +5,35 @@
             <p>Lorem Ipsum Dolor.</p>
             <div class="menu">
     <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
+    <li class="toc-item"><a href="/page1.html">Page 1</a></li>
 
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
+    <li class="toc-item"><a href="/page2.html">Page 2</a></li>
 
-    <li class="toc-item active"><a href="/level-1-1/index.html#level-1-1">Level 1-1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a></li>
+    <li class="toc-item active"><a href="/level-1-1/index.html">Level 1-1</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="/level-1-1/subpage1.html">Subpage 1, Level 1-1</a></li>
 
-            <li class="toc-item"><a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a></li>
+            <li class="toc-item"><a href="/level-1-1/subpage2.html">Subpage 2, Level 1-1</a></li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a></li>
+            <li class="toc-item"><a href="/level-1-1/level-2-1/index.html">Level 2-1</a>        <ul class="menu-level-2">
+            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage1.html">Subpage 1, Level 2-1</a></li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item active"><a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>        <ul class="menu-level-2">
-            <li class="toc-item current active"><a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a></li>
+            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage2.html">Subpage 2, Level 2-1</a></li>
 
                     </ul></li>
 
+            <li class="toc-item active"><a href="/level-1-1/level-2-2/index.html">Level 2-2</a>        <ul class="menu-level-2">
+            <li class="toc-item current active"><a href="/level-1-1/level-2-2/subpage1.html">Subpage 1, Level 2-2</a></li>
+
+            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage2.html">Subpage 2, Level 2-2</a></li>
+
                     </ul></li>
 
-    <li class="toc-item"><a href="/level-1-2/index.html#level-1-2">Level 1-2</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
+                    </ul></li>
 
-            <li class="toc-item"><a href="/level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a></li>
+    <li class="toc-item"><a href="/level-1-2/index.html">Level 1-2</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="/level-1-2/subpage1.html">Subpage 1, Level 1-2</a></li>
+
+            <li class="toc-item"><a href="/level-1-2/subpage2.html">Subpage 2, Level 1-2</a></li>
 
                     </ul></li>
 

--- a/tests/Integration/tests/navigation/menu-level-3/expected/level-1-2/subpage1.html
+++ b/tests/Integration/tests/navigation/menu-level-3/expected/level-1-2/subpage1.html
@@ -5,35 +5,35 @@
             <p>Lorem Ipsum Dolor.</p>
             <div class="menu">
     <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
+    <li class="toc-item"><a href="/page1.html">Page 1</a></li>
 
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
+    <li class="toc-item"><a href="/page2.html">Page 2</a></li>
 
-    <li class="toc-item"><a href="/level-1-1/index.html#level-1-1">Level 1-1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a></li>
+    <li class="toc-item"><a href="/level-1-1/index.html">Level 1-1</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="/level-1-1/subpage1.html">Subpage 1, Level 1-1</a></li>
 
-            <li class="toc-item"><a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a></li>
+            <li class="toc-item"><a href="/level-1-1/subpage2.html">Subpage 2, Level 1-1</a></li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a></li>
+            <li class="toc-item"><a href="/level-1-1/level-2-1/index.html">Level 2-1</a>        <ul class="menu-level-2">
+            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage1.html">Subpage 1, Level 2-1</a></li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a></li>
+            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage2.html">Subpage 2, Level 2-1</a></li>
 
                     </ul></li>
 
+            <li class="toc-item"><a href="/level-1-1/level-2-2/index.html">Level 2-2</a>        <ul class="menu-level-2">
+            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage1.html">Subpage 1, Level 2-2</a></li>
+
+            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage2.html">Subpage 2, Level 2-2</a></li>
+
                     </ul></li>
 
-    <li class="toc-item active"><a href="/level-1-2/index.html#level-1-2">Level 1-2</a>        <ul class="menu-level-1">
-            <li class="toc-item current active"><a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
+                    </ul></li>
 
-            <li class="toc-item"><a href="/level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a></li>
+    <li class="toc-item active"><a href="/level-1-2/index.html">Level 1-2</a>        <ul class="menu-level-1">
+            <li class="toc-item current active"><a href="/level-1-2/subpage1.html">Subpage 1, Level 1-2</a></li>
+
+            <li class="toc-item"><a href="/level-1-2/subpage2.html">Subpage 2, Level 1-2</a></li>
 
                     </ul></li>
 

--- a/tests/Integration/tests/navigation/menu-level-3/expected/page1.html
+++ b/tests/Integration/tests/navigation/menu-level-3/expected/page1.html
@@ -5,35 +5,35 @@
             <p>Lorem Ipsum Dolor.</p>
             <div class="menu">
     <ul class="menu-level">
-    <li class="toc-item current active"><a href="/page1.html#page-1">Page 1</a></li>
+    <li class="toc-item current active"><a href="/page1.html">Page 1</a></li>
 
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
+    <li class="toc-item"><a href="/page2.html">Page 2</a></li>
 
-    <li class="toc-item"><a href="/level-1-1/index.html#level-1-1">Level 1-1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a></li>
+    <li class="toc-item"><a href="/level-1-1/index.html">Level 1-1</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="/level-1-1/subpage1.html">Subpage 1, Level 1-1</a></li>
 
-            <li class="toc-item"><a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a></li>
+            <li class="toc-item"><a href="/level-1-1/subpage2.html">Subpage 2, Level 1-1</a></li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a></li>
+            <li class="toc-item"><a href="/level-1-1/level-2-1/index.html">Level 2-1</a>        <ul class="menu-level-2">
+            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage1.html">Subpage 1, Level 2-1</a></li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a></li>
+            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage2.html">Subpage 2, Level 2-1</a></li>
 
                     </ul></li>
 
+            <li class="toc-item"><a href="/level-1-1/level-2-2/index.html">Level 2-2</a>        <ul class="menu-level-2">
+            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage1.html">Subpage 1, Level 2-2</a></li>
+
+            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage2.html">Subpage 2, Level 2-2</a></li>
+
                     </ul></li>
 
-    <li class="toc-item"><a href="/level-1-2/index.html#level-1-2">Level 1-2</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
+                    </ul></li>
 
-            <li class="toc-item"><a href="/level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a></li>
+    <li class="toc-item"><a href="/level-1-2/index.html">Level 1-2</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="/level-1-2/subpage1.html">Subpage 1, Level 1-2</a></li>
+
+            <li class="toc-item"><a href="/level-1-2/subpage2.html">Subpage 2, Level 1-2</a></li>
 
                     </ul></li>
 

--- a/tests/Integration/tests/navigation/menu-relative/expected/level-1-1/level-2-2/subpage1.html
+++ b/tests/Integration/tests/navigation/menu-relative/expected/level-1-1/level-2-2/subpage1.html
@@ -5,35 +5,35 @@
             <p>Lorem Ipsum Dolor.</p>
             <div class="menu">
     <ul class="menu-level">
-    <li class="toc-item"><a href="../../page1.html#page-1">Page 1</a></li>
+    <li class="toc-item"><a href="../../page1.html">Page 1</a></li>
 
-    <li class="toc-item"><a href="../../page2.html#page-2">Page 2</a></li>
+    <li class="toc-item"><a href="../../page2.html">Page 2</a></li>
 
-    <li class="toc-item active"><a href="../index.html#level-1-1">Level 1-1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="../subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a></li>
+    <li class="toc-item active"><a href="../index.html">Level 1-1</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="../subpage1.html">Subpage 1, Level 1-1</a></li>
 
-            <li class="toc-item"><a href="../subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a></li>
+            <li class="toc-item"><a href="../subpage2.html">Subpage 2, Level 1-1</a></li>
 
-            <li class="toc-item"><a href="../level-2-1/index.html#level-2-1">Level 2-1</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="../level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a></li>
+            <li class="toc-item"><a href="../level-2-1/index.html">Level 2-1</a>        <ul class="menu-level-2">
+            <li class="toc-item"><a href="../level-2-1/subpage1.html">Subpage 1, Level 2-1</a></li>
 
-            <li class="toc-item"><a href="../level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item active"><a href="index.html#level-2-2">Level 2-2</a>        <ul class="menu-level-2">
-            <li class="toc-item current active"><a href="#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
-
-            <li class="toc-item"><a href="subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a></li>
+            <li class="toc-item"><a href="../level-2-1/subpage2.html">Subpage 2, Level 2-1</a></li>
 
                     </ul></li>
 
+            <li class="toc-item active"><a href="index.html">Level 2-2</a>        <ul class="menu-level-2">
+            <li class="toc-item current active"><a href="#">Subpage 1, Level 2-2</a></li>
+
+            <li class="toc-item"><a href="subpage2.html">Subpage 2, Level 2-2</a></li>
+
                     </ul></li>
 
-    <li class="toc-item"><a href="../../level-1-2/index.html#level-1-2">Level 1-2</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="../../level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
+                    </ul></li>
 
-            <li class="toc-item"><a href="../../level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a></li>
+    <li class="toc-item"><a href="../../level-1-2/index.html">Level 1-2</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="../../level-1-2/subpage1.html">Subpage 1, Level 1-2</a></li>
+
+            <li class="toc-item"><a href="../../level-1-2/subpage2.html">Subpage 2, Level 1-2</a></li>
 
                     </ul></li>
 

--- a/tests/Integration/tests/navigation/menu-relative/expected/level-1-2/subpage1.html
+++ b/tests/Integration/tests/navigation/menu-relative/expected/level-1-2/subpage1.html
@@ -5,35 +5,35 @@
             <p>Lorem Ipsum Dolor.</p>
             <div class="menu">
     <ul class="menu-level">
-    <li class="toc-item"><a href="../page1.html#page-1">Page 1</a></li>
+    <li class="toc-item"><a href="../page1.html">Page 1</a></li>
 
-    <li class="toc-item"><a href="../page2.html#page-2">Page 2</a></li>
+    <li class="toc-item"><a href="../page2.html">Page 2</a></li>
 
-    <li class="toc-item"><a href="../level-1-1/index.html#level-1-1">Level 1-1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="../level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a></li>
+    <li class="toc-item"><a href="../level-1-1/index.html">Level 1-1</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="../level-1-1/subpage1.html">Subpage 1, Level 1-1</a></li>
 
-            <li class="toc-item"><a href="../level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a></li>
+            <li class="toc-item"><a href="../level-1-1/subpage2.html">Subpage 2, Level 1-1</a></li>
 
-            <li class="toc-item"><a href="../level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="../level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a></li>
+            <li class="toc-item"><a href="../level-1-1/level-2-1/index.html">Level 2-1</a>        <ul class="menu-level-2">
+            <li class="toc-item"><a href="../level-1-1/level-2-1/subpage1.html">Subpage 1, Level 2-1</a></li>
 
-            <li class="toc-item"><a href="../level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="../level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="../level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
-
-            <li class="toc-item"><a href="../level-1-1/level-2-2/subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a></li>
+            <li class="toc-item"><a href="../level-1-1/level-2-1/subpage2.html">Subpage 2, Level 2-1</a></li>
 
                     </ul></li>
 
+            <li class="toc-item"><a href="../level-1-1/level-2-2/index.html">Level 2-2</a>        <ul class="menu-level-2">
+            <li class="toc-item"><a href="../level-1-1/level-2-2/subpage1.html">Subpage 1, Level 2-2</a></li>
+
+            <li class="toc-item"><a href="../level-1-1/level-2-2/subpage2.html">Subpage 2, Level 2-2</a></li>
+
                     </ul></li>
 
-    <li class="toc-item active"><a href="index.html#level-1-2">Level 1-2</a>        <ul class="menu-level-1">
-            <li class="toc-item current active"><a href="#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
+                    </ul></li>
 
-            <li class="toc-item"><a href="subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a></li>
+    <li class="toc-item active"><a href="index.html">Level 1-2</a>        <ul class="menu-level-1">
+            <li class="toc-item current active"><a href="#">Subpage 1, Level 1-2</a></li>
+
+            <li class="toc-item"><a href="subpage2.html">Subpage 2, Level 1-2</a></li>
 
                     </ul></li>
 

--- a/tests/Integration/tests/navigation/menu-relative/expected/page1.html
+++ b/tests/Integration/tests/navigation/menu-relative/expected/page1.html
@@ -5,35 +5,35 @@
             <p>Lorem Ipsum Dolor.</p>
             <div class="menu">
     <ul class="menu-level">
-    <li class="toc-item current active"><a href="#page-1">Page 1</a></li>
+    <li class="toc-item current active"><a href="#">Page 1</a></li>
 
-    <li class="toc-item"><a href="page2.html#page-2">Page 2</a></li>
+    <li class="toc-item"><a href="page2.html">Page 2</a></li>
 
-    <li class="toc-item"><a href="level-1-1/index.html#level-1-1">Level 1-1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a></li>
+    <li class="toc-item"><a href="level-1-1/index.html">Level 1-1</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="level-1-1/subpage1.html">Subpage 1, Level 1-1</a></li>
 
-            <li class="toc-item"><a href="level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a></li>
+            <li class="toc-item"><a href="level-1-1/subpage2.html">Subpage 2, Level 1-1</a></li>
 
-            <li class="toc-item"><a href="level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a></li>
+            <li class="toc-item"><a href="level-1-1/level-2-1/index.html">Level 2-1</a>        <ul class="menu-level-2">
+            <li class="toc-item"><a href="level-1-1/level-2-1/subpage1.html">Subpage 1, Level 2-1</a></li>
 
-            <li class="toc-item"><a href="level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
-
-            <li class="toc-item"><a href="level-1-1/level-2-2/subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a></li>
+            <li class="toc-item"><a href="level-1-1/level-2-1/subpage2.html">Subpage 2, Level 2-1</a></li>
 
                     </ul></li>
 
+            <li class="toc-item"><a href="level-1-1/level-2-2/index.html">Level 2-2</a>        <ul class="menu-level-2">
+            <li class="toc-item"><a href="level-1-1/level-2-2/subpage1.html">Subpage 1, Level 2-2</a></li>
+
+            <li class="toc-item"><a href="level-1-1/level-2-2/subpage2.html">Subpage 2, Level 2-2</a></li>
+
                     </ul></li>
 
-    <li class="toc-item"><a href="level-1-2/index.html#level-1-2">Level 1-2</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
+                    </ul></li>
 
-            <li class="toc-item"><a href="level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a></li>
+    <li class="toc-item"><a href="level-1-2/index.html">Level 1-2</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="level-1-2/subpage1.html">Subpage 1, Level 1-2</a></li>
+
+            <li class="toc-item"><a href="level-1-2/subpage2.html">Subpage 2, Level 1-2</a></li>
 
                     </ul></li>
 

--- a/tests/Integration/tests/navigation/reference-with-angle-bracket/expected/index.html
+++ b/tests/Integration/tests/navigation/reference-with-angle-bracket/expected/index.html
@@ -6,7 +6,7 @@
 For new records, use the <a href="/page.html#typo3-backend-link-newrecord">&lt;be:link.newRecordViewHelper&gt;</a>.</p>
             <div class="toc">
     <ul class="menu-level">
-    <li class="toc-item"><a href="/page.html#link-newrecord">link.newRecord</a></li>
+    <li class="toc-item"><a href="/page.html">link.newRecord</a></li>
 
     </ul>
 </div>

--- a/tests/Integration/tests/references/reference-level-3-relative/expected/index.html
+++ b/tests/Integration/tests/references/reference-level-3-relative/expected/index.html
@@ -16,35 +16,35 @@
 
             <div class="toc">
     <ul class="menu-level">
-    <li class="toc-item"><a href="page1.html#page-1">Page 1</a></li>
+    <li class="toc-item"><a href="page1.html">Page 1</a></li>
 
-    <li class="toc-item"><a href="page2.html#page-2">Page 2</a></li>
+    <li class="toc-item"><a href="page2.html">Page 2</a></li>
 
-    <li class="toc-item"><a href="level-1-1/index.html#level-1-1">Level 1-1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a></li>
+    <li class="toc-item"><a href="level-1-1/index.html">Level 1-1</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="level-1-1/subpage1.html">Subpage 1, Level 1-1</a></li>
 
-            <li class="toc-item"><a href="level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a></li>
+            <li class="toc-item"><a href="level-1-1/subpage2.html">Subpage 2, Level 1-1</a></li>
 
-            <li class="toc-item"><a href="level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a></li>
+            <li class="toc-item"><a href="level-1-1/level-2-1/index.html">Level 2-1</a>        <ul class="menu-level-2">
+            <li class="toc-item"><a href="level-1-1/level-2-1/subpage1.html">Subpage 1, Level 2-1</a></li>
 
-            <li class="toc-item"><a href="level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
-
-            <li class="toc-item"><a href="level-1-1/level-2-2/subpage2.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
+            <li class="toc-item"><a href="level-1-1/level-2-1/subpage2.html">Subpage 2, Level 2-1</a></li>
 
                     </ul></li>
 
+            <li class="toc-item"><a href="level-1-1/level-2-2/index.html">Level 2-2</a>        <ul class="menu-level-2">
+            <li class="toc-item"><a href="level-1-1/level-2-2/subpage1.html">Subpage 1, Level 2-2</a></li>
+
+            <li class="toc-item"><a href="level-1-1/level-2-2/subpage2.html">Subpage 1, Level 2-2</a></li>
+
                     </ul></li>
 
-    <li class="toc-item"><a href="level-1-2/index.html#level-1-2">Level 1-2</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
+                    </ul></li>
 
-            <li class="toc-item"><a href="level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a></li>
+    <li class="toc-item"><a href="level-1-2/index.html">Level 1-2</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="level-1-2/subpage1.html">Subpage 1, Level 1-2</a></li>
+
+            <li class="toc-item"><a href="level-1-2/subpage2.html">Subpage 2, Level 1-2</a></li>
 
                     </ul></li>
 

--- a/tests/Integration/tests/references/reference-level-3/expected/index.html
+++ b/tests/Integration/tests/references/reference-level-3/expected/index.html
@@ -16,35 +16,35 @@
 
             <div class="toc">
     <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
+    <li class="toc-item"><a href="/page1.html">Page 1</a></li>
 
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
+    <li class="toc-item"><a href="/page2.html">Page 2</a></li>
 
-    <li class="toc-item"><a href="/level-1-1/index.html#level-1-1">Level 1-1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a></li>
+    <li class="toc-item"><a href="/level-1-1/index.html">Level 1-1</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="/level-1-1/subpage1.html">Subpage 1, Level 1-1</a></li>
 
-            <li class="toc-item"><a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a></li>
+            <li class="toc-item"><a href="/level-1-1/subpage2.html">Subpage 2, Level 1-1</a></li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a></li>
+            <li class="toc-item"><a href="/level-1-1/level-2-1/index.html">Level 2-1</a>        <ul class="menu-level-2">
+            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage1.html">Subpage 1, Level 2-1</a></li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage2.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
+            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage2.html">Subpage 2, Level 2-1</a></li>
 
                     </ul></li>
 
+            <li class="toc-item"><a href="/level-1-1/level-2-2/index.html">Level 2-2</a>        <ul class="menu-level-2">
+            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage1.html">Subpage 1, Level 2-2</a></li>
+
+            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage2.html">Subpage 1, Level 2-2</a></li>
+
                     </ul></li>
 
-    <li class="toc-item"><a href="/level-1-2/index.html#level-1-2">Level 1-2</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
+                    </ul></li>
 
-            <li class="toc-item"><a href="/level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a></li>
+    <li class="toc-item"><a href="/level-1-2/index.html">Level 1-2</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="/level-1-2/subpage1.html">Subpage 1, Level 1-2</a></li>
+
+            <li class="toc-item"><a href="/level-1-2/subpage2.html">Subpage 2, Level 1-2</a></li>
 
                     </ul></li>
 

--- a/tests/Integration/tests/toctree/toctree-caption/expected/index.html
+++ b/tests/Integration/tests/toctree/toctree-caption/expected/index.html
@@ -5,9 +5,9 @@
             <div class="toc">
             <p class="caption"><strong>Table of Contents</strong></p>
     <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
+    <li class="toc-item"><a href="/page1.html">Page 1</a></li>
 
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
+    <li class="toc-item"><a href="/page2.html">Page 2</a></li>
 
     </ul>
 </div>

--- a/tests/Integration/tests/toctree/toctree-level-2/expected/index.html
+++ b/tests/Integration/tests/toctree/toctree-level-2/expected/index.html
@@ -5,21 +5,21 @@
             <p>Lorem Ipsum Dolor.</p>
             <div class="toc">
     <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
+    <li class="toc-item"><a href="/page1.html">Page 1</a></li>
 
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
+    <li class="toc-item"><a href="/page2.html">Page 2</a></li>
 
-    <li class="toc-item"><a href="/subfolder/index.html#subfolder-index">Subfolder Index</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/subfolder/subpage1.html#subpage-1">Subpage 1</a></li>
+    <li class="toc-item"><a href="/subfolder/index.html">Subfolder Index</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="/subfolder/subpage1.html">Subpage 1</a></li>
 
-            <li class="toc-item"><a href="/subfolder/subpage2.html#subpage-2">Subpage 2</a></li>
+            <li class="toc-item"><a href="/subfolder/subpage2.html">Subpage 2</a></li>
 
                     </ul></li>
 
-    <li class="toc-item"><a href="/subfolder2/index.html#subfolder-index">Subfolder Index</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/subfolder2/subpage1.html#subpage-1">Subpage 1</a></li>
+    <li class="toc-item"><a href="/subfolder2/index.html">Subfolder Index</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="/subfolder2/subpage1.html">Subpage 1</a></li>
 
-            <li class="toc-item"><a href="/subfolder2/subpage2.html#subpage-2">Subpage 2</a></li>
+            <li class="toc-item"><a href="/subfolder2/subpage2.html">Subpage 2</a></li>
 
                     </ul></li>
 

--- a/tests/Integration/tests/toctree/toctree-level-2/expected/subfolder/index.html
+++ b/tests/Integration/tests/toctree/toctree-level-2/expected/subfolder/index.html
@@ -10,9 +10,9 @@
 
             <div class="toc">
     <ul class="menu-level">
-    <li class="toc-item"><a href="/subfolder/subpage1.html#subpage-1">Subpage 1</a></li>
+    <li class="toc-item"><a href="/subfolder/subpage1.html">Subpage 1</a></li>
 
-    <li class="toc-item"><a href="/subfolder/subpage2.html#subpage-2">Subpage 2</a></li>
+    <li class="toc-item"><a href="/subfolder/subpage2.html">Subpage 2</a></li>
 
     </ul>
 </div>

--- a/tests/Integration/tests/toctree/toctree-level-3-maxdepth-1/expected/index.html
+++ b/tests/Integration/tests/toctree/toctree-level-3-maxdepth-1/expected/index.html
@@ -5,13 +5,13 @@
             <p>Lorem Ipsum Dolor.</p>
             <div class="toc">
     <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
+    <li class="toc-item"><a href="/page1.html">Page 1</a></li>
 
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
+    <li class="toc-item"><a href="/page2.html">Page 2</a></li>
 
-    <li class="toc-item"><a href="/level-1-1/index.html#level-1-1">Level 1-1</a></li>
+    <li class="toc-item"><a href="/level-1-1/index.html">Level 1-1</a></li>
 
-    <li class="toc-item"><a href="/level-1-2/index.html#level-1-2">Level 1-2</a></li>
+    <li class="toc-item"><a href="/level-1-2/index.html">Level 1-2</a></li>
 
     </ul>
 </div>

--- a/tests/Integration/tests/toctree/toctree-level-3-maxdepth-2/expected/index.html
+++ b/tests/Integration/tests/toctree/toctree-level-3-maxdepth-2/expected/index.html
@@ -5,25 +5,25 @@
             <p>Lorem Ipsum Dolor.</p>
             <div class="toc">
     <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
+    <li class="toc-item"><a href="/page1.html">Page 1</a></li>
 
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
+    <li class="toc-item"><a href="/page2.html">Page 2</a></li>
 
-    <li class="toc-item"><a href="/level-1-1/index.html#level-1-1">Level 1-1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a></li>
+    <li class="toc-item"><a href="/level-1-1/index.html">Level 1-1</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="/level-1-1/subpage1.html">Subpage 1, Level 1-1</a></li>
 
-            <li class="toc-item"><a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a></li>
+            <li class="toc-item"><a href="/level-1-1/subpage2.html">Subpage 2, Level 1-1</a></li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a></li>
+            <li class="toc-item"><a href="/level-1-1/level-2-1/index.html">Level 2-1</a></li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a></li>
+            <li class="toc-item"><a href="/level-1-1/level-2-2/index.html">Level 2-2</a></li>
 
                     </ul></li>
 
-    <li class="toc-item"><a href="/level-1-2/index.html#level-1-2">Level 1-2</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
+    <li class="toc-item"><a href="/level-1-2/index.html">Level 1-2</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="/level-1-2/subpage1.html">Subpage 1, Level 1-2</a></li>
 
-            <li class="toc-item"><a href="/level-1-2/subpage2.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
+            <li class="toc-item"><a href="/level-1-2/subpage2.html">Subpage 1, Level 1-2</a></li>
 
                     </ul></li>
 

--- a/tests/Integration/tests/toctree/toctree-level-3/expected/index.html
+++ b/tests/Integration/tests/toctree/toctree-level-3/expected/index.html
@@ -5,35 +5,35 @@
             <p>Lorem Ipsum Dolor.</p>
             <div class="toc">
     <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
+    <li class="toc-item"><a href="/page1.html">Page 1</a></li>
 
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
+    <li class="toc-item"><a href="/page2.html">Page 2</a></li>
 
-    <li class="toc-item"><a href="/level-1-1/index.html#level-1-1">Level 1-1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a></li>
+    <li class="toc-item"><a href="/level-1-1/index.html">Level 1-1</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="/level-1-1/subpage1.html">Subpage 1, Level 1-1</a></li>
 
-            <li class="toc-item"><a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a></li>
+            <li class="toc-item"><a href="/level-1-1/subpage2.html">Subpage 2, Level 1-1</a></li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a></li>
+            <li class="toc-item"><a href="/level-1-1/level-2-1/index.html">Level 2-1</a>        <ul class="menu-level-2">
+            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage1.html">Subpage 1, Level 2-1</a></li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage2.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
+            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage2.html">Subpage 2, Level 2-1</a></li>
 
                     </ul></li>
 
+            <li class="toc-item"><a href="/level-1-1/level-2-2/index.html">Level 2-2</a>        <ul class="menu-level-2">
+            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage1.html">Subpage 1, Level 2-2</a></li>
+
+            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage2.html">Subpage 1, Level 2-2</a></li>
+
                     </ul></li>
 
-    <li class="toc-item"><a href="/level-1-2/index.html#level-1-2">Level 1-2</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
+                    </ul></li>
 
-            <li class="toc-item"><a href="/level-1-2/subpage2.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
+    <li class="toc-item"><a href="/level-1-2/index.html">Level 1-2</a>        <ul class="menu-level-1">
+            <li class="toc-item"><a href="/level-1-2/subpage1.html">Subpage 1, Level 1-2</a></li>
+
+            <li class="toc-item"><a href="/level-1-2/subpage2.html">Subpage 1, Level 1-2</a></li>
 
                     </ul></li>
 

--- a/tests/Integration/tests/toctree/toctree-no-duplicates/expected/index.html
+++ b/tests/Integration/tests/toctree/toctree-no-duplicates/expected/index.html
@@ -4,13 +4,13 @@
 
             <div class="toc">
     <ul class="menu-level">
-    <li class="toc-item"><a href="/overview.html#overview">Overview</a></li>
+    <li class="toc-item"><a href="/overview.html">Overview</a></li>
 
-    <li class="toc-item"><a href="/apple.html#apple">Apple</a></li>
+    <li class="toc-item"><a href="/apple.html">Apple</a></li>
 
-    <li class="toc-item"><a href="/banana.html#banana">Banana</a></li>
+    <li class="toc-item"><a href="/banana.html">Banana</a></li>
 
-    <li class="toc-item"><a href="/cherry.html#cherry">Cherry</a></li>
+    <li class="toc-item"><a href="/cherry.html">Cherry</a></li>
 
     </ul>
 </div>

--- a/tests/Integration/tests/toctree/toctree-no-duplicates/expected/overview.html
+++ b/tests/Integration/tests/toctree/toctree-no-duplicates/expected/overview.html
@@ -5,13 +5,13 @@
             <p>Lorem Ipsum Dolor</p>
             <div class="menu">
     <ul class="menu-level">
-    <li class="toc-item current active"><a href="/overview.html#overview">Overview</a></li>
+    <li class="toc-item current active"><a href="/overview.html">Overview</a></li>
 
-    <li class="toc-item"><a href="/apple.html#apple">Apple</a></li>
+    <li class="toc-item"><a href="/apple.html">Apple</a></li>
 
-    <li class="toc-item"><a href="/banana.html#banana">Banana</a></li>
+    <li class="toc-item"><a href="/banana.html">Banana</a></li>
 
-    <li class="toc-item"><a href="/cherry.html#cherry">Cherry</a></li>
+    <li class="toc-item"><a href="/cherry.html">Cherry</a></li>
 
     </ul>
 </div>

--- a/tests/Integration/tests/toctree/toctree-simple/expected/index.html
+++ b/tests/Integration/tests/toctree/toctree-simple/expected/index.html
@@ -4,14 +4,14 @@
 
             <div class="toc">
     <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a>        <ul class="section-level-1">
+    <li class="toc-item"><a href="/page1.html">Page 1</a>        <ul class="section-level-1">
             <li class="toc-item"><a href="/page1.html#chapter-1">Chapter 1</a></li>
 
             <li class="toc-item"><a href="/page1.html#chapter-2">Chapter 2</a></li>
 
                     </ul></li>
 
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
+    <li class="toc-item"><a href="/page2.html">Page 2</a></li>
 
     </ul>
 </div>

--- a/tests/Integration/tests/toctree/toctree-titlesonly/expected/index.html
+++ b/tests/Integration/tests/toctree/toctree-titlesonly/expected/index.html
@@ -4,9 +4,9 @@
 
             <div class="toc">
     <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
+    <li class="toc-item"><a href="/page1.html">Page 1</a></li>
 
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
+    <li class="toc-item"><a href="/page2.html">Page 2</a></li>
 
     </ul>
 </div>


### PR DESCRIPTION
We already had a flag for menu entries to mark them as "document root", but it was always set to `false`. This PR sets it to `true` when then menu entry references a document root title (in contrast to a sub title within that document).

I've also updated the renderer to not add the anchor when it's a root title. This makes the UX nicer, as you don't need to jump to the document root when you're just navigating to the document start.