### PR TITLE
[BUGFIX] Anchor References may not have an interlink part

### DIFF
--- a/packages/guides/src/ReferenceResolvers/AnchorReferenceResolver.php
+++ b/packages/guides/src/ReferenceResolvers/AnchorReferenceResolver.php
@@ -35,7 +35,7 @@ final class AnchorReferenceResolver implements ReferenceResolver
 
     public function resolve(LinkInlineNode $node, RenderContext $renderContext, Messages $messages): bool
     {
-        if (!$node instanceof ReferenceNode) {
+        if (!$node instanceof ReferenceNode || $node->getInterlinkDomain() !== '') {
             return false;
         }
 

--- a/tests/Integration/tests/interlink/interlink-ref-inventory-unknown/expected/Index.html
+++ b/tests/Integration/tests/interlink/interlink-ref-inventory-unknown/expected/Index.html
@@ -1,0 +1,10 @@
+<!-- content start -->
+    <div class="section" id="document-title">
+            <a id="doc"></a>
+            <h1>Document Title</h1>
+
+            <p>Lorem Ipsum Dolor.</p>
+            <p>See the TYPO3 documentation!</p>
+    </div>
+
+<!-- content end -->

--- a/tests/Integration/tests/interlink/interlink-ref-inventory-unknown/expected/logs/warning.log
+++ b/tests/Integration/tests/interlink/interlink-ref-inventory-unknown/expected/logs/warning.log
@@ -1,0 +1,1 @@
+app.WARNING: Inventory with key unknowninventory not found.

--- a/tests/Integration/tests/interlink/interlink-ref-inventory-unknown/input/Index.rst
+++ b/tests/Integration/tests/interlink/interlink-ref-inventory-unknown/input/Index.rst
@@ -1,0 +1,10 @@
+
+..  _doc:
+
+==============
+Document Title
+==============
+
+Lorem Ipsum Dolor.
+
+See the :ref:`TYPO3 documentation <unknowninventory:doc>`!

--- a/tests/Integration/tests/interlink/interlink-ref-inventory-unknown/input/guides.xml
+++ b/tests/Integration/tests/interlink/interlink-ref-inventory-unknown/input/guides.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides xmlns="https://www.phpdoc.org/guides"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd"
+>
+    <project title="My Project" version="main (development)" />
+    <inventory id="t3coreapi" url="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/" />
+</guides>


### PR DESCRIPTION
Otherwise, references to an unknown interlink reference get rendered as if they are an internal anchor link.

Resolves https://github.com/phpDocumentor/guides/issues/837