### PR TITLE
[FEATURE] Introduce exchangeable InterlinkParser

### DIFF
--- a/packages/guides-restructured-text/resources/config/guides-restructured-text.php
+++ b/packages/guides-restructured-text/resources/config/guides-restructured-text.php
@@ -56,6 +56,8 @@ use phpDocumentor\Guides\RestructuredText\Directives\WarningDirective;
 use phpDocumentor\Guides\RestructuredText\MarkupLanguageParser;
 use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContextFactory;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineParser;
+use phpDocumentor\Guides\RestructuredText\Parser\Interlink\DefaultInterlinkParser;
+use phpDocumentor\Guides\RestructuredText\Parser\Interlink\InterlinkParser;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\AnnotationRule;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\BlockQuoteRule;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\CommentRule;
@@ -231,6 +233,8 @@ return static function (ContainerConfigurator $container): void {
 
         ->set('phpdoc.guides.parser.rst.body_elements', RuleContainer::class)
         ->set('phpdoc.guides.parser.rst.structural_elements', RuleContainer::class)
+
+        ->set(InterlinkParser::class, DefaultInterlinkParser::class)
 
         ->set(AnnotationRule::class)
         ->tag('phpdoc.guides.parser.rst.body_element', ['priority' => AnnotationRule::PRIORITY])

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Interlink/DefaultInterlinkParser.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Interlink/DefaultInterlinkParser.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\RestructuredText\Parser\Interlink;
+
+use function preg_match;
+
+final class DefaultInterlinkParser implements InterlinkParser
+{
+    /** @see https://regex101.com/r/htMn5p/1 */
+    private const INTERLINK_REGEX = '/^([a-zA-Z0-9-_]+):(.*$)/';
+
+    public function extractInterlink(string $fullReference): InterlinkData
+    {
+        if (!preg_match(self::INTERLINK_REGEX, $fullReference, $matches)) {
+            return new InterlinkData($fullReference, '');
+        }
+
+        return new InterlinkData($matches[2], $matches[1] ?? '');
+    }
+}

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Interlink/InterlinkData.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Interlink/InterlinkData.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\RestructuredText\Parser\Interlink;
+
+class InterlinkData
+{
+    public function __construct(
+        public readonly string $reference,
+        public readonly string $interlink,
+    ) {
+    }
+}

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Interlink/InterlinkParser.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Interlink/InterlinkParser.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\RestructuredText\Parser\Interlink;
+
+interface InterlinkParser
+{
+    public function extractInterlink(string $fullReference): InterlinkData;
+}

--- a/packages/guides-restructured-text/src/RestructuredText/TextRoles/AbstractReferenceTextRole.php
+++ b/packages/guides-restructured-text/src/RestructuredText/TextRoles/AbstractReferenceTextRole.php
@@ -13,9 +13,6 @@ abstract class AbstractReferenceTextRole implements TextRole
 {
     use EmbeddedUriParser;
 
-    /** @see https://regex101.com/r/htMn5p/1 */
-    public const INTERLINK_REGEX = '/^([a-zA-Z0-9-_]+):(.*$)/';
-
     public function processNode(
         DocumentParserContext $documentParserContext,
         string $role,

--- a/packages/guides-restructured-text/src/RestructuredText/TextRoles/DocReferenceTextRole.php
+++ b/packages/guides-restructured-text/src/RestructuredText/TextRoles/DocReferenceTextRole.php
@@ -6,12 +6,16 @@ namespace phpDocumentor\Guides\RestructuredText\TextRoles;
 
 use phpDocumentor\Guides\Nodes\Inline\AbstractLinkInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\DocReferenceNode;
-
-use function preg_match;
+use phpDocumentor\Guides\RestructuredText\Parser\Interlink\InterlinkParser;
 
 class DocReferenceTextRole extends AbstractReferenceTextRole
 {
     final public const NAME = 'doc';
+
+    public function __construct(
+        private readonly InterlinkParser $interlinkParser,
+    ) {
+    }
 
     public function getName(): string
     {
@@ -27,15 +31,8 @@ class DocReferenceTextRole extends AbstractReferenceTextRole
     /** @return DocReferenceNode */
     protected function createNode(string $referenceTarget, string|null $referenceName, string $role): AbstractLinkInlineNode
     {
-        $pattern =  AbstractReferenceTextRole::INTERLINK_REGEX;
-        if (preg_match($pattern, $referenceTarget, $matches)) {
-            $interlinkDomain = $matches[1];
-            $path = $matches[2];
-        } else {
-            $interlinkDomain = '';
-            $path = $referenceTarget;
-        }
+        $interlinkData = $this->interlinkParser->extractInterlink($referenceTarget);
 
-        return new DocReferenceNode($path, $referenceName ?? '', $interlinkDomain);
+        return new DocReferenceNode($interlinkData->reference, $referenceName ?? '', $interlinkData->interlink);
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/TextRoles/GenericReferenceTextRole.php
+++ b/packages/guides-restructured-text/src/RestructuredText/TextRoles/GenericReferenceTextRole.php
@@ -7,15 +7,16 @@ namespace phpDocumentor\Guides\RestructuredText\TextRoles;
 use phpDocumentor\Guides\Nodes\Inline\AbstractLinkInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\ReferenceNode;
 use phpDocumentor\Guides\ReferenceResolvers\AnchorReducer;
+use phpDocumentor\Guides\RestructuredText\Parser\Interlink\InterlinkParser;
 
 use function array_keys;
-use function preg_match;
 
 class GenericReferenceTextRole extends AbstractReferenceTextRole
 {
     public function __construct(
         private readonly GenericLinkProvider $genericLinkProvider,
         private readonly AnchorReducer $anchorReducer,
+        private readonly InterlinkParser $interlinkParser,
     ) {
     }
 
@@ -34,15 +35,9 @@ class GenericReferenceTextRole extends AbstractReferenceTextRole
     protected function createNode(string $referenceTarget, string|null $referenceName, string $role): AbstractLinkInlineNode
     {
         $linkType = $this->genericLinkProvider->getLinkType($role);
-        $pattern = '/^([a-zA-Z0-9]+):(.*$)/';
-        if (preg_match(AbstractReferenceTextRole::INTERLINK_REGEX, $referenceTarget, $matches)) {
-            $interlinkDomain = $matches[1];
-            $id = $this->anchorReducer->reduceAnchor($matches[2]);
-        } else {
-            $interlinkDomain = '';
-            $id = $this->anchorReducer->reduceAnchor($referenceTarget);
-        }
+        $interlinkData = $this->interlinkParser->extractInterlink($referenceTarget);
+        $reference = $this->anchorReducer->reduceAnchor($interlinkData->reference);
 
-        return new ReferenceNode($id, $referenceName ?? '', $interlinkDomain, $linkType);
+        return new ReferenceNode($reference, $referenceName ?? '', $interlinkData->interlink, $linkType);
     }
 }

--- a/packages/guides-restructured-text/tests/unit/Parser/InlineTokenParserTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/InlineTokenParserTest.php
@@ -17,6 +17,7 @@ use phpDocumentor\Guides\Nodes\Inline\VariableInlineNode;
 use phpDocumentor\Guides\Nodes\InlineCompoundNode;
 use phpDocumentor\Guides\ParserContext;
 use phpDocumentor\Guides\RestructuredText\MarkupLanguageParser;
+use phpDocumentor\Guides\RestructuredText\Parser\Interlink\DefaultInterlinkParser;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules\AnnotationRoleRule;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules\AnonymousPhraseRule;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules\AnonymousReferenceRule;
@@ -53,7 +54,7 @@ final class InlineTokenParserTest extends TestCase
             new LiteralTextRole(),
             [
                 new ReferenceTextRole(),
-                new DocReferenceTextRole(),
+                new DocReferenceTextRole(new DefaultInterlinkParser()),
             ],
         );
         $this->documentParserContext = new DocumentParserContext(

--- a/packages/guides-restructured-text/tests/unit/TextRoles/DocReferenceTextRoleTest.php
+++ b/packages/guides-restructured-text/tests/unit/TextRoles/DocReferenceTextRoleTest.php
@@ -6,6 +6,7 @@ namespace phpDocumentor\Guides\RestructuredText\TextRoles;
 
 use phpDocumentor\Guides\Nodes\Inline\DocReferenceNode;
 use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
+use phpDocumentor\Guides\RestructuredText\Parser\Interlink\DefaultInterlinkParser;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -18,7 +19,7 @@ class DocReferenceTextRoleTest extends TestCase
     public function setUp(): void
     {
         $this->documentParserContext = $this->createMock(DocumentParserContext::class);
-        $this->docReferenceTextRole = new DocReferenceTextRole();
+        $this->docReferenceTextRole = new DocReferenceTextRole(new DefaultInterlinkParser());
     }
 
     #[DataProvider('docReferenceProvider')]


### PR DESCRIPTION
In TYPO3 we want to allow additonal special signs, so that interlinks to composer names can be made.

Additionally, this also removed duplicate code