### PR TITLE
Revert phpize for versions, never treat them like numbers

### DIFF
--- a/packages/guides/src/DependencyInjection/GuidesExtension.php
+++ b/packages/guides/src/DependencyInjection/GuidesExtension.php
@@ -38,7 +38,10 @@ use function array_values;
 use function assert;
 use function dirname;
 use function is_array;
+use function is_int;
+use function is_string;
 use function pathinfo;
+use function var_export;
 
 final class GuidesExtension extends Extension implements CompilerPassInterface, ConfigurationInterface, PrependExtensionInterface
 {
@@ -55,7 +58,20 @@ final class GuidesExtension extends Extension implements CompilerPassInterface, 
                 ->arrayNode('project')
                     ->children()
                         ->scalarNode('title')->end()
-                        ->scalarNode('version')->end()
+                        ->scalarNode('version')
+                            ->beforeNormalization()
+                            ->always(
+                                // We need to revert the phpize call in XmlUtils. Version is always a string!
+                                static function ($value) {
+                                    if (!is_int($value) && !is_string($value)) {
+                                        return var_export($value, true);
+                                    }
+
+                                    return $value;
+                                },
+                            )
+                            ->end()
+                        ->end()
                         ->scalarNode('release')->end()
                         ->scalarNode('copyright')->end()
                     ->end()

--- a/tests/Integration/tests/meta/version-from-guides-xml/input/skip
+++ b/tests/Integration/tests/meta/version-from-guides-xml/input/skip
@@ -1,1 +1,0 @@
-3.0 is treated as a float in the TreeBuilder and the trailing zero is lost


### PR DESCRIPTION
Fixes #829 

Don't ask me how/why this works, I just bluntly copied it from @jaapio's work on phpDocumentor's config (https://github.com/phpDocumentor/phpDocumentor/commit/991adcf381140a5900566e2bdb57cef3f8db343c).