### PR TITLE
[FEATURE] Support basic glossary directive

### DIFF
--- a/packages/guides-restructured-text/resources/template/html/body/directive/glossary.html.twig
+++ b/packages/guides-restructured-text/resources/template/html/body/directive/glossary.html.twig
@@ -1,0 +1,1 @@
+<div class="{{ node.glossary }}">{{ renderNode(node.value) }}</div>

--- a/tests/Integration/tests/directives/directive-glossary/expected/index.html
+++ b/tests/Integration/tests/directives/directive-glossary/expected/index.html
@@ -1,0 +1,19 @@
+<!-- content start -->
+    <div class="section" id="directive-tests">
+            <h1>Directive tests</h1>
+
+            <div class=""><dl>
+                        <dt>environment</dt>
+
+        <dd>A structure where information about all documents under the root is
+saved, and used for cross-referencing. The environment is pickled
+after the parsing stage, so that successive runs only need to read
+and parse new and changed documents.</dd>                        <dt>source directory</dt>
+
+        <dd>The directory which, including its subdirectories, contains all
+source files for one documentation project.</dd>    </dl>
+</div>
+
+    </div>
+
+<!-- content end -->

--- a/tests/Integration/tests/directives/directive-glossary/input/index.rst
+++ b/tests/Integration/tests/directives/directive-glossary/input/index.rst
@@ -1,0 +1,14 @@
+Directive tests
+===============
+
+..  glossary::
+
+    environment
+        A structure where information about all documents under the root is
+        saved, and used for cross-referencing. The environment is pickled
+        after the parsing stage, so that successive runs only need to read
+        and parse new and changed documents.
+
+    source directory
+        The directory which, including its subdirectories, contains all
+        source files for one documentation project.

--- a/tests/Integration/tests/tables/list-table-directive/expected/index.html
+++ b/tests/Integration/tests/tables/list-table-directive/expected/index.html
@@ -1,10 +1,3 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <title>table</title>
-
-</head>
-<body>
 <!-- content start -->
     <div class="section" id="table">
             <h1>table</h1>
@@ -71,5 +64,3 @@ crunchy, now would it?</td>
     </div>
 
 <!-- content end -->
-</body>
-</html>


### PR DESCRIPTION
Support glossary directive containing a definition list. Multiple terms, groups and :sorted: flag are not yet supported

https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-glossary

resolves: #929
releases: main, 1.0