### PR TITLE
[BUGFIX] Fix non-working short-options for "config" and "working-dir"

### DIFF
--- a/packages/guides-cli/bin/guides
+++ b/packages/guides-cli/bin/guides
@@ -9,7 +9,6 @@ use Symfony\Component\Console\Input\ArgvInput;
 use phpDocumentor\Guides\Cli\Application;
 use phpDocumentor\Guides\Cli\DependencyInjection\ApplicationExtension;
 use phpDocumentor\Guides\Cli\DependencyInjection\ContainerFactory;
-use Symfony\Component\Console\Output\ConsoleOutput;
 
 $vendorDir = dirname(__DIR__) . '/../../vendor';
 $autoloadDirectory = $vendorDir . '/autoload.php';
@@ -47,11 +46,13 @@ if (is_file($projectConfig)) {
         echo 'Loading guides.xml from ' . $projectConfig . PHP_EOL;
     }
     // vendor folder was placed directly into the project directory
-    $containerFactory->addConfigFile($projectConfig);
+    if ($projectConfig) {
+        $containerFactory->addConfigFile($projectConfig);
+    }
 }
 
-$workingDir = $input->getParameterOption('--working-dir', getcwd(), true);
-$localConfig = $input->getParameterOption('--config', $workingDir, true).'/guides.xml';
+$workingDir = $input->getParameterOption(['--working-dir', '-w'], getcwd(), true);
+$localConfig = $input->getParameterOption(['--config', '-c'], $workingDir, true) . '/guides.xml';
 
 if (is_file($localConfig) && realpath($localConfig) !== $projectConfig) {
     if ($verbosity === 3) {

--- a/packages/guides-cli/bin/guides
+++ b/packages/guides-cli/bin/guides
@@ -46,7 +46,7 @@ if (is_file($projectConfig)) {
         echo 'Loading guides.xml from ' . $projectConfig . PHP_EOL;
     }
     // vendor folder was placed directly into the project directory
-    if ($projectConfig) {
+    if ($projectConfig !== false && $projectConfig !== '') {
         $containerFactory->addConfigFile($projectConfig);
     }
 }


### PR DESCRIPTION
This adresses:

* OutputInterface namespace import is unused
* realpath() may fail, needs gating to satisfy phpstan even though it's unlikely that is_file() returns true, but realpath() doesn't.
* Currently only `--config` and not `-c` is parsed, same with `--working-dir` (`-w`)
* Note: A phpstan error remains due to `getcwd()` maybe returning false and I didn't want to obfuscate this statement with if-condititions; if you have suggestions to improve the type juggling here, tell me.