### PR TITLE
Cache matching node renderers

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/NodeRenderers/Html/AdmonitionNodeRenderer.php
+++ b/packages/guides-restructured-text/src/RestructuredText/NodeRenderers/Html/AdmonitionNodeRenderer.php
@@ -21,6 +21,7 @@ use phpDocumentor\Guides\RestructuredText\Nodes\AdmonitionNode;
 use phpDocumentor\Guides\TemplateRenderer;
 
 use function implode;
+use function is_a;
 
 /** @implements NodeRenderer<AdmonitionNode> */
 class AdmonitionNodeRenderer implements NodeRenderer
@@ -29,9 +30,9 @@ class AdmonitionNodeRenderer implements NodeRenderer
     {
     }
 
-    public function supports(Node $node): bool
+    public function supports(string $nodeFqcn): bool
     {
-        return $node instanceof AdmonitionNode;
+        return $nodeFqcn === AdmonitionNode::class || is_a($nodeFqcn, AdmonitionNode::class, true);
     }
 
     public function render(Node $node, RenderContext $renderContext): string

--- a/packages/guides-restructured-text/src/RestructuredText/NodeRenderers/Html/CollectionNodeRenderer.php
+++ b/packages/guides-restructured-text/src/RestructuredText/NodeRenderers/Html/CollectionNodeRenderer.php
@@ -20,6 +20,8 @@ use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\TemplateRenderer;
 
