### PR TITLE
Add tests for maxdepth option on toctree without titlesonly

### DIFF
--- a/tests/Integration/tests/toctree/toctree-maxdepth/expected/index.html
+++ b/tests/Integration/tests/toctree/toctree-maxdepth/expected/index.html
@@ -1,0 +1,96 @@
+<!-- content start -->
+<div class="section" id="index">
+    <h1>Index</h1>
+
+    <p>Maxdepth 1</p>
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item"><a href="/page1.html#page-1-level-1">Page 1, Level 1</a></li>
+            <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-1">Subpage 2, Page 1, Level 1</a></li>
+        </ul>
+    </div>
+
+    <p>Maxdepth 2</p>
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item"><a href="/page1.html#page-1-level-1">Page 1, Level 1</a>        <ul class="section-level-1">
+                <li class="toc-item"><a href="/subpage1/page1.html#subpage-1-page-1-level-1">Subpage 1, Page 1, Level 1</a></li>
+                <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-2-level-1">Subpage 1, Page 2, Level 1</a></li>
+                <li class="toc-item"><a href="/page1.html#page-1-level-2-1">Page 1, Level 2.1</a></li>
+                <li class="toc-item"><a href="/page1.html#page-1-level-2-2">Page 1, Level 2.2</a></li>
+            </ul></li>
+
+            <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-1">Subpage 2, Page 1, Level 1</a>        <ul class="section-level-1">
+                <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-2-1">Subpage 2, Page 1, Level 2.1</a></li>
+                    <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-2-2">Subpage 2, Page 1, Level 2.2</a></li>
+            </ul></li>
+        </ul>
+    </div>
+
+    <p>Maxdepth 3</p>
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item"><a href="/page1.html#page-1-level-1">Page 1, Level 1</a>        <ul class="section-level-1">
+                <li class="toc-item"><a href="/subpage1/page1.html#subpage-1-page-1-level-1">Subpage 1, Page 1, Level 1</a>        <ul class="section-level-2">
+                    <li class="toc-item"><a href="/subpage1/page1.html#subpage-1-page-1-level-2-1">Subpage 1, Page 1, Level 2.1</a></li>
+                    <li class="toc-item"><a href="/subpage1/page1.html#subpage-1-page-1-level-2-2">Subpage 1, Page 1, Level 2.2</a></li>
+                </ul></li>
+
+                <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-2-level-1">Subpage 1, Page 2, Level 1</a>        <ul class="section-level-2">
+                    <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-2-level-2-1">Subpage 1, Page 2, Level 2.1</a></li>
+                    <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-2-level-2-2">Subpage 1, Page 2, Level 2.2</a></li>
+                </ul></li>
+
+                <li class="toc-item"><a href="/page1.html#page-1-level-2-1">Page 1, Level 2.1</a>        <ul class="section-level-2">
+                    <li class="toc-item"><a href="/page1.html#page-1-level-3">Page 1, Level 3</a></li>
+                </ul></li>
+
+                <li class="toc-item"><a href="/page1.html#page-1-level-2-2">Page 1, Level 2.2</a></li>
+            </ul></li>
+
+            <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-1">Subpage 2, Page 1, Level 1</a>        <ul class="section-level-1">
+                <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-2-1">Subpage 2, Page 1, Level 2.1</a>        <ul class="section-level-2">
+                    <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-3">Subpage 2, Page 1, Level 3</a></li>
+                </ul></li>
+
+                <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-2-2">Subpage 2, Page 1, Level 2.2</a></li>
+            </ul></li>
+        </ul>
+    </div>
+
+    <p>Maxdepth 4</p>
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item"><a href="/page1.html#page-1-level-1">Page 1, Level 1</a>        <ul class="section-level-1">
+                <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-1-level-1">Subpage 1, Page 1, Level 1</a>        <ul class="section-level-2">
+                    <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-1-level-2-1">Subpage 1, Page 1, Level 2.1</a>        <ul class="section-level-3">
+                        <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-1-level-3">Subpage 1, Page 1, Level 3</a></li>
+                    </ul></li>
+                    <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-1-level-2-2">Subpage 1, Page 1, Level 2.2</a></li>
+                </ul></li>
+
+                <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-2-level-1">Subpage 1, Page 2, Level 1</a>        <ul class="section-level-2">
+                    <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-2-level-2-1">Subpage 1, Page 2, Level 2.1</a>        <ul class="section-level-3">
+                        <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-2-level-3">Subpage 1, Page 2, Level 3</a></li>
+                    </ul></li>
+                    <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-2-level-2-2">Subpage 1, Page 2, Level 2.2</a></li>
+                </ul></li>
+
+                <li class="toc-item"><a href="/page1.html#page-1-level-2-1">Page 1, Level 2.1</a>        <ul class="section-level-2">
+                    <li class="toc-item"><a href="/page1.html#page-1-level-3">Page 1, Level 3</a></li>
+                </ul></li>
+
+                <li class="toc-item"><a href="/page1.html#page-1-level-2-2">Page 1, Level 2.2</a></li>
+            </ul></li>
+
+            <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-1">Subpage 2, Page 1, Level 1</a>        <ul class="section-level-1">
+                <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-2-1">Subpage 2, Page 1, Level 2.1</a>        <ul class="section-level-2">
+                    <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-3">Subpage 2, Page 1, Level 3</a></li>
+                </ul></li>
+
+                <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-2-2">Subpage 2, Page 1, Level 2.2</a></li>
+            </ul></li>
+        </ul>
+    </div>
+</div>
+<!-- content end -->

