### PR TITLE
[TASK] Forward directive options to node

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
@@ -153,13 +153,21 @@ final class DirectiveRule implements Rule
      */
     private function postProcessNode(Node $node, array $options): Node
     {
+        $optionsForNode = [];
         foreach ($options as $option) {
-            if ($option->getName() !== 'class' || !is_string($option->getValue()) || $option->getValue() === '') {
+            if (!is_string($option->getValue())) {
                 continue;
             }
 
-            $node->setClasses(array_merge($node->getClasses(), explode(' ', (string) $option->getValue())));
+            if ($option->getName() === 'class') {
+                $node->setClasses(array_merge($node->getClasses(), explode(' ', (string) $option->getValue())));
+                continue;
+            }
+
+            $optionsForNode[$option->getName()] = $option->getValue();
         }
+
+        $node = $node->withOptions(array_merge($optionsForNode, $node->getOptions()));
 
         return $node;
     }

--- a/tests/Integration/tests/graphs/plantuml-external/expected/Plantuml/index.html
+++ b/tests/Integration/tests/graphs/plantuml-external/expected/Plantuml/index.html
@@ -4,12 +4,12 @@
 
             <figure
         class="uml-diagram"
-            >
+        style="width: 1000"    >
         75038c5ec593504a90a100f9668e1138
     <figcaption>Figure 1-1: Application flow</figcaption></figure>
             <figure
         class="uml-diagram"
-            >
+        style="width: 1000"    >
         75038c5ec593504a90a100f9668e1138
     <figcaption>Figure 1-1: Application flow</figcaption></figure>
     </div>

--- a/tests/Integration/tests/graphs/plantuml-external/expected/index.html
+++ b/tests/Integration/tests/graphs/plantuml-external/expected/index.html
@@ -4,12 +4,12 @@
 
             <figure
         class="uml-diagram"
-            >
+        style="width: 1000"    >
         75038c5ec593504a90a100f9668e1138
     <figcaption>Figure 1-1: Application flow</figcaption></figure>
             <figure
         class="uml-diagram"
-            >
+        style="width: 1000"    >
         75038c5ec593504a90a100f9668e1138
     <figcaption>Figure 1-1: Application flow</figcaption></figure>
             <div class="toc">

--- a/tests/Integration/tests/toctree/toctree-maxdepth/expected/index.html
+++ b/tests/Integration/tests/toctree/toctree-maxdepth/expected/index.html
@@ -242,6 +242,7 @@
 
     </ul>
 </div>
+
             <p>Glob</p>
             <div class="toc">
     <ul class="menu-level">


### PR DESCRIPTION
This enables themes to define additional options that can then be used in the theme, for example additional information for code-nodes.

This also fixes an undetected bug in graphs where the width option was swalloed