### PR TITLE
[BUGFIX] Treat numeral filenames as string

### DIFF
--- a/packages/guides/src/FileCollector.php
+++ b/packages/guides/src/FileCollector.php
@@ -61,11 +61,11 @@ final class FileCollector
 
         $parseQueue = new Files();
         foreach ($this->fileInfos as $filename => $_fileInfo) {
-            if (!$this->doesFileRequireParsing($filename)) {
+            if (!$this->doesFileRequireParsing((string) $filename)) {
                 continue;
             }
 
-            $parseQueue->add($filename);
+            $parseQueue->add((string) $filename);
         }
 
         return $parseQueue;

--- a/tests/Integration/tests/numeral-rst/expected/index.html
+++ b/tests/Integration/tests/numeral-rst/expected/index.html
@@ -1,0 +1,8 @@
+<!-- content start -->
+    <div class="section" id="some-title">
+            <h1>Some Title</h1>
+
+            <p>Lorem Ipsum</p>
+    </div>
+
+<!-- content end -->

--- a/tests/Integration/tests/numeral-rst/expected/objects.inv.json
+++ b/tests/Integration/tests/numeral-rst/expected/objects.inv.json
@@ -1,0 +1,30 @@
+{
+    "std:doc": {
+        "404": [
+            "-",
+            "-",
+            "404.html",
+            "Page not found (404)"
+        ],
+        "index": [
+            "-",
+            "-",
+            "index.html",
+            "Some Title"
+        ]
+    },
+    "std:label": {
+        "page-not-found-404": [
+            "-",
+            "-",
+            "404.html#page-not-found-404",
+            "Page not found (404)"
+        ],
+        "some-title": [
+            "-",
+            "-",
+            "index.html#some-title",
+            "Some Title"
+        ]
+    }
+}

--- a/tests/Integration/tests/numeral-rst/input/404.rst
+++ b/tests/Integration/tests/numeral-rst/input/404.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+====================
+Page not found (404)
+====================
+
+The page you were redirected to no longer exists.
+
+To search the entire TYPO3 documentation (https://docs.typo3.org), use the search
+box on the top of the page.

--- a/tests/Integration/tests/numeral-rst/input/index.rst
+++ b/tests/Integration/tests/numeral-rst/input/index.rst
@@ -1,0 +1,4 @@
+Some Title
+==========
+
+Lorem Ipsum


### PR DESCRIPTION
Currently pages such as 404.rst cause type errors and fail the application.