### PR TITLE
[FEATURE] add configuration block directive

### DIFF
--- a/packages/guides-restructured-text/resources/config/guides-restructured-text.php
+++ b/packages/guides-restructured-text/resources/config/guides-restructured-text.php
@@ -11,6 +11,7 @@ use phpDocumentor\Guides\RestructuredText\Directives\BreadcrumbDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\CautionDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\ClassDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\CodeBlockDirective;
+use phpDocumentor\Guides\RestructuredText\Directives\ConfigurationBlockDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\ConfvalDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\ContainerDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\ContentsDirective;
@@ -115,6 +116,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\inline_service;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
 
@@ -175,6 +177,10 @@ return static function (ContainerConfigurator $container): void {
             ),
         ])
         ->set(ConfvalDirective::class)
+        ->set(ConfigurationBlockDirective::class)
+        ->args([
+            '$languageLabels' => param('phpdoc.rst.code_language_labels'),
+        ])
         ->set(ContainerDirective::class)
         ->set(ContentsDirective::class)
         ->arg('$documentNameResolver', service(DocumentNameResolverInterface::class))

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ConfigurationBlockDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ConfigurationBlockDirective.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\RestructuredText\Directives;
+
+use phpDocumentor\Guides\Nodes\CodeNode;
+use phpDocumentor\Guides\Nodes\CollectionNode;
+use phpDocumentor\Guides\Nodes\Configuration\ConfigurationBlockNode;
+use phpDocumentor\Guides\Nodes\Configuration\ConfigurationTab;
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
+use phpDocumentor\Guides\RestructuredText\Parser\Directive;
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\String\Slugger\AsciiSlugger;
+use Symfony\Component\String\Slugger\SluggerInterface;
+
+use function assert;
+use function get_debug_type;
+
+final class ConfigurationBlockDirective extends SubDirective
+{
+    private SluggerInterface $slugger;
+
+    /**
+     * @param Rule<CollectionNode> $startingRule
+     * @param array<string, string> $languageLabels
+     */
+    public function __construct(
+        private LoggerInterface $logger,
+        Rule $startingRule,
+        private readonly array $languageLabels = [],
+    ) {
+        parent::__construct($startingRule);
+
+        $this->slugger = new AsciiSlugger();
+    }
+
+    public function getName(): string
+    {
+        return 'configuration-block';
+    }
+
+    protected function processSub(
+        BlockContext $blockContext,
+        CollectionNode $collectionNode,
+        Directive $directive,
+    ): Node|null {
+        $tabs = [];
+        foreach ($collectionNode->getValue() as $child) {
+            if (!$child instanceof CodeNode) {
+                $this->logger->warning('The ".. configuration-block::" directive only supports code blocks, "' . get_debug_type($child) . '" given.');
+
+                continue;
+            }
+
+            $language = $child->getLanguage();
+            assert($language !== null);
+
+            $label = $this->languageLabels[$language] ?? $this->slugger->slug($language, ' ')->title()->toString();
+
+            $tabs[] = new ConfigurationTab(
+                $label,
+                $this->slugger->slug($label)->lower()->toString(),
+                $child,
+            );
+        }
+
+        return new ConfigurationBlockNode($tabs);
+    }
+}

--- a/packages/guides/resources/template/html/body/configuration-block.html.twig
+++ b/packages/guides/resources/template/html/body/configuration-block.html.twig
@@ -1,0 +1,17 @@
+<div class="configuration-block">
+    <div role="tablist" aria-label="Configuration formats" class="configuration-tabs configuration-tabs-length-{{ node.tabs|length }}">
+        {% for tab in node.tabs %}
+            <button role="tab" type="button" data-language="{{ tab.slug }}"
+                    aria-controls="{{ 'configuration-block-tabpanel-' ~ tab.hash }}" aria-selected="{{ loop.first ? 'true' : 'false' }}"
+                    {{ loop.first ? 'data-active="true"' }} {{ not loop.first ? 'tabindex="-1"' }}>
+                <span>{{ tab.label }}</span>
+            </button>
+        {% endfor %}
+    </div>
+
+    {% for tab in node.tabs %}
+        <div role="tabpanel" id="{{ 'configuration-block-tabpanel-' ~ tab.hash }}" aria-label="{{ tab.label }}" class="configuration-codeblock" data-language="{{ tab.slug }}" style="{{ not loop.first ? 'display: none' }}">
+            {{ renderNode(tab.content) }}
+        </div>
+    {% endfor %}
+</div>

--- a/packages/guides/resources/template/html/template.php
+++ b/packages/guides/resources/template/html/template.php
@@ -6,6 +6,7 @@ use phpDocumentor\Guides\Nodes\AnchorNode;
 use phpDocumentor\Guides\Nodes\AnnotationListNode;
 use phpDocumentor\Guides\Nodes\CitationNode;
 use phpDocumentor\Guides\Nodes\CodeNode;
+use phpDocumentor\Guides\Nodes\Configuration\ConfigurationBlockNode;
 use phpDocumentor\Guides\Nodes\DefinitionListNode;
 use phpDocumentor\Guides\Nodes\DefinitionLists\DefinitionNode;
 use phpDocumentor\Guides\Nodes\DocumentNode;
