### PR TITLE
Resolve path after checking it leads to an existing file

### DIFF
--- a/packages/guides-cli/bin/guides
+++ b/packages/guides-cli/bin/guides
@@ -40,8 +40,9 @@ if ($input->hasParameterOption('-vvv', true)) {
 
 $containerFactory = new ContainerFactory([new ApplicationExtension()]);
 
-$projectConfig = realpath($vendorDir . '/../guides.xml');
+$projectConfig = $vendorDir . '/../guides.xml';
 if (is_file($projectConfig)) {
+    $projectConfig = realpath($vendorDir . '/../guides.xml');
     if ($verbosity === 3) {
         echo 'Loading guides.xml from ' . $projectConfig . PHP_EOL;
     }


### PR DESCRIPTION
Running the tool without creating a guides.xml is a valid scenario, and should be supported. This means realpath() may return false, which is not a valid input for is_file().

Fixes #824