### PR TITLE
[FIX] Do not use html elements in menu items

### DIFF
--- a/packages/guides/resources/template/html/body/menu/menu-item.html.twig
+++ b/packages/guides/resources/template/html/body/menu/menu-item.html.twig
@@ -1,4 +1,4 @@
-<li class="toc-item {%- if node.isCurrent %} current{% endif -%} {%- if node.isInRootline %} active{% endif -%}"><a href="{{ url }}">{{ renderNode(node.value.value) }}</a>
+<li class="toc-item {%- if node.isCurrent %} current{% endif -%} {%- if node.isInRootline %} active{% endif -%}"><a href="{{ url }}">{{ node.value.toString }}</a>
     {%- if node.children|length %}
         <ul class="menu-level-{{ node.level }}">
             {% for child in node.children -%}

--- a/tests/Integration/tests/navigation/menu-relative/input/level-1-1/index.rst
+++ b/tests/Integration/tests/navigation/menu-relative/input/level-1-1/index.rst
@@ -1,5 +1,5 @@
 =========
-Level 1-1
+Level ``1-1``
 =========
 
 Lorem Ipsum Dolor.


### PR DESCRIPTION
Menu items should be plain text, do not render the nodes of the title. Just get the plaintext string.

fixes #814 