### PR TITLE
[TASK] Improve progress bar

### DIFF
--- a/packages/guides/src/Event/PostCollectFilesForParsingEvent.php
+++ b/packages/guides/src/Event/PostCollectFilesForParsingEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Event;
+
+use phpDocumentor\Guides\Files;
+use phpDocumentor\Guides\Handlers\ParseDirectoryCommand;
+
+/**
+ * This event is called after all files have been collected for parsing
+ * But before the actual parsing begins.
+ *
+ * It can be used to manipulate the files to be parsed.
+ */
+final class PostCollectFilesForParsingEvent
+{
+    public function __construct(
+        private readonly ParseDirectoryCommand $command,
+        private Files $files,
+    ) {
+    }
+
+    public function getCommand(): ParseDirectoryCommand
+    {
+        return $this->command;
+    }
+
+    public function getFiles(): Files
+    {
+        return $this->files;
+    }
+
+    public function setFiles(Files $files): void
+    {
+        $this->files = $files;
+    }
+}

--- a/packages/guides/src/Event/PostRenderDocument.php
+++ b/packages/guides/src/Event/PostRenderDocument.php
@@ -16,8 +16,10 @@ use phpDocumentor\Guides\Nodes\DocumentNode;
 final class PostRenderDocument
 {
     /** @param NodeRenderer<DocumentNode> $renderer */
-    public function __construct(private readonly NodeRenderer $renderer, private readonly RenderDocumentCommand $command)
-    {
+    public function __construct(
+        private readonly NodeRenderer $renderer,
+        private readonly RenderDocumentCommand $command,
+    ) {
     }
 
     /** @return NodeRenderer<DocumentNode> */

--- a/packages/guides/src/Event/PreRenderProcess.php
+++ b/packages/guides/src/Event/PreRenderProcess.php
@@ -17,8 +17,10 @@ final class PreRenderProcess
 {
     private bool $exitRendering = false;
 
-    public function __construct(private readonly RenderCommand $command)
-    {
+    public function __construct(
+        private readonly RenderCommand $command,
+        private readonly int $steps = 1,
+    ) {
     }
 
     public function getCommand(): RenderCommand
@@ -36,5 +38,10 @@ final class PreRenderProcess
         $this->exitRendering = $exitRendering;
 
         return $this;
+    }
+
+    public function getSteps(): int
+    {
+        return $this->steps;
     }
 }

--- a/packages/guides/src/Files.php
+++ b/packages/guides/src/Files.php
@@ -14,13 +14,15 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides;
 
 use ArrayIterator;
+use Countable;
 use Iterator;
 use IteratorAggregate;
 
+use function count;
 use function in_array;
 
 /** @implements IteratorAggregate<string> */
-final class Files implements IteratorAggregate
+final class Files implements IteratorAggregate, Countable
 {
     /** @var string[] */
     private array $files = [];
@@ -38,5 +40,10 @@ final class Files implements IteratorAggregate
     public function getIterator(): Iterator
     {
         return new ArrayIterator($this->files);
+    }
+
+    public function count(): int
+    {
+        return count($this->files);
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -32,7 +32,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
-			count: 2
+			count: 1
 			path: packages/guides-cli/src/Command/Run.php
 
 		-


### PR DESCRIPTION
* Display a progress bar during parsing
* Display one progress bar per renderer
* Introduce an event once the files have been collected for parsing

This gives me progress bars like this after rendering:

Parsing: 16/16 [============================] 100% Parsed 16 files in 0.98 seconds
Rendering: 16/16 [============================] 100% Output format html: Rendered 16 documents in 0.71 seconds
Rendering: 16/16 [============================] 100% Output format interlink: Rendered 16 documents in 0.00 seconds

During rendering and during parsing the currently handled file is displayed.