+use function is_a;
+
 /** @implements NodeRenderer<CollectionNode> */
 final class CollectionNodeRenderer implements NodeRenderer
 {
@@ -27,9 +29,9 @@ final class CollectionNodeRenderer implements NodeRenderer
     {
     }
 
-    public function supports(Node $node): bool
+    public function supports(string $nodeFqcn): bool
     {
-        return $node instanceof CollectionNode;
+        return $nodeFqcn === CollectionNode::class || is_a($nodeFqcn, CollectionNode::class, true);
     }
 
     public function render(Node $node, RenderContext $renderContext): string

--- a/packages/guides-restructured-text/src/RestructuredText/NodeRenderers/Html/ContainerNodeRenderer.php
+++ b/packages/guides-restructured-text/src/RestructuredText/NodeRenderers/Html/ContainerNodeRenderer.php
@@ -20,6 +20,8 @@ use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\RestructuredText\Nodes\ContainerNode;
 use phpDocumentor\Guides\TemplateRenderer;
 
+use function is_a;
+
 /** @implements NodeRenderer<ContainerNode> */
 final class ContainerNodeRenderer implements NodeRenderer
 {
@@ -27,9 +29,9 @@ final class ContainerNodeRenderer implements NodeRenderer
     {
     }
 
-    public function supports(Node $node): bool
+    public function supports(string $nodeFqcn): bool
     {
-        return $node instanceof ContainerNode;
+        return $nodeFqcn === ContainerNode::class || is_a($nodeFqcn, ContainerNode::class, true);
     }
 
     public function render(Node $node, RenderContext $renderContext): string

--- a/packages/guides-restructured-text/src/RestructuredText/NodeRenderers/Html/GeneralDirectiveNodeRenderer.php
+++ b/packages/guides-restructured-text/src/RestructuredText/NodeRenderers/Html/GeneralDirectiveNodeRenderer.php
@@ -21,6 +21,7 @@ use phpDocumentor\Guides\RestructuredText\Nodes\GeneralDirectiveNode;
 use phpDocumentor\Guides\TemplateRenderer;
 use Psr\Log\LoggerInterface;
 
+use function is_a;
 use function preg_replace;
 use function sprintf;
 use function str_replace;
@@ -34,9 +35,9 @@ class GeneralDirectiveNodeRenderer implements NodeRenderer
     ) {
     }
 
-    public function supports(Node $node): bool
+    public function supports(string $nodeFqcn): bool
     {
-        return $node instanceof GeneralDirectiveNode;
+        return $nodeFqcn === GeneralDirectiveNode::class || is_a($nodeFqcn, GeneralDirectiveNode::class, true);
     }
 
     public function render(Node $node, RenderContext $renderContext): string

--- a/packages/guides-restructured-text/src/RestructuredText/NodeRenderers/Html/SidebarNodeRenderer.php
+++ b/packages/guides-restructured-text/src/RestructuredText/NodeRenderers/Html/SidebarNodeRenderer.php
@@ -20,6 +20,8 @@ use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\RestructuredText\Nodes\SidebarNode;
 use phpDocumentor\Guides\TemplateRenderer;
 
+use function is_a;
+
 /** @implements NodeRenderer<SidebarNode> */
 final class SidebarNodeRenderer implements NodeRenderer
 {
@@ -27,9 +29,9 @@ final class SidebarNodeRenderer implements NodeRenderer
     {
     }
 
-    public function supports(Node $node): bool
+    public function supports(string $nodeFqcn): bool
     {
-        return $node instanceof SidebarNode;
+        return $nodeFqcn === SidebarNode::class || is_a($nodeFqcn, SidebarNode::class, true);
     }
 
     public function render(Node $node, RenderContext $renderContext): string

--- a/packages/guides-restructured-text/src/RestructuredText/NodeRenderers/Html/TopicNodeRenderer.php
+++ b/packages/guides-restructured-text/src/RestructuredText/NodeRenderers/Html/TopicNodeRenderer.php
@@ -21,6 +21,8 @@ use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\RestructuredText\Nodes\TopicNode;
 use phpDocumentor\Guides\TemplateRenderer;
 
+use function is_a;
+
 /** @implements NodeRenderer<TocNode> */
 final class TopicNodeRenderer implements NodeRenderer
 {
@@ -28,9 +30,9 @@ final class TopicNodeRenderer implements NodeRenderer
     {
     }
 
-    public function supports(Node $node): bool
+    public function supports(string $nodeFqcn): bool
     {
-        return $node instanceof TopicNode;
+        return $nodeFqcn === TopicNode::class || is_a($nodeFqcn, TopicNode::class, true);
     }
 
     public function render(Node $node, RenderContext $renderContext): string

--- a/packages/guides-restructured-text/src/RestructuredText/NodeRenderers/LaTeX/GeneralDirectiveNodeRenderer.php
+++ b/packages/guides-restructured-text/src/RestructuredText/NodeRenderers/LaTeX/GeneralDirectiveNodeRenderer.php
@@ -21,6 +21,7 @@ use phpDocumentor\Guides\RestructuredText\Nodes\GeneralDirectiveNode;
 use phpDocumentor\Guides\TemplateRenderer;
 use Psr\Log\LoggerInterface;
 
+use function is_a;
 use function preg_replace;
 use function sprintf;
 use function str_replace;
@@ -34,9 +35,9 @@ class GeneralDirectiveNodeRenderer implements NodeRenderer
     ) {
     }
 
-    public function supports(Node $node): bool
+    public function supports(string $nodeFqcn): bool
     {
-        return $node instanceof GeneralDirectiveNode;
+        return $nodeFqcn === GeneralDirectiveNode::class || is_a($nodeFqcn, GeneralDirectiveNode::class, true);
     }
 
     public function render(Node $node, RenderContext $renderContext): string

--- a/packages/guides/src/NodeRenderers/DefaultNodeRenderer.php
+++ b/packages/guides/src/NodeRenderers/DefaultNodeRenderer.php
@@ -74,7 +74,7 @@ class DefaultNodeRenderer implements NodeRenderer, NodeRendererFactoryAware
         return '';
     }
 
-    public function supports(Node $node): bool
+    public function supports(string $nodeFqcn): bool
     {
         return true;
     }

--- a/packages/guides/src/NodeRenderers/DelegatingNodeRenderer.php
+++ b/packages/guides/src/NodeRenderers/DelegatingNodeRenderer.php
@@ -21,7 +21,7 @@ final class DelegatingNodeRenderer implements NodeRenderer, NodeRendererFactoryA
         $this->nodeRendererFactory = $nodeRendererFactory;
     }
 
-    public function supports(Node $node): bool
+    public function supports(string $nodeFqcn): bool
     {
         return true;
     }

