### PR TITLE
[BUGFIX] Prevent Twig from swallowing whitespace between inline tags

### DIFF
--- a/packages/guides/resources/template/html/inline/plain-text.html.twig
+++ b/packages/guides/resources/template/html/inline/plain-text.html.twig
@@ -1,1 +1,5 @@
-{{- node.value -}}
+{%- if node.value == ' ' -%}
+    {{ '&#32;'|raw }}
+{%- else -%}
+    {{ node.value }}
+{%- endif -%}

--- a/tests/Functional/tests/definition-list/definition-list.html
+++ b/tests/Functional/tests/definition-list/definition-list.html
@@ -31,7 +31,7 @@
             <span class="classifier"><code>classifier</code></span>
         </dt>
         <dd>Definition 1</dd>
-        <dt><strong>Complex:</strong> <code>int</code></dt>
+        <dt><strong>Complex:</strong>&#32;<code>int</code></dt>
         <dd>Colon must be surrounded by spaces to be a term identifier</dd>
         <dt>multi-line definition term</dt>
         <dd>

--- a/tests/Integration/tests/inline-combinations/expected/index.html
+++ b/tests/Integration/tests/inline-combinations/expected/index.html
@@ -1,0 +1,13 @@
+<!-- content start -->
+    <div class="section" id="document-title">
+            <a id="start"></a>
+            <h1>Document Title</h1>
+
+            <p>Lorem Ipsum Dolor.</p>
+            <p><strong>all</strong>&#32;<a href="/index.html#start">data</a></p>
+            <p><em>all</em>&#32;<a href="/index.html#start">data</a></p>
+            <p><strong>bold</strong> and <em>italic</em></p>
+            <p><strong>bold</strong>&#32;<em>italic</em></p>
+    </div>
+
+<!-- content end -->

--- a/tests/Integration/tests/inline-combinations/input/index.rst
+++ b/tests/Integration/tests/inline-combinations/input/index.rst
@@ -1,0 +1,15 @@
+..  _start:
+
+==============
+Document Title
+==============
+
+Lorem Ipsum Dolor.
+
+**all** :ref:`data <start>`
+
+*all* :ref:`data <start>`
+
+**bold** and *italic*
+
+**bold** *italic*

--- a/tests/Integration/tests/tables/list-table-directive/expected/index.html
+++ b/tests/Integration/tests/tables/list-table-directive/expected/index.html
@@ -1,10 +1,3 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <title>table</title>
-
-</head>
-<body>
 <!-- content start -->
     <div class="section" id="table">
             <h1>table</h1>
@@ -71,5 +64,3 @@ crunchy, now would it?</td>
     </div>
 
 <!-- content end -->
-</body>
-</html>


### PR DESCRIPTION
resolves #922

I can only solve this by outputting &32; which equals a space. @wouterj is there any solution to force Twig to preserve a real space char?