### PR TITLE
[BUGFIX] Use output file path for relative url calculations

### DIFF
--- a/packages/guides/src/RenderContext.php
+++ b/packages/guides/src/RenderContext.php
@@ -134,7 +134,7 @@ class RenderContext
 
     public function getDirName(): string
     {
-        $dirname = dirname($this->getCurrentFileName());
+        $dirname = dirname($this->outputFilePath);
 
         if ($dirname === '.') {
             return '';


### PR DESCRIPTION
In standard renderings output and input filenames with their paths are the same except for the file ending. However, in project based rendering nodes the currentFileName in the rendering context is null, leading to an error.

In these cases we add the outputfile path manually to the render context.

The relative urls must now be calculated relative to the output path, not the input path.