--- a/packages/guides/src/NodeRenderers/Html/BreadCrumbNodeRenderer.php
+++ b/packages/guides/src/NodeRenderers/Html/BreadCrumbNodeRenderer.php
@@ -14,6 +14,7 @@ use phpDocumentor\Guides\TemplateRenderer;
 
 use function array_reverse;
 use function assert;
+use function is_a;
 
 /**
  * @template T as Node
@@ -28,9 +29,9 @@ class BreadCrumbNodeRenderer implements NodeRenderer
     ) {
     }
 
-    public function supports(Node $node): bool
+    public function supports(string $nodeFqcn): bool
     {
-        return $node instanceof BreadCrumbNode;
+        return $nodeFqcn === BreadCrumbNode::class || is_a($nodeFqcn, BreadCrumbNode::class, true);
     }
     
     /** @param T $node */

--- a/packages/guides/src/NodeRenderers/Html/DocumentNodeRenderer.php
+++ b/packages/guides/src/NodeRenderers/Html/DocumentNodeRenderer.php
@@ -11,6 +11,7 @@ use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\TemplateRenderer;
 
 use function assert;
+use function is_a;
 
 /**
  * @template T as Node
@@ -25,9 +26,9 @@ final class DocumentNodeRenderer implements NodeRenderer
     ) {
     }
 
-    public function supports(Node $node): bool
+    public function supports(string $nodeFqcn): bool
     {
-        return $node instanceof DocumentNode;
+        return $nodeFqcn === DocumentNode::class || is_a($nodeFqcn, DocumentNode::class, true);
     }
 
     /** @param T $node */

--- a/packages/guides/src/NodeRenderers/Html/MenuEntryRenderer.php
+++ b/packages/guides/src/NodeRenderers/Html/MenuEntryRenderer.php
@@ -11,6 +11,8 @@ use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\Renderer\UrlGenerator\UrlGeneratorInterface;
 use phpDocumentor\Guides\TemplateRenderer;
 
+use function is_a;
+
 /** @implements NodeRenderer<MenuEntryNode> */
 final class MenuEntryRenderer implements NodeRenderer
 {
@@ -20,9 +22,9 @@ final class MenuEntryRenderer implements NodeRenderer
     ) {
     }
 
-    public function supports(Node $node): bool
+    public function supports(string $nodeFqcn): bool
     {
-        return $node instanceof MenuEntryNode;
+        return $nodeFqcn === MenuEntryNode::class || is_a($nodeFqcn, MenuEntryNode::class, true);
     }
 
     public function render(Node $node, RenderContext $renderContext): string

--- a/packages/guides/src/NodeRenderers/Html/MenuNodeRenderer.php
+++ b/packages/guides/src/NodeRenderers/Html/MenuNodeRenderer.php
@@ -22,6 +22,8 @@ use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\TemplateRenderer;
 use Webmozart\Assert\Assert;
 
+use function is_a;
+
 /** @implements NodeRenderer<MenuNode> */
 final class MenuNodeRenderer implements NodeRenderer
 {
@@ -57,8 +59,8 @@ final class MenuNodeRenderer implements NodeRenderer
         return 'body/menu/menu.html.twig';
     }
 
-    public function supports(Node $node): bool
+    public function supports(string $nodeFqcn): bool
     {
-        return $node instanceof MenuNode;
+        return $nodeFqcn === MenuNode::class || is_a($nodeFqcn, MenuNode::class, true);
     }
 }

--- a/packages/guides/src/NodeRenderers/Html/TableNodeRenderer.php
+++ b/packages/guides/src/NodeRenderers/Html/TableNodeRenderer.php
@@ -19,6 +19,8 @@ use phpDocumentor\Guides\Nodes\TableNode;
 use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\TemplateRenderer;
 
+use function is_a;
+
 /** @implements NodeRenderer<TableNode> */
 class TableNodeRenderer implements NodeRenderer
 {
@@ -42,8 +44,8 @@ class TableNodeRenderer implements NodeRenderer
         );
     }
 
-    public function supports(Node $node): bool
+    public function supports(string $nodeFqcn): bool
     {
-        return $node instanceof TableNode;
+        return $nodeFqcn === TableNode::class || is_a($nodeFqcn, TableNode::class, true);
     }
 }