--- a/tests/Integration/tests/toctree/toctree-maxdepth/input/index.rst
+++ b/tests/Integration/tests/toctree/toctree-maxdepth/input/index.rst
@@ -1,0 +1,34 @@
+Index
+=====
+
+Maxdepth 1
+
+.. toctree::
+    :maxdepth: 1
+
+    page1
+    subpage2/page1
+
+Maxdepth 2
+
+.. toctree::
+    :maxdepth: 2
+
+    page1
+    subpage2/page1
+
+Maxdepth 3
+
+.. toctree::
+    :maxdepth: 3
+
+    page1
+    subpage2/page1
+
+Maxdepth 4
+
+.. toctree::
+    :maxdepth: 4
+
+    page1
+    subpage2/page1

--- a/tests/Integration/tests/toctree/toctree-maxdepth/input/page1.rst
+++ b/tests/Integration/tests/toctree/toctree-maxdepth/input/page1.rst
@@ -1,0 +1,21 @@
+Page 1, Level 1
+===============
+
+.. toctree::
+    
+    subpage1/*
+
+Page 1, Level 2.1
+-----------------
+
+Paragraph.
+
+Page 1, Level 3
+~~~~~~~~~~~~~~~
+
+Paragraph.
+
+Page 1, Level 2.2
+-----------------
+
+Paragraph.

--- a/tests/Integration/tests/toctree/toctree-maxdepth/input/skip
+++ b/tests/Integration/tests/toctree/toctree-maxdepth/input/skip
@@ -1,0 +1,1 @@
+Maxdepth toctrees includes too much items without titlesonly

--- a/tests/Integration/tests/toctree/toctree-maxdepth/input/subpage1/page1.rst
+++ b/tests/Integration/tests/toctree/toctree-maxdepth/input/subpage1/page1.rst
@@ -1,0 +1,19 @@
+Subpage 1, Page 1, Level 1
+==========================
+
+Paragraph.
+
+Subpage 1, Page 1, Level 2.1
+----------------------------
+
+Paragraph.
+
+Subpage 1, Page 1, Level 3
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Paragraph.
+
+Subpage 1, Page 1, Level 2.2
+----------------------------
+
+Paragraph.

--- a/tests/Integration/tests/toctree/toctree-maxdepth/input/subpage1/page2.rst
+++ b/tests/Integration/tests/toctree/toctree-maxdepth/input/subpage1/page2.rst
@@ -1,0 +1,19 @@
+Subpage 1, Page 2, Level 1
+==========================
+
+Paragraph.
+
+Subpage 1, Page 2, Level 2.1
+----------------------------
+
+Paragraph.
+
+Subpage 1, Page 2, Level 3
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Paragraph.
+
+Subpage 1, Page 2, Level 2.2
+----------------------------
+
+Paragraph.

--- a/tests/Integration/tests/toctree/toctree-maxdepth/input/subpage2/page1.rst
+++ b/tests/Integration/tests/toctree/toctree-maxdepth/input/subpage2/page1.rst
@@ -1,0 +1,19 @@
+Subpage 2, Page 1, Level 1
+==========================
+
+Paragraph.
+
+Subpage 2, Page 1, Level 2.1
+----------------------------
+
+Paragraph.
+
+Subpage 2, Page 1, Level 3
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Paragraph.
+
+Subpage 2, Page 1, Level 2.2
+----------------------------
+
+Paragraph.


### PR DESCRIPTION
Unfortunately, it seems like we do not yet properly support maxdepth on toctrees. Almost all tests were using it in combination with `titlesonly`, but it seems completely broken without this option. In the Symfony docs, we only have toctrees with `:maxdepth: 1` without `:titlesonly:`, so I'm afraid guides must support the option properly for us to move to guides.

I've added a test case for this, the expected file is verified with Sphinx' behavior. Currently, guides renders 4 times the same toctree. The maxdepth option seems not to be taken into account for how many subtitles it must render, and the documents in sub-toctrees are not in the list (the latter is not something we rely on in Symfony docs btw).
<details><summary>Current HTML output</summary>

```html
<div class="toc">
    <ul class="menu-level">
        <li class="toc-item"><a href="/page1.html#page-1-level-1">Page 1, Level 1</a>        <ul class="section-level-1">
            <li class="toc-item"><a href="/page1.html#page-1-level-2-1">Page 1, Level 2.1</a>        <ul class="section-level-2">
                <li class="toc-item"><a href="/page1.html#page-1-level-3">Page 1, Level 3</a></li>
            </ul></li>

            <li class="toc-item"><a href="/page1.html#page-1-level-2-2">Page 1, Level 2.2</a></li>
        </ul></li>

        <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-1">Subpage 2, Page 1, Level 1</a>        <ul class="section-level-1">
            <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-2-1">Subpage 2, Page 1, Level 2.1</a>        <ul class="section-level-2">
                <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-3">Subpage 2, Page 1, Level 3</a></li>
            </ul></li>

            <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-2-2">Subpage 2, Page 1, Level 2.2</a></li>
        </ul></li>
    </ul>
</div>
```

</details>

I propose to merge this PR soon as-is to not forget about it. I'm happy to help on implementing this, but I need to deep-dive into all toctree and menu code in this library first.