### PR TITLE
[BUGFIX] Multiline comments may contain empty lines

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/CommentRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/CommentRule.php
@@ -56,11 +56,11 @@ final class CommentRule implements Rule
             return false;
         }
 
-        return $this->isComment($line) || (trim($line) !== '' && $line[0] === ' ');
+        return $this->isComment($line) || trim($line) === '' || $line[0] === ' ';
     }
 
     private function isComment(string $line): bool
     {
-        return trim($line) === '..' || preg_match('/^\.\.\s+.*$/mUsi', $line) > 0;
+        return trim($line) === '..' || preg_match('/^\.\.\s+[^:]*$/mUsi', $line) > 0;
     }
 }

--- a/tests/Functional/tests/comment-empty/comment-empty.html
+++ b/tests/Functional/tests/comment-empty/comment-empty.html
@@ -1,4 +1,1 @@
 <p>this is not a comment</p>
-<blockquote>
-    <p>this is a blockquote</p>
-</blockquote>

--- a/tests/Integration/tests/class/class-directive/expected/index.html
+++ b/tests/Integration/tests/class/class-directive/expected/index.html
@@ -20,8 +20,6 @@
         <p>A note without a class</p>
 </div>
 
-            <blockquote class="highlights"><p>Block quote text.</p></blockquote>
-
     </div>
 
 <!-- content end -->

--- a/tests/Integration/tests/class/class-directive/input/index.rst
+++ b/tests/Integration/tests/class/class-directive/input/index.rst
@@ -37,4 +37,4 @@ Document title
 
 ..
 
-    Block quote text.
+    This is a comment

--- a/tests/Integration/tests/comments/comment-multiline/expected/index.html
+++ b/tests/Integration/tests/comments/comment-multiline/expected/index.html
@@ -1,0 +1,8 @@
+<!-- content start -->
+    <div class="section" id="some-title">
+            <h1>Some Title</h1>
+
+            <p>This text is no comment</p>
+    </div>
+
+<!-- content end -->

--- a/tests/Integration/tests/comments/comment-multiline/input/index.rst
+++ b/tests/Integration/tests/comments/comment-multiline/input/index.rst
@@ -1,0 +1,10 @@
+Some Title
+==========
+
+..
+   This whole indented block
+   is a comment.
+
+   Still in the comment.
+
+This text is no comment

--- a/tests/Integration/tests/comments/comment-nested/expected/index.html
+++ b/tests/Integration/tests/comments/comment-nested/expected/index.html
@@ -1,0 +1,12 @@
+<!-- content start -->
+    <div class="section" id="some-title">
+            <h1>Some Title</h1>
+
+            <div class="admonition note">
+            <p>No comment!</p><p>This text is no comment</p>
+</div>
+
+            <p>After the node</p>
+    </div>
+
+<!-- content end -->

--- a/tests/Integration/tests/comments/comment-nested/input/index.rst
+++ b/tests/Integration/tests/comments/comment-nested/input/index.rst
@@ -1,0 +1,15 @@
+Some Title
+==========
+
+..  note::
+    No comment!
+
+    ..
+       This whole indented block
+       is a comment.
+
+       Still in the comment.
+
+    This text is no comment
+
+After the node


### PR DESCRIPTION
See https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#comments

There were some old functional tests stating that a block citation after and empty comment is displayed, this is wrong however.