--- a/packages/guides/src/NodeRenderers/Html/TemplatedNodeRenderer.php
+++ b/packages/guides/src/NodeRenderers/Html/TemplatedNodeRenderer.php
@@ -11,6 +11,8 @@ use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\TemplateRenderer;
 use Webmozart\Assert\Assert;
 
+use function is_a;
+
 /** @implements NodeRenderer<TemplatedNode> */
 final class TemplatedNodeRenderer implements NodeRenderer
 {
@@ -25,8 +27,8 @@ final class TemplatedNodeRenderer implements NodeRenderer
         return $this->renderer->renderTemplate($renderContext, $node->getValue(), $node->getData());
     }
 
-    public function supports(Node $node): bool
+    public function supports(string $nodeFqcn): bool
     {
-        return $node instanceof TemplatedNode;
+        return $nodeFqcn === TemplatedNode::class || is_a($nodeFqcn, TemplatedNode::class, true);
     }
 }

--- a/packages/guides/src/NodeRenderers/InMemoryNodeRendererFactory.php
+++ b/packages/guides/src/NodeRenderers/InMemoryNodeRendererFactory.php
@@ -17,6 +17,9 @@ use phpDocumentor\Guides\Nodes\Node;
 
 class InMemoryNodeRendererFactory implements NodeRendererFactory
 {
+    /** @var array<class-string<Node>, NodeRenderer<Node>> */
+    private array $cache = [];
+
     /**
      * @param iterable<NodeRenderer<Node>> $nodeRenderers
      * @param NodeRenderer<Node> $defaultNodeRenderer
@@ -40,12 +43,17 @@ class InMemoryNodeRendererFactory implements NodeRendererFactory
 
     public function get(Node $node): NodeRenderer
     {
+        $nodeFqcn = $node::class;
+        if (isset($this->cache[$nodeFqcn])) {
+            return $this->cache[$nodeFqcn];
+        }
+
         foreach ($this->nodeRenderers as $nodeRenderer) {
-            if ($nodeRenderer->supports($node)) {
-                return $nodeRenderer;
+            if ($nodeRenderer->supports($nodeFqcn)) {
+                return $this->cache[$nodeFqcn] = $nodeRenderer;
             }
         }
 
-        return $this->defaultNodeRenderer;
+        return $this->cache[$nodeFqcn] = $this->defaultNodeRenderer;
     }
 }

--- a/packages/guides/src/NodeRenderers/LaTeX/TableNodeRenderer.php
+++ b/packages/guides/src/NodeRenderers/LaTeX/TableNodeRenderer.php
@@ -25,6 +25,7 @@ use phpDocumentor\Guides\RenderContext;
 use function assert;
 use function count;
 use function implode;
+use function is_a;
 use function max;
 
 /** @implements NodeRenderer<TableNode> */
@@ -77,8 +78,8 @@ class TableNodeRenderer implements NodeRenderer, NodeRendererFactoryAware
         return "\\begin{tabular}{" . $aligns . "}\n" . $rows . "\n\\end{tabular}\n";
     }
 
-    public function supports(Node $node): bool
+    public function supports(string $nodeFqcn): bool
     {
-        return $node instanceof TableNode;
+        return $nodeFqcn === TableNode::class || is_a($nodeFqcn, TableNode::class, true);
     }
 }

--- a/packages/guides/src/NodeRenderers/LaTeX/TitleNodeRenderer.php
+++ b/packages/guides/src/NodeRenderers/LaTeX/TitleNodeRenderer.php
@@ -20,6 +20,8 @@ use phpDocumentor\Guides\Nodes\TitleNode;
 use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\TemplateRenderer;
 
+use function is_a;
+
 /** @implements NodeRenderer<TitleNode> */
 class TitleNodeRenderer implements NodeRenderer
 {
@@ -53,8 +55,8 @@ class TitleNodeRenderer implements NodeRenderer
         );
     }
 
-    public function supports(Node $node): bool
+    public function supports(string $nodeFqcn): bool
     {
-        return $node instanceof TitleNode;
+        return $nodeFqcn === TitleNode::class || is_a($nodeFqcn, TitleNode::class, true);
     }
 }

