### PR TITLE
[TASK] Allow to omit whitespace before reference target

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Parser/References/EmbeddedReferenceParser.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/References/EmbeddedReferenceParser.php
@@ -14,19 +14,25 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\References;
 
 use function preg_match;
+use function trim;
 
 trait EmbeddedReferenceParser
 {
+    /**
+     * https://regex101.com/r/KadqKx/1
+     */
+    private string $referenceRegex = '/^(.*?)(<([^<]+)>)?$/s';
+
     private function extractEmbeddedReference(string $text): ReferenceData
     {
-        preg_match('/^(.*?)(?:(?:\s|^)<([^<]+)>)?$/s', $text, $matches);
+        preg_match($this->referenceRegex, $text, $matches);
 
-        $text = $matches[1] === '' ? null : $matches[1];
-        $reference = $matches[1];
+        $text = $matches[1] === '' ? null : trim($matches[1]);
+        $reference = trim($matches[1]);
 
-        if (isset($matches[2])) {
+        if (isset($matches[3])) {
             // there is an embedded URI, text and URI are different
-            $reference = $matches[2];
+            $reference = $matches[3];
         } else {
             $text = null;
         }

--- a/tests/Integration/tests/references/reference-without-space/expected/index.html
+++ b/tests/Integration/tests/references/reference-without-space/expected/index.html
@@ -1,0 +1,9 @@
+<!-- content start -->
+    <div class="section" id="the-head">
+            <a id="anchor"></a>
+            <h1>the &lt;head&gt;</h1>
+
+            <p>See also <a href="/index.html#anchor">This is the anchor</a>.</p>
+    </div>
+
+<!-- content end -->

--- a/tests/Integration/tests/references/reference-without-space/input/index.rst
+++ b/tests/Integration/tests/references/reference-without-space/input/index.rst
@@ -1,0 +1,6 @@
+.. _anchor:
+
+the \<head\>
+============
+
+See also :ref:`This is the anchor<anchor>`.


### PR DESCRIPTION
While reST expects a whitespace here, Sphinx allows to omit the whitespace and still interprets them correctly.