### PR TITLE
[TASK] Allow to load `guides.xml` when in composer mode

### DIFF
--- a/packages/guides-cli/bin/guides
+++ b/packages/guides-cli/bin/guides
@@ -41,12 +41,19 @@ if ($input->hasParameterOption('-vvv', true)) {
 $containerFactory = new ContainerFactory([new ApplicationExtension()]);
 
 $projectConfig = realpath($vendorDir . '/../guides.xml');
-if (is_file($projectConfig)) {
+if ($projectConfig === false) {
+    // Usage as a normal composer package
+    $projectConfig = realpath($vendorDir . '/t3docs/render-guides/guides.xml');
+}
+
+if ($projectConfig && is_file($projectConfig)) {
     if ($verbosity === 3) {
-        echo 'Loading guides.xml from ' . $projectConfig . PHP_EOL;
+        echo 'Loading render-guides/guides.xml from ' . $projectConfig . PHP_EOL;
     }
     // vendor folder was placed directly into the project directory
     $containerFactory->addConfigFile($projectConfig);
+} elseif ($verbosity === 3) {
+    echo 'No render-guides/guides.xml found.' . PHP_EOL;
 }
 
 $workingDir = $input->getParameterOption('--working-dir', getcwd(), true);


### PR DESCRIPTION
When building a PHAR, or using this project as a composer dependency, the `vendor/bin/guides` binary could not be called due to a PHP error.

This is because the file `guides.xml` is referenced via `vendor/../guides.xml`. That works in the root of the main `render-guides` repository, but not in a composer environment.

There the correct location is `vendor/t3docs/render-guides/guides.xml`.

This PR adds a check to resolve that file in case the first try returns FALSE for the realpath() lookup.

Generally this lookup code is a bit spaghetti-ish and we should properly refactor this. For the time being, a hotfix like this would allow me to continue on using `render-guides` as a dependency in referring projects.