### PR TITLE
[BUGFIX] Support :abbr: textrole

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/TextRoles/AbbreviationTextRole.php
+++ b/packages/guides-restructured-text/src/RestructuredText/TextRoles/AbbreviationTextRole.php
@@ -34,6 +34,12 @@ final class AbbreviationTextRole extends BaseTextRole
 {
     protected string $name = 'abbreviation';
 
+    /** @return string[] */
+    public function getAliases(): array
+    {
+        return ['abbr'];
+    }
+
     public function __construct(
         private readonly LoggerInterface $logger,
     ) {

--- a/tests/Functional/tests/text-roles/text-roles.html
+++ b/tests/Functional/tests/text-roles/text-roles.html
@@ -1,6 +1,7 @@
 <p><code>Default interpreted text</code></p>
 <p><code>Lorem Ipsum</code></p>
 <p><abbr title="last-in, first-out">LIFO</abbr></p>
+<p><abbr title="Pretty Good Privacy">PGP</abbr></p>
 <p><em class="aspect">Some important aspect</em></p>
 <p><code>result = (1 + x) * 32</code></p>
 <p><strong class="command">rm</strong></p>

--- a/tests/Functional/tests/text-roles/text-roles.rst
+++ b/tests/Functional/tests/text-roles/text-roles.rst
@@ -4,6 +4,8 @@
 
 :abbreviation:`LIFO (last-in, first-out)`
 
+:abbr:`PGP (Pretty Good Privacy)`
+
 :aspect:`Some important aspect`
 
 :code:`result = (1 + x) * 32`


### PR DESCRIPTION
In Sphinx it is an alias for :abbreviation:

https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-abbr

resolves #899