--- a/packages/guides/src/NodeRenderers/LaTeX/TocNodeRenderer.php
+++ b/packages/guides/src/NodeRenderers/LaTeX/TocNodeRenderer.php
@@ -20,6 +20,8 @@ use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\TemplateRenderer;
 
+use function is_a;
+
 /** @implements  NodeRenderer<TocNode> */
 class TocNodeRenderer implements NodeRenderer
 {
@@ -40,8 +42,8 @@ class TocNodeRenderer implements NodeRenderer
         );
     }
 
-    public function supports(Node $node): bool
+    public function supports(string $nodeFqcn): bool
     {
-        return $node instanceof TocNode;
+        return $nodeFqcn === TocNode::class || is_a($nodeFqcn, TocNode::class, true);
     }
 }

--- a/packages/guides/src/NodeRenderers/NodeRenderer.php
+++ b/packages/guides/src/NodeRenderers/NodeRenderer.php
@@ -19,7 +19,8 @@ use phpDocumentor\Guides\RenderContext;
 /** @template T of Node */
 interface NodeRenderer
 {
-    public function supports(Node $node): bool;
+    /** @param class-string<Node> $nodeFqcn */
+    public function supports(string $nodeFqcn): bool;
 
     /** @param T $node */
     public function render(Node $node, RenderContext $renderContext): string;

--- a/packages/guides/src/NodeRenderers/OutputAwareDelegatingNodeRenderer.php
+++ b/packages/guides/src/NodeRenderers/OutputAwareDelegatingNodeRenderer.php
@@ -28,7 +28,7 @@ final class OutputAwareDelegatingNodeRenderer implements NodeRenderer
         $this->nodeRenderers = $nodeRenderers;
     }
 
-    public function supports(Node $node): bool
+    public function supports(string $nodeFqcn): bool
     {
         return true;
     }

--- a/packages/guides/src/NodeRenderers/PreRenderers/PreRenderer.php
+++ b/packages/guides/src/NodeRenderers/PreRenderers/PreRenderer.php
@@ -19,9 +19,9 @@ final class PreRenderer implements NodeRenderer
     ) {
     }
 
-    public function supports(Node $node): bool
+    public function supports(string $nodeFqcn): bool
     {
-        return $this->nodeRenderer->supports($node);
+        return $this->nodeRenderer->supports($nodeFqcn);
     }
 
     public function render(Node $node, RenderContext $renderContext): string

--- a/packages/guides/src/NodeRenderers/TemplateNodeRenderer.php
+++ b/packages/guides/src/NodeRenderers/TemplateNodeRenderer.php
@@ -8,6 +8,8 @@ use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\TemplateRenderer;
 
+use function is_a;
+
 /**
  * @template T as Node
  * @implements NodeRenderer<T>
@@ -19,9 +21,9 @@ final class TemplateNodeRenderer implements NodeRenderer
     {
     }
 
-    public function supports(Node $node): bool
+    public function supports(string $nodeFqcn): bool
     {
-        return $node instanceof $this->nodeClass;
+        return $nodeFqcn === $this->nodeClass || is_a($nodeFqcn, $this->nodeClass, true);
     }
 
     /** @param T $node */


### PR DESCRIPTION
By caching which node renderer can be used for which node, we can avoid a lot of foreach loops.

From a quick local test (with pcov enabled), this improved run time by 50%. Blackfire diff: https://blackfire.io/profiles/compare/9aa42af9-7692-418c-9d34-f7e010a22f8f/graph

We can optionally do this in a non-BC breaking way by introducing a new cacheable interface with a `supportsFqcn()` method (similar to Symfony's [voter caching](https://github.com/symfony/symfony/blob/7.1/src/Symfony/Component/Security/Core/Authorization/Voter/CacheableVoterInterface.php)). However, I can find no node renderer in guides and Symfony that does something other than `instanceof`. So I would favor simplicity for the years to come over this BC break.
But I'm happy to discuss rewriting this to a smooth upgrade path if this helps TYPO3.