@@ -65,6 +66,7 @@ return [
     DocumentNode::class => 'structure/document.html.twig',
     ImageNode::class => 'body/image.html.twig',
     CodeNode::class => 'body/code.html.twig',
+    ConfigurationBlockNode::class => 'body/configuration-block.html.twig',
     DefinitionListNode::class => 'body/definition-list.html.twig',
     DefinitionNode::class => 'body/definition.html.twig',
     FieldListNode::class => 'body/field-list.html.twig',

--- a/packages/guides/src/Nodes/Configuration/ConfigurationBlockNode.php
+++ b/packages/guides/src/Nodes/Configuration/ConfigurationBlockNode.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Nodes\Configuration;
+
+use phpDocumentor\Guides\Nodes\AbstractNode;
+
+/** @extends AbstractNode<list<ConfigurationTab>> */
+final class ConfigurationBlockNode extends AbstractNode
+{
+    /** @param list<ConfigurationTab> $tabs */
+    public function __construct(
+        array $tabs,
+    ) {
+        $this->value = $tabs;
+    }
+
+    /** @return list<ConfigurationTab> */
+    public function getTabs(): array
+    {
+        return $this->value;
+    }
+}

--- a/packages/guides/src/Nodes/Configuration/ConfigurationTab.php
+++ b/packages/guides/src/Nodes/Configuration/ConfigurationTab.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Nodes\Configuration;
+
+use phpDocumentor\Guides\Nodes\CodeNode;
+
+use function hash;
+
+final class ConfigurationTab
+{
+    public readonly string $hash;
+
+    public function __construct(
+        public readonly string $label,
+        public readonly string $slug,
+        public readonly CodeNode $content,
+    ) {
+        $this->hash = hash('xxh128', $content->getValue());
+    }
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -91,6 +91,11 @@ parameters:
 			path: packages/guides-graphs/src/Graphs/Renderer/PlantumlRenderer.php
 
 		-
+			message: "#^Cannot call method scalarNode\\(\\) on Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\|null\\.$#"
+			count: 1
+			path: packages/guides-restructured-text/src/RestructuredText/DependencyInjection/ReStructuredTextExtension.php
+
+		-
 			message: "#^Using nullsafe property access on non\\-nullable type Doctrine\\\\Common\\\\Lexer\\\\Token\\<int, string\\>\\. Use \\-\\> instead\\.$#"
 			count: 1
 			path: packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/AnonymousPhraseRule.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -18,6 +18,11 @@
       <code>scalarNode</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="packages/guides-restructured-text/src/RestructuredText/DependencyInjection/ReStructuredTextExtension.php">
+    <UndefinedInterfaceMethod>
+      <code>scalarNode</code>
+    </UndefinedInterfaceMethod>
+  </file>
   <file src="packages/guides-restructured-text/src/RestructuredText/Parser/Productions/EnumeratedListRule.php">
     <InvalidArgument>
       <code>$listConfig</code>

--- a/tests/Integration/tests/directives/directive-configuration-block/expected/index.html
+++ b/tests/Integration/tests/directives/directive-configuration-block/expected/index.html
@@ -1,0 +1,30 @@
+<!-- content start -->
+    <div class="section" id="directive-tests">
+        <h1>Directive tests</h1>
+
+        <div class="configuration-block">
+            <div role="tablist" aria-label="Configuration formats" class="configuration-tabs configuration-tabs-length-2">
+                <button role="tab" type="button" data-language="yaml"
+                        aria-controls="configuration-block-tabpanel-523eafc9524d67db5f21ecae2362d532" aria-selected="true"
+                        data-active="true" >
+                    <span>Yaml</span>
+                </button>
+                <button role="tab" type="button" data-language="custom"
+                        aria-controls="configuration-block-tabpanel-a51ba27b3c76153f629592baf23834dc" aria-selected="false"
+                        tabindex="-1">
+                    <span>CUSTOM</span>
+                </button>
+            </div>
+
+            <div role="tabpanel" id="configuration-block-tabpanel-523eafc9524d67db5f21ecae2362d532" aria-label="Yaml" class="configuration-codeblock" data-language="yaml" style="">
+                <pre><code class="language-yaml"># app/config/services.yml</code></pre>
+            </div>
+            <div role="tabpanel" id="configuration-block-tabpanel-a51ba27b3c76153f629592baf23834dc" aria-label="CUSTOM" class="configuration-codeblock" data-language="custom" style="display: none">
+                <pre><code class="language-php">// config/routes.php</code></pre>
+            </div>
+        </div>
+
+    </div>
+
+
+<!-- content end -->

--- a/tests/Integration/tests/directives/directive-configuration-block/input/guides.xml
+++ b/tests/Integration/tests/directives/directive-configuration-block/input/guides.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides xmlns="https://www.phpdoc.org/guides"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd">
+    <extension class="\phpDocumentor\Guides\RestructuredText\DependencyInjection\ReStructuredTextExtension">
+            <code-language-label language="php" label="CUSTOM" />
+            <code-language-label language="other" label="Other" />
+    </extension>
+</guides>

--- a/tests/Integration/tests/directives/directive-configuration-block/input/index.rst
+++ b/tests/Integration/tests/directives/directive-configuration-block/input/index.rst
@@ -1,0 +1,13 @@
+Directive tests
+===============
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # app/config/services.yml
+
+    .. code-block:: php
+
+        // config/routes.php
+


### PR DESCRIPTION
Add the implementation of the configuration block directive. To make the implemtation more generic a configuration option is introduced. This will allow the users to configure their own labels.