### PR TITLE
Allow excluding paths from the source directory

### DIFF
--- a/packages/guides/src/Handlers/ParseDirectoryCommand.php
+++ b/packages/guides/src/Handlers/ParseDirectoryCommand.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\Handlers;
 
+use Flyfinder\Specification\SpecificationInterface;
 use League\Flysystem\FilesystemInterface;
 use phpDocumentor\Guides\Nodes\ProjectNode;
 
@@ -23,6 +24,7 @@ final class ParseDirectoryCommand
         private readonly string $directory,
         private readonly string $inputFormat,
         private readonly ProjectNode $projectNode,
+        private readonly SpecificationInterface|null $excludedSpecification = null,
     ) {
     }
 
@@ -44,5 +46,10 @@ final class ParseDirectoryCommand
     public function getProjectNode(): ProjectNode
     {
         return $this->projectNode;
+    }
+
+    public function getExcludedSpecification(): SpecificationInterface|null
+    {
+        return $this->excludedSpecification;
     }
 }

--- a/packages/guides/src/Handlers/ParseDirectoryHandler.php
+++ b/packages/guides/src/Handlers/ParseDirectoryHandler.php
@@ -56,7 +56,7 @@ final class ParseDirectoryHandler
             $extension,
         );
 
-        $files = $this->fileCollector->collect($origin, $currentDirectory, $extension);
+        $files = $this->fileCollector->collect($origin, $currentDirectory, $extension, $command->getExcludedSpecification());
 
         $postCollectFilesForParsingEvent = $this->eventDispatcher->dispatch(
             new PostCollectFilesForParsingEvent($command, $files),


### PR DESCRIPTION
E.g. in the Symfony docs, we must exclude the `_build` directory from the source directory (the project's root) to not get rst files from dependencies parsed. I can imagine excluding `vendor/` makes sense for more repositories.

EDIT: Hah, I didn't know I was submitting this PR right when 1.0.0 was released. Fortunately, the changes in this PR are backwards-compatible so it's completely fine for a 1.1 release.