### PR TITLE
Fix whitespace control

### DIFF
--- a/packages/guides-theme-bootstrap/resources/template/body/directive/tabs/tabs-body.html.twig
+++ b/packages/guides-theme-bootstrap/resources/template/body/directive/tabs/tabs-body.html.twig
@@ -1,3 +1,4 @@
 <div class="tab-pane fade {%- if tab.active %} show active{% endif -%}" id="{{ tab.key }}-{{ tabsId }}" role="tabpanel" aria-labelledby="{{ tab.key }}-tab-{{ tabsId }}">
     {{ renderNode(tab.value) }}
 </div>
+{# force a new line at the end of the file #}

--- a/packages/guides-theme-bootstrap/resources/template/body/directive/tabs/tabs-button.html.twig
+++ b/packages/guides-theme-bootstrap/resources/template/body/directive/tabs/tabs-button.html.twig
@@ -6,3 +6,4 @@
         {{ renderNode(tab.content) }}
     </button>
 </li>
+{# force a new line at the end of the file #}

--- a/packages/guides-theme-bootstrap/resources/template/body/menu/mainmenu/menu-level.html.twig
+++ b/packages/guides-theme-bootstrap/resources/template/body/menu/mainmenu/menu-level.html.twig
@@ -1,17 +1,19 @@
 
 <ul class="level-{{ menuEntry.level }}">
-        {% for entry in menuEntry.children -%}
-                <li><a href="{{ renderLink(entry.url) }}"
-                       class="nav-link {%- if menu.currentPath == entry.url %} current {%- endif -%}{% if entry.url in menu.rootlinePaths %} active {%- endif -%}"
-                            {%- if menu.currentPath == entry.url %} aria-current="page" {%- endif -%} >
-                                {{ renderNode(entry.value.value) }}
-                        </a>
+    {% for entry in menuEntry.children -%}
+        <li>
+            <a href="{{ renderLink(entry.url) }}"
+               class="nav-link {%- if menu.currentPath == entry.url %} current {%- endif -%}{% if entry.url in menu.rootlinePaths %} active {%- endif -%}"
+                {%- if menu.currentPath == entry.url %} aria-current="page" {%- endif -%}>
+                    {{- renderNode(entry.value.value) -}}
+            </a>
 
-                        {%- if entry.children|length %}
-                                {% include "body/menu/mainmenu/menu-level.html.twig" with {
-                                        menuEntry:entry
-                                } %}
-                        {%- endif -%}
-                </li>
-        {% endfor %}
+            {%- if entry.children|length %}
+                    {% include "body/menu/mainmenu/menu-level.html.twig" with {
+                            menuEntry:entry
+                    } %}
+            {%- endif ~%}
+        </li>
+    {% endfor %}
 </ul>
+{# force a new line at the end of the file #}

--- a/packages/guides-theme-bootstrap/resources/template/body/menu/mainmenu/menu.html.twig
+++ b/packages/guides-theme-bootstrap/resources/template/body/menu/mainmenu/menu.html.twig
@@ -1,23 +1,24 @@
 <nav class="nav flex-column">
-        {% if node.caption %}
-            <h2>{{ renderNode(node.caption) }}</h2>
-        {% endif %}
-        <ul class="menu-level-main">
-    {% for entry in node.menuEntries -%}
-        <li><a href="{{ renderLink(entry.url) }}"
-           class="nav-link {%- if node.currentPath == entry.url %} current {%- endif -%}{% if entry.url in node.rootlinePaths %} active {%- endif -%}"
-                        {%- if node.currentPath == entry.url %} aria-current="page" {% endif -%} >
-            {{ renderNode(entry.value.value) }}
-                </a>
+    {% if node.caption %}
+        <h2>{{ renderNode(node.caption) }}</h2>
+    {% endif %}
+    <ul class="menu-level-main">
+        {% for entry in node.menuEntries -%}
+        <li>
+            <a href="{{ renderLink(entry.url) }}"
+               class="nav-link {%- if node.currentPath == entry.url %} current {%- endif -%}{% if entry.url in node.rootlinePaths %} active {%- endif -%}"
+               {%- if node.currentPath == entry.url %} aria-current="page"{% endif -%}>
+                {{- renderNode(entry.value.value) -}}
+            </a>
 
-        {%- if entry.children|length %}
-            {% include "body/menu/mainmenu/menu-level.html.twig" with {
-                    menu:node,
-                    menuEntry:entry
-            } %}
-        {%- endif -%}
+            {%- if entry.children|length %}
+                {% include "body/menu/mainmenu/menu-level.html.twig" with {
+                        menu:node,
+                        menuEntry:entry
+                } %}
+            {%- endif ~%}
         </li>
-    {% endfor %}
-        </ul>
-
+        {% endfor %}
+    </ul>
 </nav>
+{# force a new line at the end of the file #}

--- a/packages/guides-theme-bootstrap/resources/template/body/menu/navbar/menu-level.html.twig
+++ b/packages/guides-theme-bootstrap/resources/template/body/menu/navbar/menu-level.html.twig
@@ -1,13 +1,13 @@
+
 <ul class="level-{{ node.level }}">
     {% for entry in node.menuEntries -%}
-    {% apply spaceless %}
-        <li class="nav-item">
-            <a href="{{ renderLink(entry.url) }}"
-               class="nav-link  {%- if menu.currentPath == entry.url %} current {%- endif -%}{% if entry.url in menu.rootlinePaths %} active {%- endif -%}"
-                    {%- if menu.currentPath == entry.url %} aria-current="page" {% endif %} >
-                {{ renderNode(entry.value.value) }}
-            </a>
-        </li>
-        {% endapply %}
-    {%- endfor %}
+    <li class="nav-item">
+        <a href="{{ renderLink(entry.url) }}"
+           class="nav-link  {%- if menu.currentPath == entry.url %} current {%- endif -%}{% if entry.url in menu.rootlinePaths %} active {%- endif -%}"
+                {%- if menu.currentPath == entry.url %} aria-current="page"{% endif %}>
+            {{- renderNode(entry.value.value) -}}
+        </a>
+    </li>
+    {%~ endfor %}
 </ul>
+{# force a new line at the end of the file #}

--- a/packages/guides-theme-bootstrap/resources/template/body/menu/navbar/table-of-content.html.twig
+++ b/packages/guides-theme-bootstrap/resources/template/body/menu/navbar/table-of-content.html.twig
@@ -2,10 +2,10 @@
 <ul class="navbar-nav me-auto mb-2 mb-lg-0">
     {% for entry in node.menuEntries -%}
         <li class="nav-item">
-                <a href="{{ renderLink(entry.url) }}" class="nav-link {%- if node.currentPath == entry.url %} current {%- endif -%}{% if entry.url in node.rootlinePaths %} active {%- endif -%}"
-                        {%- if node.currentPath == entry.url %} aria-current="page" {% endif %} >
-            {{ renderNode(entry.value.value) }}
-        </a>
+            <a href="{{ renderLink(entry.url) }}" class="nav-link {%- if node.currentPath == entry.url %} current {%- endif -%}{% if entry.url in node.rootlinePaths %} active {%- endif -%}"
+                    {%- if node.currentPath == entry.url %} aria-current="page"{% endif %}>
+                {{ renderNode(entry.value.value) }}
+            </a>
         </li>
 
         {%- if entry.children|length %}
@@ -16,3 +16,4 @@
         {%- endif -%}
     {% endfor %}
 </ul>
+{# force a new line at the end of the file #}

--- a/packages/guides-theme-bootstrap/resources/template/structure/navigation/navbar.html.twig
+++ b/packages/guides-theme-bootstrap/resources/template/structure/navigation/navbar.html.twig
@@ -7,7 +7,6 @@
             <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
-
             {% if parts.navbar %}
                 {% for child in parts.navbar -%}
                     {{ renderNode(child) }}
@@ -18,3 +17,4 @@
         </div>
     </div>
 </nav>
+{# force a new line at the end of the file #}

--- a/packages/guides/resources/config/guides.php
+++ b/packages/guides/resources/config/guides.php
@@ -57,6 +57,7 @@ use phpDocumentor\Guides\Twig\AssetsExtension;
 use phpDocumentor\Guides\Twig\EnvironmentBuilder;
 use phpDocumentor\Guides\Twig\GlobalMenuExtension;
 use phpDocumentor\Guides\Twig\Theme\ThemeManager;
+use phpDocumentor\Guides\Twig\TrimFilesystemLoader;
 use phpDocumentor\Guides\Twig\TwigTemplateRenderer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Reference;
@@ -223,11 +224,12 @@ return static function (ContainerConfigurator $container): void {
             param('phpdoc.guides.base_template_paths'),
         )
 
-        ->set(FilesystemLoader::class)
+        ->set(TrimFilesystemLoader::class)
         ->arg(
             '$paths',
             param('phpdoc.guides.base_template_paths'),
         )
+        ->alias(FilesystemLoader::class, TrimFilesystemLoader::class)
 
         ->set(LoadSettingsFromComposer::class)
         ->tag('event_listener', ['event' => PostProjectNodeCreated::class])

--- a/packages/guides/resources/template/html/body/admonition.html.twig
+++ b/packages/guides/resources/template/html/body/admonition.html.twig
@@ -1,3 +1,4 @@
+
 <div class="admonition {{ name }}{{ class ? (' '~class) }}{% if node.classes %} {{ node.classesString }}{% endif %}">
     {% if title and isTitled %}<p class="admonition-title">{{ renderNode(title) }}</p>{% endif %}
     {% if title and not isTitled %}<p>{{ renderNode(title) }}</p>{% endif %}

--- a/packages/guides/resources/template/html/body/code.html.twig
+++ b/packages/guides/resources/template/html/body/code.html.twig
@@ -12,4 +12,4 @@
                 {%- if node.emphasizeLines %} data-emphasize-lines="{{ node.emphasizeLines }}"{% endif -%}>
     {%- include "body/code/highlighted-code.html.twig" -%}
         </code></pre>
-{%- endif -%}
+{%~ endif -%}

--- a/packages/guides/resources/template/html/body/container.html.twig
+++ b/packages/guides/resources/template/html/body/container.html.twig
@@ -1,3 +1,4 @@
 <div class="{{ class }}"{% if id is defined and id %} id="{{ id }}"{% endif %}>
     {{ renderNode(node) }}
 </div>
+{# force a new line at the end of the file #}

--- a/packages/guides/resources/template/html/body/definition-list.html.twig
+++ b/packages/guides/resources/template/html/body/definition-list.html.twig
@@ -16,7 +16,7 @@
         {% if definitionListTerm.children %}
             {%- for definition in definitionListTerm.children -%}
             <dd>{{ renderNode(definition) }}</dd>
-            {%- endfor -%}
+            {%- endfor ~%}
         {% endif %}
     {% endfor %}
 </dl>

--- a/packages/guides/resources/template/html/body/list/list.html.twig
+++ b/packages/guides/resources/template/html/body/list/list.html.twig
@@ -9,3 +9,4 @@
     {{ renderNode(child) }}
 {% endfor %}
 </{{ keyword }}>
+{# force a new line at the end of the file #}

--- a/packages/guides/resources/template/html/body/menu/menu-item.html.twig
+++ b/packages/guides/resources/template/html/body/menu/menu-item.html.twig
@@ -1,16 +1,17 @@
-<li class="toc-item {%- if node.isCurrent %} current{% endif -%} {%- if node.isInRootline %} active{% endif -%}"><a href="{{ url }}">{{ node.value.toString }}</a>
-    {%- if node.children|length %}
+<li class="toc-item {%- if node.isCurrent %} current{% endif -%} {%- if node.isInRootline %} active{% endif -%}">
+    <a href="{{ url }}">{{ node.value.toString }}</a>
+    {%~ if node.children|length %}
         <ul class="menu-level-{{ node.level }}">
             {% for child in node.children -%}
                 {{ renderNode(child) }}
             {% endfor %}
         </ul>
-    {%- endif -%}
-    {%- if node.sections|length %}
+    {%- endif ~%}
+    {%~ if node.sections|length %}
         <ul class="section-level-{{ node.level }}">
             {% for subsection in node.sections -%}
                 {{ renderNode(subsection) }}
             {% endfor %}
         </ul>
-    {%- endif -%}
+    {%- endif ~%}
 </li>

--- a/packages/guides/resources/template/html/body/menu/menu-level.html.twig
+++ b/packages/guides/resources/template/html/body/menu/menu-level.html.twig
@@ -3,3 +3,4 @@
         {{ renderNode(entry) }}
     {% endfor %}
 </ul>
+{# force a new line at the end of the file #}

--- a/packages/guides/resources/template/html/body/paragraph.html.twig
+++ b/packages/guides/resources/template/html/body/paragraph.html.twig
@@ -1,7 +1,5 @@
-{% apply spaceless %}
-    {% set text = renderNode(node.value) %}
+{% set text = renderNode(node.value) %}
 
-    {% if text %}
-        <p{% if node.classes %} class="{{ node.classesString }}"{% endif %}>{{ text|raw }}</p>
-    {% endif %}
-{% endapply %}
+{% if text %}
+    <p{% if node.classes %} class="{{ node.classesString }}"{% endif %}>{{ text|raw }}</p>
+{% endif %}

--- a/packages/guides/resources/template/html/body/quote.html.twig
+++ b/packages/guides/resources/template/html/body/quote.html.twig
@@ -1,1 +1,1 @@
-<blockquote{% if node.classes %} class="{{ node.classesString }}"{% endif %}>{{ renderNode(node.value) }}</blockquote>
+<blockquote{% if node.classes %} class="{{ node.classesString }}"{% endif %}>{{- renderNode(node.value) -}}</blockquote>

--- a/packages/guides/resources/template/html/body/table/table-body.html.twig
+++ b/packages/guides/resources/template/html/body/table/table-body.html.twig
@@ -3,3 +3,4 @@
     {% include "body/table/table-row.html.twig" %}
 {% endfor %}
 </tbody>
+{# force a new line at the end of the file #}

--- a/packages/guides/resources/template/html/body/table/table-cell.html.twig
+++ b/packages/guides/resources/template/html/body/table/table-cell.html.twig
@@ -2,3 +2,4 @@
     {%- for child in column.children -%}
         {{- renderNode(child) -}}
     {%- else %}&nbsp;{% endfor %}</td>
+{# force a new line at the end of the file #}

--- a/packages/guides/resources/template/html/body/table/table-row.html.twig
+++ b/packages/guides/resources/template/html/body/table/table-row.html.twig
@@ -3,3 +3,4 @@
         {% include "body/table/table-cell.html.twig" %}
     {% endfor %}
 </tr>
+{# force a new line at the end of the file #}

--- a/packages/guides/resources/template/html/inline/anchor.html.twig
+++ b/packages/guides/resources/template/html/inline/anchor.html.twig
@@ -1,3 +1,1 @@
-{% apply spaceless %}
 <a id="{{- node.value -}}"></a>
-{% endapply %}

--- a/packages/guides/resources/template/html/inline/doc.html.twig
+++ b/packages/guides/resources/template/html/inline/doc.html.twig
@@ -1,1 +1,1 @@
-{% apply spaceless %}{{ include('inline/link.html.twig') }}{% endapply %}
+{{- include('inline/link.html.twig') -}}

--- a/packages/guides/resources/template/html/inline/emphasis.html.twig
+++ b/packages/guides/resources/template/html/inline/emphasis.html.twig
@@ -1,3 +1,1 @@
-{% apply spaceless %}
 <em>{{- node.value -}}</em>
-{% endapply %}

--- a/packages/guides/resources/template/html/inline/image.html.twig
+++ b/packages/guides/resources/template/html/inline/image.html.twig
@@ -1,2 +1,1 @@
-{% apply spaceless %}<img src="{{- node.url -}}" alt="{{- node.altText -}}"/>
-{% endapply %}
+<img src="{{- node.url -}}" alt="{{- node.altText -}}"/>

--- a/packages/guides/resources/template/html/inline/literal.html.twig
+++ b/packages/guides/resources/template/html/inline/literal.html.twig
@@ -1,3 +1,1 @@
-{% apply spaceless %}
 <code>{{- node.value -}}</code>
-{% endapply %}

--- a/packages/guides/resources/template/html/inline/nbsp.html.twig
+++ b/packages/guides/resources/template/html/inline/nbsp.html.twig
@@ -1,1 +1,1 @@
-{% apply spaceless %}&nbsp;{% endapply %}
+&nbsp;

--- a/packages/guides/resources/template/html/inline/newline.html.twig
+++ b/packages/guides/resources/template/html/inline/newline.html.twig
@@ -1,1 +1,1 @@
-{% apply spaceless %}<br>{% endapply %}
+<br>

--- a/packages/guides/resources/template/html/inline/ref.html.twig
+++ b/packages/guides/resources/template/html/inline/ref.html.twig
@@ -1,1 +1,1 @@
-{% apply spaceless %}{{ include('inline/link.html.twig') }}{% endapply %}
+{{- include('inline/link.html.twig') -}}

--- a/packages/guides/resources/template/html/inline/strong.html.twig
+++ b/packages/guides/resources/template/html/inline/strong.html.twig
@@ -1,2 +1,1 @@
-{% apply spaceless %}<strong>{{- node.value -}}</strong>
-{% endapply %}
+<strong>{{- node.value -}}</strong>

--- a/packages/guides/resources/template/html/inline/textroles/abbreviation.html.twig
+++ b/packages/guides/resources/template/html/inline/textroles/abbreviation.html.twig
@@ -1,3 +1,1 @@
-{% apply spaceless %}
 <abbr title="{{ node.definition }}"{%- if node.class %} class="{{ node.class }}"{% endif %}>{{ node.term }}</abbr>
-{% endapply %}

--- a/packages/guides/resources/template/html/inline/textroles/aspect.html.twig
+++ b/packages/guides/resources/template/html/inline/textroles/aspect.html.twig
@@ -1,3 +1,1 @@
-{% apply spaceless %}
 <em class="aspect{%- if node.class %} {{ node.class }}{% endif %}">{{ node.value }}</em>
-{% endapply %}

--- a/packages/guides/resources/template/html/inline/textroles/br.html.twig
+++ b/packages/guides/resources/template/html/inline/textroles/br.html.twig
@@ -1,1 +1,1 @@
-{%- apply spaceless %}<br/>{% endapply -%}
+<br/>

--- a/packages/guides/resources/template/html/inline/textroles/code.html.twig
+++ b/packages/guides/resources/template/html/inline/textroles/code.html.twig
@@ -1,4 +1,1 @@
-{% apply spaceless %}
 <code{%- if node.class %} class="{{ node.class }}"{% endif %}>{{ node.value }}</code>
-
-{% endapply %}

--- a/packages/guides/resources/template/html/inline/textroles/command.html.twig
+++ b/packages/guides/resources/template/html/inline/textroles/command.html.twig
@@ -1,4 +1,1 @@
-{% apply spaceless %}
 <strong class="command{%- if node.class %} {{ node.class }}{% endif %}">{{ node.value }}</strong>
-
-{% endapply %}

--- a/packages/guides/resources/template/html/inline/textroles/dfn.html.twig
+++ b/packages/guides/resources/template/html/inline/textroles/dfn.html.twig
@@ -1,4 +1,1 @@
-{% apply spaceless %}
 <em class="dfn{%- if node.class %} {{ node.class }}{% endif %}">{{ node.value }}</em>
-
-{% endapply %}

--- a/packages/guides/resources/template/html/inline/textroles/emphasis.html.twig
+++ b/packages/guides/resources/template/html/inline/textroles/emphasis.html.twig
@@ -1,3 +1,1 @@
-{% apply spaceless %}
 <em{%- if node.class %} class="{{ node.class }}"{% endif %}>{{ node.value }}</em>
-{% endapply %}

--- a/packages/guides/resources/template/html/inline/textroles/file.html.twig
+++ b/packages/guides/resources/template/html/inline/textroles/file.html.twig
@@ -1,4 +1,1 @@
-{% apply spaceless %}
 <span class="pre file{%- if node.class %} {{ node.class }}{% endif %}">{{ node.value }}</span>
-
-{% endapply %}

--- a/packages/guides/resources/template/html/inline/textroles/guilabel.html.twig
+++ b/packages/guides/resources/template/html/inline/textroles/guilabel.html.twig
@@ -1,3 +1,1 @@
-{% apply spaceless %}
 <span class="guilabel{%- if node.class %} {{ node.class }}{% endif %}">{{ node.value }}</span>
-{% endapply %}

--- a/packages/guides/resources/template/html/inline/textroles/kbd.html.twig
+++ b/packages/guides/resources/template/html/inline/textroles/kbd.html.twig
@@ -1,3 +1,1 @@
-{% apply spaceless %}
 <kbd{%- if node.class %} class="{{ node.class }}"{% endif %}>{{ node.value }}</kbd>
-{% endapply %}

--- a/packages/guides/resources/template/html/inline/textroles/literal.html.twig
+++ b/packages/guides/resources/template/html/inline/textroles/literal.html.twig
@@ -1,3 +1,1 @@
-{% apply spaceless %}
 <code{%- if node.class %} class="{{ node.class }}"{% endif %}>{{ node.value }}</code>
-{% endapply %}

--- a/packages/guides/resources/template/html/inline/textroles/mailheader.html.twig
+++ b/packages/guides/resources/template/html/inline/textroles/mailheader.html.twig
@@ -1,3 +1,1 @@
-{% apply spaceless %}
 <em class="mailheader{%- if node.class %} {{ node.class }}{% endif %}">{{ node.value }}</em>
-{% endapply %}

--- a/packages/guides/resources/template/html/inline/textroles/math.html.twig
+++ b/packages/guides/resources/template/html/inline/textroles/math.html.twig
@@ -1,3 +1,1 @@
-{% apply spaceless %}
 <math{%- if node.class %} class="{{ node.class }}"{% endif %}>{{ node.value }}</math>
-{% endapply %}

--- a/packages/guides/resources/template/html/inline/textroles/span.html.twig
+++ b/packages/guides/resources/template/html/inline/textroles/span.html.twig
@@ -1,3 +1,1 @@
-{% apply spaceless %}
 <span{%- if node.class %} class="{{ node.class }}"{% endif %}>{{- node.value -}}</span>
-{% endapply %}

--- a/packages/guides/resources/template/html/inline/textroles/strong.html.twig
+++ b/packages/guides/resources/template/html/inline/textroles/strong.html.twig
@@ -1,3 +1,1 @@
-{% apply spaceless %}
 <strong{%- if node.class %} class="{{ node.class }}"{% endif %}>{{ node.value }}</strong>
-{% endapply %}

--- a/packages/guides/resources/template/html/inline/textroles/sub.html.twig
+++ b/packages/guides/resources/template/html/inline/textroles/sub.html.twig
@@ -1,3 +1,1 @@
-{% apply spaceless %}
 <sub{%- if node.class %} class="{{ node.class }}"{% endif %}>{{ node.value }}</sub>
-{% endapply %}

--- a/packages/guides/resources/template/html/inline/textroles/subscript.html.twig
+++ b/packages/guides/resources/template/html/inline/textroles/subscript.html.twig
@@ -1,3 +1,1 @@
-{% apply spaceless %}
 <sub{%- if node.class %} class="{{ node.class }}"{% endif %}>{{ node.value }}</sub>
-{% endapply %}

--- a/packages/guides/resources/template/html/inline/textroles/sup.html.twig
+++ b/packages/guides/resources/template/html/inline/textroles/sup.html.twig
@@ -1,3 +1,1 @@
-{% apply spaceless %}
 <sup{%- if node.class %} class="{{ node.class }}"{% endif %}>{{ node.value }}</sup>
-{% endapply %}

--- a/packages/guides/resources/template/html/inline/textroles/superscript.html.twig
+++ b/packages/guides/resources/template/html/inline/textroles/superscript.html.twig
@@ -1,3 +1,1 @@
-{% apply spaceless %}
 <sup{%- if node.class %} class="{{ node.class }}"{% endif %}>{{ node.value }}</sup>
-{% endapply %}

--- a/packages/guides/resources/template/html/inline/textroles/t.html.twig
+++ b/packages/guides/resources/template/html/inline/textroles/t.html.twig
@@ -1,3 +1,1 @@
-{% apply spaceless %}
 <cite{%- if node.class %} class="{{ node.class }}"{% endif %}>{{ node.value }}</cite>
-{% endapply %}

--- a/packages/guides/resources/template/html/inline/textroles/title-reference.html.twig
+++ b/packages/guides/resources/template/html/inline/textroles/title-reference.html.twig
@@ -1,3 +1,1 @@
-{% apply spaceless %}
 <cite{%- if node.class %} class="{{ node.class }}"{% endif %}>{{ node.value }}</cite>
-{% endapply %}

--- a/packages/guides/resources/template/html/inline/textroles/title.html.twig
+++ b/packages/guides/resources/template/html/inline/textroles/title.html.twig
@@ -1,3 +1,1 @@
-{% apply spaceless %}
 <cite{%- if node.class %} class="{{ node.class }}"{% endif %}>{{ node.value }}</cite>
-{% endapply %}

--- a/packages/guides/resources/template/html/inline/textroles/unknown.html.twig
+++ b/packages/guides/resources/template/html/inline/textroles/unknown.html.twig
@@ -1,3 +1,1 @@
-{% apply spaceless %}
 <code class="{{ node.type }}{%- if node.class %} {{ node.class }}{% endif %}">{{ node.value }}</code>
-{% endapply %}

--- a/packages/guides/resources/template/html/inline/variable.html.twig
+++ b/packages/guides/resources/template/html/inline/variable.html.twig
@@ -1,2 +1,1 @@
-{% apply spaceless %}{{ renderNode(node.child) }}
-{% endapply %}
+{{- renderNode(node.child) -}}

--- a/packages/guides/resources/template/tex/body/paragraph.tex.twig
+++ b/packages/guides/resources/template/tex/body/paragraph.tex.twig
@@ -1,8 +1,5 @@
-{% apply spaceless %}
-{% set text = renderNode(node.value) %}
+{%- set text = renderNode(node.value) -%}
 
-{% if text|trim %}
-{{ text|raw }}
-
-{% endif %}
-{% endapply %}
+{%- if text|trim %}
+    {{- text|raw -}}
+{% endif -%}

--- a/packages/guides/resources/template/tex/inline/literal.tex.twig
+++ b/packages/guides/resources/template/tex/inline/literal.tex.twig
@@ -1,3 +1,1 @@
-{% apply spaceless %}
 \texttt{{ '{' }}{{- node.value -}}{{ '}' }}
-{% endapply %}

--- a/packages/guides/resources/template/tex/inline/textroles/generic.tex.twig
+++ b/packages/guides/resources/template/tex/inline/textroles/generic.tex.twig
@@ -1,4 +1,4 @@
 {%- include  [
     ('inline/textroles/' ~ node.type ~ '.tex.twig'),
-    'inline/textroles/unkown.tex.twig'
+    'inline/textroles/unknown.tex.twig'
     ]  -%}

--- a/packages/guides/resources/template/tex/inline/textroles/unknown.tex.twig
+++ b/packages/guides/resources/template/tex/inline/textroles/unknown.tex.twig
@@ -1,3 +1,1 @@
-{% apply spaceless %}
 \texttt{{ '{' }}{{- node.value -}}{{ '}' }}
-{% endapply %}

--- a/packages/guides/resources/template/tex/structure/header-title.tex.twig
+++ b/packages/guides/resources/template/tex/structure/header-title.tex.twig
@@ -1,6 +1,4 @@
-{%- apply spaceless -%}
 {%- set headingLevel = node.level -%}
 \{% if headingLevel == 1 %}section{% elseif headingLevel == 2 %}subsection{% elseif headingLevel == 3 %}subsubsection{% elseif headingLevel == 4 %}paragraph{% elseif headingLevel == 5 %}subparagraph{% elseif headingLevel == 6 %}subparagraph{% endif %}{
 {{- renderNode(node.value) -}}
 }
-{%- endapply -%}

--- a/packages/guides/src/Twig/TrimFilesystemLoader.php
+++ b/packages/guides/src/Twig/TrimFilesystemLoader.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\Twig;
+
+use Twig\Loader\FilesystemLoader;
+use Twig\Source;
+
+use function preg_replace;
+
+/**
+ * A file system loader that trims the last line ending from the template
+ * content.
+ */
+class TrimFilesystemLoader extends FilesystemLoader
+{
+    // phpcs:disable SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+
+    /** @param string $name */
+    public function getSourceContext($name): Source
+    {
+        // phpcs:enable
+        $source = parent::getSourceContext($name);
+
+        return new Source(
+            preg_replace('/\R$/', '', $source->getCode()) ?? $source->getCode(),
+            $source->getName(),
+            $source->getPath(),
+        );
+    }
+}

--- a/tests/Functional/tests/code-block-diff/code-block-diff.html
+++ b/tests/Functional/tests/code-block-diff/code-block-diff.html
@@ -2,7 +2,8 @@
 - Removed line
   Normal line
 - Removed line
-+ Added line</code></pre><pre><code class="language-diff">  Normal line
++ Added line</code></pre>
+<pre><code class="language-diff">  Normal line
 + Added line
 - Removed line
   Normal line

--- a/tests/Functional/tests/inline-code/inline-code.html
+++ b/tests/Functional/tests/inline-code/inline-code.html
@@ -1,1 +1,4 @@
-<p><code class="php">$result = $a + 23;</code><code class="typoscript">lib.hello.value = Hello World!</code><span class="pre file">/etc/passwd</span><kbd>ctrl</kbd> + <kbd>s</kbd></p>
+<p><code class="php">$result = $a + 23;</code>
+<code class="typoscript">lib.hello.value = Hello World!</code>
+<span class="pre file">/etc/passwd</span>
+<kbd>ctrl</kbd> + <kbd>s</kbd></p>

--- a/tests/Functional/tests/link-with-special-char/link-with-special-char.html
+++ b/tests/Functional/tests/link-with-special-char/link-with-special-char.html
@@ -1,1 +1,2 @@
-<p><a href="https://php.net/manual/en/class.intldateformatter.php#intl.intldateformatter-constants">IntlDateFormatter::MEDIUM</a><a href="https://php.net/manual/en/class.intldateformatter.php#intl.intldateformatter-constants">IntlDateFormatter:: FULL</a></p>
+<p><a href="https://php.net/manual/en/class.intldateformatter.php#intl.intldateformatter-constants">IntlDateFormatter::MEDIUM</a>
+<a href="https://php.net/manual/en/class.intldateformatter.php#intl.intldateformatter-constants">IntlDateFormatter:: FULL</a></p>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-default-menu-several/expected/anotherPage.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-default-menu-several/expected/anotherPage.html
@@ -1,150 +1,149 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
-<head>
-    <title>Another Page - Bootstrap Theme</title>
-    <!-- Required meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-        
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-</head>
-<body>
-<header class="">
-        
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <div class="container">
+    <head>
+        <title>Another Page - Bootstrap Theme</title>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <a class="navbar-brand" href="#">Navbar</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    </head>
+    <body>
+        <header class="">
 
-                                
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="#" class="nav-link current active" aria-current="page"  >
-            Another Page
-        </a>
-        </li><li class="nav-item">
-                <a href="somePage.html" class="nav-link" >
-            Some Page
-        </a>
-        </li><li class="nav-item">
-                <a href="subpages/index.html" class="nav-link" >
-            Subpages
-        </a>
-        </li>            <ul class="level-">
-    <li class="nav-item"><a href="#"
-               class="nav-link current active" aria-current="page"  >
-                Another Page
-            </a></li><li class="nav-item"><a href="somePage.html"
-               class="nav-link" >
-                Some Page
-            </a></li><li class="nav-item"><a href="subpages/index.html"
-               class="nav-link" >
-                Subpages
-            </a></li></ul>
-</ul>
-    
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="yetAnotherPage.html" class="nav-link" >
-            Yet Another Page
-        </a>
-        </li></ul>
+            <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+                <div class="container">
 
+                    <a class="navbar-brand" href="#">Navbar</a>
+                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="#" class="nav-link current active" aria-current="page">
+                                    Another Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="somePage.html" class="nav-link">
+                                    Some Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="subpages/index.html" class="nav-link">
+                                    Subpages
+                                </a>
+                            </li>            
+                            <ul class="level-">
+                                <li class="nav-item">
+                                    <a href="#"
+                                        class="nav-link current active" aria-current="page">Another Page</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a href="somePage.html"
+                                        class="nav-link">Some Page</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a href="subpages/index.html"
+                                        class="nav-link">Subpages</a>
+                                </li>
+                            </ul>
+                        </ul>
+
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="yetAnotherPage.html" class="nav-link">
+                                    Yet Another Page
+                                </a>
+                            </li></ul>
 
                     </div>
-    </div>
-</nav>
-</header>
-<main id="main-content">
-    <div class="container">
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-3">
-                                <nav class="nav flex-column">
-                    <h2>Main Menu</h2>
-                <ul class="menu-level-main">
-    <li><a href="#"
-           class="nav-link current active" aria-current="page" >
-            Another Page
-                </a></li>
-    <li><a href="somePage.html"
-           class="nav-link">
-            Some Page
-                </a></li>
-    <li><a href="subpages/index.html"
-           class="nav-link">
-            Subpages
-                </a>            
-<ul class="level-1">
-        <li><a href="subpages/subpage1.html"
-                       class="nav-link">
-                                Subpages 1
-                        </a></li>
-        <li><a href="subpages/subpage2.html"
-                       class="nav-link">
-                                Subpages 2
-                        </a></li>
-        </ul>
-</li>
-            </ul>
-
-</nav>
-    <nav class="nav flex-column">
-                    <h2>Additional Menu</h2>
-                <ul class="menu-level-main">
-    <li><a href="yetAnotherPage.html"
-           class="nav-link">
-            Yet Another Page
-                </a></li>
-            </ul>
-
-</nav>
-
-
                 </div>
-                <div class="col-lg-9">
-                        
-<nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="index.html">Document Title</a></li>
-        <li class="breadcrumb-item"><a href="#">Another Page</a></li>
-            </ol>
-</nav>
+            </nav>
+        </header>
+        <main id="main-content">
+            <div class="container">
+                <div class="container">
+                    <div class="row">
+                        <div class="col-lg-3">
+                            <nav class="nav flex-column">
+                                <h2>Main Menu</h2>
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="#"
+                                            class="nav-link current active" aria-current="page">Another Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="somePage.html"
+                                            class="nav-link">Some Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="subpages/index.html"
+                                            class="nav-link">Subpages</a>                
+                                        <ul class="level-1">
+                                            <li>
+                                                <a href="subpages/subpage1.html"
+                                                    class="nav-link">Subpages 1</a>
+                                            </li>
+                                            <li>
+                                                <a href="subpages/subpage2.html"
+                                                    class="nav-link">Subpages 2</a>
+                                            </li>
+                                        </ul>
 
-                    <!-- content start -->
-                        
+                                    </li>
+                                </ul>
+                            </nav>
+                            <nav class="nav flex-column">
+                                <h2>Additional Menu</h2>
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="yetAnotherPage.html"
+                                            class="nav-link">Yet Another Page</a>
+                                    </li>
+                                </ul>
+                            </nav>
 
-<div class="section" id="another-page">
-            <h1>Another Page</h1>
+                        </div>
+                        <div class="col-lg-9">
 
-            <p>Lorem Ipsum Dolor.</p>
-    </div>
+                            <nav aria-label="breadcrumb">
+                                <ol class="breadcrumb">
+                                    <li class="breadcrumb-item"><a href="index.html">Document Title</a></li>
+                                    <li class="breadcrumb-item"><a href="#">Another Page</a></li>
+                                </ol>
+                            </nav>
+                            <!-- content start -->
 
-                    <!-- content end -->
+                            <div class="section" id="another-page">
+                                <h1>Another Page</h1>
+
+                                <p>Lorem Ipsum Dolor.</p>
+
+                            </div>
+                            <!-- content end -->
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-    </div>
-</main>
-                <footer class="bg-primary text-light">
+        </main>
+        <footer class="bg-primary text-light">
             <div class="container">
+
                 <p>Generated by <a href="https://www.phpdoc.org/">phpDocumentor</a>.</p>
-</div>
+
+            </div>
         </footer>
-    
-<!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 1: Bootstrap Bundle with Popper -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+        <!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 2: Separate Popper and Bootstrap JS -->
-<!--
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
--->
-</body>
+        <!-- Option 1: Bootstrap Bundle with Popper -->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+        <!-- Option 2: Separate Popper and Bootstrap JS -->
+        <!--
+            <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+            <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+            -->
+    </body>
 </html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-default-menu-several/expected/index.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-default-menu-several/expected/index.html
@@ -1,174 +1,189 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
-<head>
-    <title>Document Title - Bootstrap Theme</title>
-    <!-- Required meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-        
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-</head>
-<body>
-<header class="">
-        
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <div class="container">
+    <head>
+        <title>Document Title - Bootstrap Theme</title>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <a class="navbar-brand" href="#">Navbar</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    </head>
+    <body>
+        <header class="">
 
-                                
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="anotherPage.html" class="nav-link" >
-            Another Page
-        </a>
-        </li><li class="nav-item">
-                <a href="somePage.html" class="nav-link" >
-            Some Page
-        </a>
-        </li><li class="nav-item">
-                <a href="subpages/index.html" class="nav-link" >
-            Subpages
-        </a>
-        </li>            <ul class="level-">
-    <li class="nav-item"><a href="anotherPage.html"
-               class="nav-link" >
-                Another Page
-            </a></li><li class="nav-item"><a href="somePage.html"
-               class="nav-link" >
-                Some Page
-            </a></li><li class="nav-item"><a href="subpages/index.html"
-               class="nav-link" >
-                Subpages
-            </a></li></ul>
-</ul>
-    
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="yetAnotherPage.html" class="nav-link" >
-            Yet Another Page
-        </a>
-        </li></ul>
+            <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+                <div class="container">
 
+                    <a class="navbar-brand" href="#">Navbar</a>
+                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="anotherPage.html" class="nav-link">
+                                    Another Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="somePage.html" class="nav-link">
+                                    Some Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="subpages/index.html" class="nav-link">
+                                    Subpages
+                                </a>
+                            </li>            
+                            <ul class="level-">
+                                <li class="nav-item">
+                                    <a href="anotherPage.html"
+                                        class="nav-link">Another Page</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a href="somePage.html"
+                                        class="nav-link">Some Page</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a href="subpages/index.html"
+                                        class="nav-link">Subpages</a>
+                                </li>
+                            </ul>
+                        </ul>
+
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="yetAnotherPage.html" class="nav-link">
+                                    Yet Another Page
+                                </a>
+                            </li></ul>
 
                     </div>
-    </div>
-</nav>
-</header>
-<main id="main-content">
-    <div class="container">
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-3">
-                                <nav class="nav flex-column">
-                    <h2>Main Menu</h2>
-                <ul class="menu-level-main">
-    <li><a href="anotherPage.html"
-           class="nav-link">
-            Another Page
-                </a></li>
-    <li><a href="somePage.html"
-           class="nav-link">
-            Some Page
-                </a></li>
-    <li><a href="subpages/index.html"
-           class="nav-link">
-            Subpages
-                </a>            
-<ul class="level-1">
-        <li><a href="subpages/subpage1.html"
-                       class="nav-link">
-                                Subpages 1
-                        </a></li>
-        <li><a href="subpages/subpage2.html"
-                       class="nav-link">
-                                Subpages 2
-                        </a></li>
-        </ul>
-</li>
-            </ul>
-
-</nav>
-    <nav class="nav flex-column">
-                    <h2>Additional Menu</h2>
-                <ul class="menu-level-main">
-    <li><a href="yetAnotherPage.html"
-           class="nav-link">
-            Yet Another Page
-                </a></li>
-            </ul>
-
-</nav>
-
-
                 </div>
-                <div class="col-lg-9">
-                        
-<nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="#">Document Title</a></li>
-            </ol>
-</nav>
+            </nav>
+        </header>
+        <main id="main-content">
+            <div class="container">
+                <div class="container">
+                    <div class="row">
+                        <div class="col-lg-3">
+                            <nav class="nav flex-column">
+                                <h2>Main Menu</h2>
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="anotherPage.html"
+                                            class="nav-link">Another Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="somePage.html"
+                                            class="nav-link">Some Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="subpages/index.html"
+                                            class="nav-link">Subpages</a>                
+                                        <ul class="level-1">
+                                            <li>
+                                                <a href="subpages/subpage1.html"
+                                                    class="nav-link">Subpages 1</a>
+                                            </li>
+                                            <li>
+                                                <a href="subpages/subpage2.html"
+                                                    class="nav-link">Subpages 2</a>
+                                            </li>
+                                        </ul>
 
-                    <!-- content start -->
-                        
+                                    </li>
+                                </ul>
+                            </nav>
+                            <nav class="nav flex-column">
+                                <h2>Additional Menu</h2>
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="yetAnotherPage.html"
+                                            class="nav-link">Yet Another Page</a>
+                                    </li>
+                                </ul>
+                            </nav>
 
-<div class="section" id="document-title">
-            <h1>Document Title</h1>
+                        </div>
+                        <div class="col-lg-9">
 
-            <p>Lorem Ipsum Dolor.</p>
-            <div class="toc">
-            <p class="caption">Main Menu</p>
-    <ul class="menu-level">
-    <li class="toc-item"><a href="anotherPage.html#another-page">Another Page</a></li>
+                            <nav aria-label="breadcrumb">
+                                <ol class="breadcrumb">
+                                    <li class="breadcrumb-item"><a href="#">Document Title</a></li>
+                                </ol>
+                            </nav>
+                            <!-- content start -->
 
-    <li class="toc-item"><a href="somePage.html#some-page">Some Page</a></li>
+                            <div class="section" id="document-title">
+                                <h1>Document Title</h1>
 
-    <li class="toc-item"><a href="subpages/index.html#subpages">Subpages</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="subpages/subpage1.html#subpages-1">Subpages 1</a></li>
+                                <p>Lorem Ipsum Dolor.</p>
 
-            <li class="toc-item"><a href="subpages/subpage2.html#subpages-2">Subpages 2</a></li>
+                                <div class="toc">
+                                    <p class="caption">Main Menu</p>
+                                    <ul class="menu-level">
+                                        <li class="toc-item">
+                                            <a href="anotherPage.html#another-page">Another Page</a>
 
-                    </ul></li>
 
-    </ul>
-</div>
+                                        </li>
+                                        <li class="toc-item">
+                                            <a href="somePage.html#some-page">Some Page</a>
 
-            <div class="toc">
-            <p class="caption">Additional Menu</p>
-    <ul class="menu-level">
-    <li class="toc-item"><a href="yetAnotherPage.html#yet-another-page">Yet Another Page</a></li>
 
-    </ul>
-</div>
+                                        </li>
+                                        <li class="toc-item">
+                                            <a href="subpages/index.html#subpages">Subpages</a>
+                                            <ul class="menu-level-1">
+                                                <li class="toc-item">
+                                                    <a href="subpages/subpage1.html#subpages-1">Subpages 1</a>
 
-    </div>
 
-                    <!-- content end -->
+                                                </li>
+                                                <li class="toc-item">
+                                                    <a href="subpages/subpage2.html#subpages-2">Subpages 2</a>
+
+
+                                                </li>
+                                            </ul>
+
+                                        </li>
+                                    </ul>
+                                </div>
+                                <div class="toc">
+                                    <p class="caption">Additional Menu</p>
+                                    <ul class="menu-level">
+                                        <li class="toc-item">
+                                            <a href="yetAnotherPage.html#yet-another-page">Yet Another Page</a>
+
+
+                                        </li>
+                                    </ul>
+                                </div>
+                            </div>
+                            <!-- content end -->
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-    </div>
-</main>
-                <footer class="bg-primary text-light">
+        </main>
+        <footer class="bg-primary text-light">
             <div class="container">
+
                 <p>Generated by <a href="https://www.phpdoc.org/">phpDocumentor</a>.</p>
-</div>
+
+            </div>
         </footer>
-    
-<!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 1: Bootstrap Bundle with Popper -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+        <!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 2: Separate Popper and Bootstrap JS -->
-<!--
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
--->
-</body>
+        <!-- Option 1: Bootstrap Bundle with Popper -->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+        <!-- Option 2: Separate Popper and Bootstrap JS -->
+        <!--
+            <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+            <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+            -->
+    </body>
 </html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-default-menu-several/expected/somePage.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-default-menu-several/expected/somePage.html
@@ -1,150 +1,149 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
-<head>
-    <title>Some Page - Bootstrap Theme</title>
-    <!-- Required meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-        
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-</head>
-<body>
-<header class="">
-        
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <div class="container">
+    <head>
+        <title>Some Page - Bootstrap Theme</title>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <a class="navbar-brand" href="#">Navbar</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    </head>
+    <body>
+        <header class="">
 
-                                
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="anotherPage.html" class="nav-link" >
-            Another Page
-        </a>
-        </li><li class="nav-item">
-                <a href="#" class="nav-link current active" aria-current="page"  >
-            Some Page
-        </a>
-        </li><li class="nav-item">
-                <a href="subpages/index.html" class="nav-link" >
-            Subpages
-        </a>
-        </li>            <ul class="level-">
-    <li class="nav-item"><a href="anotherPage.html"
-               class="nav-link" >
-                Another Page
-            </a></li><li class="nav-item"><a href="#"
-               class="nav-link current active" aria-current="page"  >
-                Some Page
-            </a></li><li class="nav-item"><a href="subpages/index.html"
-               class="nav-link" >
-                Subpages
-            </a></li></ul>
-</ul>
-    
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="yetAnotherPage.html" class="nav-link" >
-            Yet Another Page
-        </a>
-        </li></ul>
+            <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+                <div class="container">
 
+                    <a class="navbar-brand" href="#">Navbar</a>
+                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="anotherPage.html" class="nav-link">
+                                    Another Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="#" class="nav-link current active" aria-current="page">
+                                    Some Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="subpages/index.html" class="nav-link">
+                                    Subpages
+                                </a>
+                            </li>            
+                            <ul class="level-">
+                                <li class="nav-item">
+                                    <a href="anotherPage.html"
+                                        class="nav-link">Another Page</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a href="#"
+                                        class="nav-link current active" aria-current="page">Some Page</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a href="subpages/index.html"
+                                        class="nav-link">Subpages</a>
+                                </li>
+                            </ul>
+                        </ul>
+
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="yetAnotherPage.html" class="nav-link">
+                                    Yet Another Page
+                                </a>
+                            </li></ul>
 
                     </div>
-    </div>
-</nav>
-</header>
-<main id="main-content">
-    <div class="container">
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-3">
-                                <nav class="nav flex-column">
-                    <h2>Main Menu</h2>
-                <ul class="menu-level-main">
-    <li><a href="anotherPage.html"
-           class="nav-link">
-            Another Page
-                </a></li>
-    <li><a href="#"
-           class="nav-link current active" aria-current="page" >
-            Some Page
-                </a></li>
-    <li><a href="subpages/index.html"
-           class="nav-link">
-            Subpages
-                </a>            
-<ul class="level-1">
-        <li><a href="subpages/subpage1.html"
-                       class="nav-link">
-                                Subpages 1
-                        </a></li>
-        <li><a href="subpages/subpage2.html"
-                       class="nav-link">
-                                Subpages 2
-                        </a></li>
-        </ul>
-</li>
-            </ul>
-
-</nav>
-    <nav class="nav flex-column">
-                    <h2>Additional Menu</h2>
-                <ul class="menu-level-main">
-    <li><a href="yetAnotherPage.html"
-           class="nav-link">
-            Yet Another Page
-                </a></li>
-            </ul>
-
-</nav>
-
-
                 </div>
-                <div class="col-lg-9">
-                        
-<nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="index.html">Document Title</a></li>
-        <li class="breadcrumb-item"><a href="#">Some Page</a></li>
-            </ol>
-</nav>
+            </nav>
+        </header>
+        <main id="main-content">
+            <div class="container">
+                <div class="container">
+                    <div class="row">
+                        <div class="col-lg-3">
+                            <nav class="nav flex-column">
+                                <h2>Main Menu</h2>
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="anotherPage.html"
+                                            class="nav-link">Another Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="#"
+                                            class="nav-link current active" aria-current="page">Some Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="subpages/index.html"
+                                            class="nav-link">Subpages</a>                
+                                        <ul class="level-1">
+                                            <li>
+                                                <a href="subpages/subpage1.html"
+                                                    class="nav-link">Subpages 1</a>
+                                            </li>
+                                            <li>
+                                                <a href="subpages/subpage2.html"
+                                                    class="nav-link">Subpages 2</a>
+                                            </li>
+                                        </ul>
 
-                    <!-- content start -->
-                        
+                                    </li>
+                                </ul>
+                            </nav>
+                            <nav class="nav flex-column">
+                                <h2>Additional Menu</h2>
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="yetAnotherPage.html"
+                                            class="nav-link">Yet Another Page</a>
+                                    </li>
+                                </ul>
+                            </nav>
 
-<div class="section" id="some-page">
-            <h1>Some Page</h1>
+                        </div>
+                        <div class="col-lg-9">
 
-            <p>Lorem Ipsum <span class="custom">Dolor</span>.</p>
-    </div>
+                            <nav aria-label="breadcrumb">
+                                <ol class="breadcrumb">
+                                    <li class="breadcrumb-item"><a href="index.html">Document Title</a></li>
+                                    <li class="breadcrumb-item"><a href="#">Some Page</a></li>
+                                </ol>
+                            </nav>
+                            <!-- content start -->
 
-                    <!-- content end -->
+                            <div class="section" id="some-page">
+                                <h1>Some Page</h1>
+
+                                <p>Lorem Ipsum <span class="custom">Dolor</span>.</p>
+
+                            </div>
+                            <!-- content end -->
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-    </div>
-</main>
-                <footer class="bg-primary text-light">
+        </main>
+        <footer class="bg-primary text-light">
             <div class="container">
+
                 <p>Generated by <a href="https://www.phpdoc.org/">phpDocumentor</a>.</p>
-</div>
+
+            </div>
         </footer>
-    
-<!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 1: Bootstrap Bundle with Popper -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+        <!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 2: Separate Popper and Bootstrap JS -->
-<!--
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
--->
-</body>
+        <!-- Option 1: Bootstrap Bundle with Popper -->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+        <!-- Option 2: Separate Popper and Bootstrap JS -->
+        <!--
+            <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+            <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+            -->
+    </body>
 </html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-default-menu-several/expected/subpages/index.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-default-menu-several/expected/subpages/index.html
@@ -1,151 +1,152 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
-<head>
-    <title>Subpages - Bootstrap Theme</title>
-    <!-- Required meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-        
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-</head>
-<body>
-<header class="">
-        
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <div class="container">
+    <head>
+        <title>Subpages - Bootstrap Theme</title>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <a class="navbar-brand" href="#">Navbar</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    </head>
+    <body>
+        <header class="">
 
-                                
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="../anotherPage.html" class="nav-link" >
-            Another Page
-        </a>
-        </li><li class="nav-item">
-                <a href="../somePage.html" class="nav-link" >
-            Some Page
-        </a>
-        </li><li class="nav-item">
-                <a href="#" class="nav-link current active" aria-current="page"  >
-            Subpages
-        </a>
-        </li>            <ul class="level-">
-    <li class="nav-item"><a href="../anotherPage.html"
-               class="nav-link" >
-                Another Page
-            </a></li><li class="nav-item"><a href="../somePage.html"
-               class="nav-link" >
-                Some Page
-            </a></li><li class="nav-item"><a href="#"
-               class="nav-link current active" aria-current="page"  >
-                Subpages
-            </a></li></ul>
-</ul>
-    
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="../yetAnotherPage.html" class="nav-link" >
-            Yet Another Page
-        </a>
-        </li></ul>
+            <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+                <div class="container">
 
+                    <a class="navbar-brand" href="#">Navbar</a>
+                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="../anotherPage.html" class="nav-link">
+                                    Another Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="../somePage.html" class="nav-link">
+                                    Some Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="#" class="nav-link current active" aria-current="page">
+                                    Subpages
+                                </a>
+                            </li>            
+                            <ul class="level-">
+                                <li class="nav-item">
+                                    <a href="../anotherPage.html"
+                                        class="nav-link">Another Page</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a href="../somePage.html"
+                                        class="nav-link">Some Page</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a href="#"
+                                        class="nav-link current active" aria-current="page">Subpages</a>
+                                </li>
+                            </ul>
+                        </ul>
+
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="../yetAnotherPage.html" class="nav-link">
+                                    Yet Another Page
+                                </a>
+                            </li></ul>
 
                     </div>
-    </div>
-</nav>
-</header>
-<main id="main-content">
-    <div class="container">
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-3">
-                                <nav class="nav flex-column">
-                    <h2>Main Menu</h2>
-                <ul class="menu-level-main">
-    <li><a href="../anotherPage.html"
-           class="nav-link">
-            Another Page
-                </a></li>
-    <li><a href="../somePage.html"
-           class="nav-link">
-            Some Page
-                </a></li>
-    <li><a href="#"
-           class="nav-link current active" aria-current="page" >
-            Subpages
-                </a>            
-<ul class="level-1">
-        <li><a href="subpage1.html"
-                       class="nav-link">
-                                Subpages 1
-                        </a></li>
-        <li><a href="subpage2.html"
-                       class="nav-link">
-                                Subpages 2
-                        </a></li>
-        </ul>
-</li>
-            </ul>
-
-</nav>
-    <nav class="nav flex-column">
-                    <h2>Additional Menu</h2>
-                <ul class="menu-level-main">
-    <li><a href="../yetAnotherPage.html"
-           class="nav-link">
-            Yet Another Page
-                </a></li>
-            </ul>
-
-</nav>
-
-
                 </div>
-                <div class="col-lg-9">
-                        
-<nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="../index.html">Document Title</a></li>
-        <li class="breadcrumb-item"><a href="#">Subpages</a></li>
-            </ol>
-</nav>
+            </nav>
+        </header>
+        <main id="main-content">
+            <div class="container">
+                <div class="container">
+                    <div class="row">
+                        <div class="col-lg-3">
+                            <nav class="nav flex-column">
+                                <h2>Main Menu</h2>
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="../anotherPage.html"
+                                            class="nav-link">Another Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="../somePage.html"
+                                            class="nav-link">Some Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="#"
+                                            class="nav-link current active" aria-current="page">Subpages</a>                
+                                        <ul class="level-1">
+                                            <li>
+                                                <a href="subpage1.html"
+                                                    class="nav-link">Subpages 1</a>
+                                            </li>
+                                            <li>
+                                                <a href="subpage2.html"
+                                                    class="nav-link">Subpages 2</a>
+                                            </li>
+                                        </ul>
 
-                    <!-- content start -->
-                        <div class="section" id="subpages">
-            <h1>Subpages</h1>
+                                    </li>
+                                </ul>
+                            </nav>
+                            <nav class="nav flex-column">
+                                <h2>Additional Menu</h2>
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="../yetAnotherPage.html"
+                                            class="nav-link">Yet Another Page</a>
+                                    </li>
+                                </ul>
+                            </nav>
 
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="subpage1.html#subpages-1">Subpages 1</a></li>
+                        </div>
+                        <div class="col-lg-9">
 
-    <li class="toc-item"><a href="subpage2.html#subpages-2">Subpages 2</a></li>
+                            <nav aria-label="breadcrumb">
+                                <ol class="breadcrumb">
+                                    <li class="breadcrumb-item"><a href="../index.html">Document Title</a></li>
+                                    <li class="breadcrumb-item"><a href="#">Subpages</a></li>
+                                </ol>
+                            </nav>
+                            <!-- content start -->
+                            <div class="section" id="subpages">
+                                <h1>Subpages</h1>
+                                <div class="toc">
+                                    <ul class="menu-level">
+                                        <li class="toc-item">
+                                            <a href="subpage1.html#subpages-1">Subpages 1</a>
 
-    </ul>
-</div>
 
-    </div>
+                                        </li>
+                                        <li class="toc-item">
+                                            <a href="subpage2.html#subpages-2">Subpages 2</a>
 
-                    <!-- content end -->
+
+                                        </li>
+                                    </ul>
+                                </div>
+                            </div>
+                            <!-- content end -->
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-    </div>
-</main>
-        
-<!-- Optional JavaScript; choose one of the two! -->
+        </main>
 
-<!-- Option 1: Bootstrap Bundle with Popper -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+        <!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 2: Separate Popper and Bootstrap JS -->
-<!--
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
--->
-</body>
+        <!-- Option 1: Bootstrap Bundle with Popper -->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+        <!-- Option 2: Separate Popper and Bootstrap JS -->
+        <!--
+            <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+            <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+            -->
+    </body>
 </html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-default-menu-several/expected/subpages/subpage1.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-default-menu-several/expected/subpages/subpage1.html
@@ -1,143 +1,139 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
-<head>
-    <title>Subpages 1 - Bootstrap Theme</title>
-    <!-- Required meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-        
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-</head>
-<body>
-<header class="">
-        
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <div class="container">
+    <head>
+        <title>Subpages 1 - Bootstrap Theme</title>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <a class="navbar-brand" href="#">Navbar</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    </head>
+    <body>
+        <header class="">
 
-                                
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="../anotherPage.html" class="nav-link" >
-            Another Page
-        </a>
-        </li><li class="nav-item">
-                <a href="../somePage.html" class="nav-link" >
-            Some Page
-        </a>
-        </li><li class="nav-item">
-                <a href="index.html" class="nav-link active" >
-            Subpages
-        </a>
-        </li>            <ul class="level-">
-    <li class="nav-item"><a href="../anotherPage.html"
-               class="nav-link" >
-                Another Page
-            </a></li><li class="nav-item"><a href="../somePage.html"
-               class="nav-link" >
-                Some Page
-            </a></li><li class="nav-item"><a href="index.html"
-               class="nav-link active" >
-                Subpages
-            </a></li></ul>
-</ul>
-    
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="../yetAnotherPage.html" class="nav-link" >
-            Yet Another Page
-        </a>
-        </li></ul>
+            <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+                <div class="container">
 
+                    <a class="navbar-brand" href="#">Navbar</a>
+                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="../anotherPage.html" class="nav-link">
+                                    Another Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="../somePage.html" class="nav-link">
+                                    Some Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="index.html" class="nav-link active">
+                                    Subpages
+                                </a>
+                            </li>            
+                            <ul class="level-">
+                                <li class="nav-item">
+                                    <a href="../anotherPage.html"
+                                        class="nav-link">Another Page</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a href="../somePage.html"
+                                        class="nav-link">Some Page</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a href="index.html"
+                                        class="nav-link active">Subpages</a>
+                                </li>
+                            </ul>
+                        </ul>
+
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="../yetAnotherPage.html" class="nav-link">
+                                    Yet Another Page
+                                </a>
+                            </li></ul>
 
                     </div>
-    </div>
-</nav>
-</header>
-<main id="main-content">
-    <div class="container">
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-3">
-                                <nav class="nav flex-column">
-                    <h2>Main Menu</h2>
-                <ul class="menu-level-main">
-    <li><a href="../anotherPage.html"
-           class="nav-link">
-            Another Page
-                </a></li>
-    <li><a href="../somePage.html"
-           class="nav-link">
-            Some Page
-                </a></li>
-    <li><a href="index.html"
-           class="nav-link active">
-            Subpages
-                </a>            
-<ul class="level-1">
-        <li><a href="#"
-                       class="nav-link current active" aria-current="page">
-                                Subpages 1
-                        </a></li>
-        <li><a href="subpage2.html"
-                       class="nav-link">
-                                Subpages 2
-                        </a></li>
-        </ul>
-</li>
-            </ul>
-
-</nav>
-    <nav class="nav flex-column">
-                    <h2>Additional Menu</h2>
-                <ul class="menu-level-main">
-    <li><a href="../yetAnotherPage.html"
-           class="nav-link">
-            Yet Another Page
-                </a></li>
-            </ul>
-
-</nav>
-
-
                 </div>
-                <div class="col-lg-9">
-                        
-<nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="../index.html">Document Title</a></li>
-        <li class="breadcrumb-item"><a href="index.html">Subpages</a></li>
-        <li class="breadcrumb-item"><a href="#">Subpages 1</a></li>
-            </ol>
-</nav>
+            </nav>
+        </header>
+        <main id="main-content">
+            <div class="container">
+                <div class="container">
+                    <div class="row">
+                        <div class="col-lg-3">
+                            <nav class="nav flex-column">
+                                <h2>Main Menu</h2>
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="../anotherPage.html"
+                                            class="nav-link">Another Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="../somePage.html"
+                                            class="nav-link">Some Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="index.html"
+                                            class="nav-link active">Subpages</a>                
+                                        <ul class="level-1">
+                                            <li>
+                                                <a href="#"
+                                                    class="nav-link current active" aria-current="page">Subpages 1</a>
+                                            </li>
+                                            <li>
+                                                <a href="subpage2.html"
+                                                    class="nav-link">Subpages 2</a>
+                                            </li>
+                                        </ul>
 
-                    <!-- content start -->
-                        <div class="section" id="subpages-1">
-            <h1>Subpages 1</h1>
+                                    </li>
+                                </ul>
+                            </nav>
+                            <nav class="nav flex-column">
+                                <h2>Additional Menu</h2>
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="../yetAnotherPage.html"
+                                            class="nav-link">Yet Another Page</a>
+                                    </li>
+                                </ul>
+                            </nav>
 
-    </div>
+                        </div>
+                        <div class="col-lg-9">
 
-                    <!-- content end -->
+                            <nav aria-label="breadcrumb">
+                                <ol class="breadcrumb">
+                                    <li class="breadcrumb-item"><a href="../index.html">Document Title</a></li>
+                                    <li class="breadcrumb-item"><a href="index.html">Subpages</a></li>
+                                    <li class="breadcrumb-item"><a href="#">Subpages 1</a></li>
+                                </ol>
+                            </nav>
+                            <!-- content start -->
+                            <div class="section" id="subpages-1">
+                                <h1>Subpages 1</h1>
+                            </div>
+                            <!-- content end -->
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-    </div>
-</main>
-        
-<!-- Optional JavaScript; choose one of the two! -->
+        </main>
 
-<!-- Option 1: Bootstrap Bundle with Popper -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+        <!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 2: Separate Popper and Bootstrap JS -->
-<!--
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
--->
-</body>
+        <!-- Option 1: Bootstrap Bundle with Popper -->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+        <!-- Option 2: Separate Popper and Bootstrap JS -->
+        <!--
+            <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+            <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+            -->
+    </body>
 </html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-default-menu-several/expected/subpages/subpage2.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-default-menu-several/expected/subpages/subpage2.html
@@ -1,143 +1,139 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
-<head>
-    <title>Subpages 2 - Bootstrap Theme</title>
-    <!-- Required meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-        
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-</head>
-<body>
-<header class="">
-        
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <div class="container">
+    <head>
+        <title>Subpages 2 - Bootstrap Theme</title>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <a class="navbar-brand" href="#">Navbar</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    </head>
+    <body>
+        <header class="">
 
-                                
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="../anotherPage.html" class="nav-link" >
-            Another Page
-        </a>
-        </li><li class="nav-item">
-                <a href="../somePage.html" class="nav-link" >
-            Some Page
-        </a>
-        </li><li class="nav-item">
-                <a href="index.html" class="nav-link active" >
-            Subpages
-        </a>
-        </li>            <ul class="level-">
-    <li class="nav-item"><a href="../anotherPage.html"
-               class="nav-link" >
-                Another Page
-            </a></li><li class="nav-item"><a href="../somePage.html"
-               class="nav-link" >
-                Some Page
-            </a></li><li class="nav-item"><a href="index.html"
-               class="nav-link active" >
-                Subpages
-            </a></li></ul>
-</ul>
-    
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="../yetAnotherPage.html" class="nav-link" >
-            Yet Another Page
-        </a>
-        </li></ul>
+            <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+                <div class="container">
 
+                    <a class="navbar-brand" href="#">Navbar</a>
+                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="../anotherPage.html" class="nav-link">
+                                    Another Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="../somePage.html" class="nav-link">
+                                    Some Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="index.html" class="nav-link active">
+                                    Subpages
+                                </a>
+                            </li>            
+                            <ul class="level-">
+                                <li class="nav-item">
+                                    <a href="../anotherPage.html"
+                                        class="nav-link">Another Page</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a href="../somePage.html"
+                                        class="nav-link">Some Page</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a href="index.html"
+                                        class="nav-link active">Subpages</a>
+                                </li>
+                            </ul>
+                        </ul>
+
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="../yetAnotherPage.html" class="nav-link">
+                                    Yet Another Page
+                                </a>
+                            </li></ul>
 
                     </div>
-    </div>
-</nav>
-</header>
-<main id="main-content">
-    <div class="container">
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-3">
-                                <nav class="nav flex-column">
-                    <h2>Main Menu</h2>
-                <ul class="menu-level-main">
-    <li><a href="../anotherPage.html"
-           class="nav-link">
-            Another Page
-                </a></li>
-    <li><a href="../somePage.html"
-           class="nav-link">
-            Some Page
-                </a></li>
-    <li><a href="index.html"
-           class="nav-link active">
-            Subpages
-                </a>            
-<ul class="level-1">
-        <li><a href="subpage1.html"
-                       class="nav-link">
-                                Subpages 1
-                        </a></li>
-        <li><a href="#"
-                       class="nav-link current active" aria-current="page">
-                                Subpages 2
-                        </a></li>
-        </ul>
-</li>
-            </ul>
-
-</nav>
-    <nav class="nav flex-column">
-                    <h2>Additional Menu</h2>
-                <ul class="menu-level-main">
-    <li><a href="../yetAnotherPage.html"
-           class="nav-link">
-            Yet Another Page
-                </a></li>
-            </ul>
-
-</nav>
-
-
                 </div>
-                <div class="col-lg-9">
-                        
-<nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="../index.html">Document Title</a></li>
-        <li class="breadcrumb-item"><a href="index.html">Subpages</a></li>
-        <li class="breadcrumb-item"><a href="#">Subpages 2</a></li>
-            </ol>
-</nav>
+            </nav>
+        </header>
+        <main id="main-content">
+            <div class="container">
+                <div class="container">
+                    <div class="row">
+                        <div class="col-lg-3">
+                            <nav class="nav flex-column">
+                                <h2>Main Menu</h2>
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="../anotherPage.html"
+                                            class="nav-link">Another Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="../somePage.html"
+                                            class="nav-link">Some Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="index.html"
+                                            class="nav-link active">Subpages</a>                
+                                        <ul class="level-1">
+                                            <li>
+                                                <a href="subpage1.html"
+                                                    class="nav-link">Subpages 1</a>
+                                            </li>
+                                            <li>
+                                                <a href="#"
+                                                    class="nav-link current active" aria-current="page">Subpages 2</a>
+                                            </li>
+                                        </ul>
 
-                    <!-- content start -->
-                        <div class="section" id="subpages-2">
-            <h1>Subpages 2</h1>
+                                    </li>
+                                </ul>
+                            </nav>
+                            <nav class="nav flex-column">
+                                <h2>Additional Menu</h2>
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="../yetAnotherPage.html"
+                                            class="nav-link">Yet Another Page</a>
+                                    </li>
+                                </ul>
+                            </nav>
 
-    </div>
+                        </div>
+                        <div class="col-lg-9">
 
-                    <!-- content end -->
+                            <nav aria-label="breadcrumb">
+                                <ol class="breadcrumb">
+                                    <li class="breadcrumb-item"><a href="../index.html">Document Title</a></li>
+                                    <li class="breadcrumb-item"><a href="index.html">Subpages</a></li>
+                                    <li class="breadcrumb-item"><a href="#">Subpages 2</a></li>
+                                </ol>
+                            </nav>
+                            <!-- content start -->
+                            <div class="section" id="subpages-2">
+                                <h1>Subpages 2</h1>
+                            </div>
+                            <!-- content end -->
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-    </div>
-</main>
-        
-<!-- Optional JavaScript; choose one of the two! -->
+        </main>
 
-<!-- Option 1: Bootstrap Bundle with Popper -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+        <!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 2: Separate Popper and Bootstrap JS -->
-<!--
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
--->
-</body>
+        <!-- Option 1: Bootstrap Bundle with Popper -->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+        <!-- Option 2: Separate Popper and Bootstrap JS -->
+        <!--
+            <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+            <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+            -->
+    </body>
 </html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-default-menu-several/expected/yetAnotherPage.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-default-menu-several/expected/yetAnotherPage.html
@@ -1,150 +1,149 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
-<head>
-    <title>Yet Another Page - Bootstrap Theme</title>
-    <!-- Required meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-        
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-</head>
-<body>
-<header class="">
-        
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <div class="container">
+    <head>
+        <title>Yet Another Page - Bootstrap Theme</title>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <a class="navbar-brand" href="#">Navbar</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    </head>
+    <body>
+        <header class="">
 
-                                
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="anotherPage.html" class="nav-link" >
-            Another Page
-        </a>
-        </li><li class="nav-item">
-                <a href="somePage.html" class="nav-link" >
-            Some Page
-        </a>
-        </li><li class="nav-item">
-                <a href="subpages/index.html" class="nav-link" >
-            Subpages
-        </a>
-        </li>            <ul class="level-">
-    <li class="nav-item"><a href="anotherPage.html"
-               class="nav-link" >
-                Another Page
-            </a></li><li class="nav-item"><a href="somePage.html"
-               class="nav-link" >
-                Some Page
-            </a></li><li class="nav-item"><a href="subpages/index.html"
-               class="nav-link" >
-                Subpages
-            </a></li></ul>
-</ul>
-    
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="#" class="nav-link current active" aria-current="page"  >
-            Yet Another Page
-        </a>
-        </li></ul>
+            <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+                <div class="container">
 
+                    <a class="navbar-brand" href="#">Navbar</a>
+                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="anotherPage.html" class="nav-link">
+                                    Another Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="somePage.html" class="nav-link">
+                                    Some Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="subpages/index.html" class="nav-link">
+                                    Subpages
+                                </a>
+                            </li>            
+                            <ul class="level-">
+                                <li class="nav-item">
+                                    <a href="anotherPage.html"
+                                        class="nav-link">Another Page</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a href="somePage.html"
+                                        class="nav-link">Some Page</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a href="subpages/index.html"
+                                        class="nav-link">Subpages</a>
+                                </li>
+                            </ul>
+                        </ul>
+
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="#" class="nav-link current active" aria-current="page">
+                                    Yet Another Page
+                                </a>
+                            </li></ul>
 
                     </div>
-    </div>
-</nav>
-</header>
-<main id="main-content">
-    <div class="container">
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-3">
-                                <nav class="nav flex-column">
-                    <h2>Main Menu</h2>
-                <ul class="menu-level-main">
-    <li><a href="anotherPage.html"
-           class="nav-link">
-            Another Page
-                </a></li>
-    <li><a href="somePage.html"
-           class="nav-link">
-            Some Page
-                </a></li>
-    <li><a href="subpages/index.html"
-           class="nav-link">
-            Subpages
-                </a>            
-<ul class="level-1">
-        <li><a href="subpages/subpage1.html"
-                       class="nav-link">
-                                Subpages 1
-                        </a></li>
-        <li><a href="subpages/subpage2.html"
-                       class="nav-link">
-                                Subpages 2
-                        </a></li>
-        </ul>
-</li>
-            </ul>
-
-</nav>
-    <nav class="nav flex-column">
-                    <h2>Additional Menu</h2>
-                <ul class="menu-level-main">
-    <li><a href="#"
-           class="nav-link current active" aria-current="page" >
-            Yet Another Page
-                </a></li>
-            </ul>
-
-</nav>
-
-
                 </div>
-                <div class="col-lg-9">
-                        
-<nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="index.html">Document Title</a></li>
-        <li class="breadcrumb-item"><a href="#">Yet Another Page</a></li>
-            </ol>
-</nav>
+            </nav>
+        </header>
+        <main id="main-content">
+            <div class="container">
+                <div class="container">
+                    <div class="row">
+                        <div class="col-lg-3">
+                            <nav class="nav flex-column">
+                                <h2>Main Menu</h2>
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="anotherPage.html"
+                                            class="nav-link">Another Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="somePage.html"
+                                            class="nav-link">Some Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="subpages/index.html"
+                                            class="nav-link">Subpages</a>                
+                                        <ul class="level-1">
+                                            <li>
+                                                <a href="subpages/subpage1.html"
+                                                    class="nav-link">Subpages 1</a>
+                                            </li>
+                                            <li>
+                                                <a href="subpages/subpage2.html"
+                                                    class="nav-link">Subpages 2</a>
+                                            </li>
+                                        </ul>
 
-                    <!-- content start -->
-                        
+                                    </li>
+                                </ul>
+                            </nav>
+                            <nav class="nav flex-column">
+                                <h2>Additional Menu</h2>
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="#"
+                                            class="nav-link current active" aria-current="page">Yet Another Page</a>
+                                    </li>
+                                </ul>
+                            </nav>
 
-<div class="section" id="yet-another-page">
-            <h1>Yet Another Page</h1>
+                        </div>
+                        <div class="col-lg-9">
 
-            <p>Lorem Ipsum Dolor.</p>
-    </div>
+                            <nav aria-label="breadcrumb">
+                                <ol class="breadcrumb">
+                                    <li class="breadcrumb-item"><a href="index.html">Document Title</a></li>
+                                    <li class="breadcrumb-item"><a href="#">Yet Another Page</a></li>
+                                </ol>
+                            </nav>
+                            <!-- content start -->
 
-                    <!-- content end -->
+                            <div class="section" id="yet-another-page">
+                                <h1>Yet Another Page</h1>
+
+                                <p>Lorem Ipsum Dolor.</p>
+
+                            </div>
+                            <!-- content end -->
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-    </div>
-</main>
-                <footer class="bg-primary text-light">
+        </main>
+        <footer class="bg-primary text-light">
             <div class="container">
+
                 <p>Generated by <a href="https://www.phpdoc.org/">phpDocumentor</a>.</p>
-</div>
+
+            </div>
         </footer>
-    
-<!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 1: Bootstrap Bundle with Popper -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+        <!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 2: Separate Popper and Bootstrap JS -->
-<!--
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
--->
-</body>
+        <!-- Option 1: Bootstrap Bundle with Popper -->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+        <!-- Option 2: Separate Popper and Bootstrap JS -->
+        <!--
+            <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+            <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+            -->
+    </body>
 </html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-default-menu/expected/anotherPage.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-default-menu/expected/anotherPage.html
@@ -1,110 +1,106 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
-<head>
-    <title>Another Page - Bootstrap Theme</title>
-    <!-- Required meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-        
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-</head>
-<body>
-<header class="">
-        
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <div class="container">
+    <head>
+        <title>Another Page - Bootstrap Theme</title>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <a class="navbar-brand" href="#">Navbar</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    </head>
+    <body>
+        <header class="">
 
-                                
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="/anotherPage.html" class="nav-link current active" aria-current="page"  >
-            Another Page
-        </a>
-        </li><li class="nav-item">
-                <a href="/somePage.html" class="nav-link" >
-            Some Page
-        </a>
-        </li><li class="nav-item">
-                <a href="/yetAnotherPage.html" class="nav-link" >
-            Yet Another Page
-        </a>
-        </li></ul>
+            <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+                <div class="container">
 
+                    <a class="navbar-brand" href="#">Navbar</a>
+                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="/anotherPage.html" class="nav-link current active" aria-current="page">
+                                    Another Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="/somePage.html" class="nav-link">
+                                    Some Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="/yetAnotherPage.html" class="nav-link">
+                                    Yet Another Page
+                                </a>
+                            </li></ul>
 
                     </div>
-    </div>
-</nav>
-</header>
-<main id="main-content">
-    <div class="container">
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-3">
-                                <nav class="nav flex-column">
-                <ul class="menu-level-main">
-    <li><a href="/anotherPage.html"
-           class="nav-link current active" aria-current="page" >
-            Another Page
-                </a></li>
-    <li><a href="/somePage.html"
-           class="nav-link">
-            Some Page
-                </a></li>
-    <li><a href="/yetAnotherPage.html"
-           class="nav-link">
-            Yet Another Page
-                </a></li>
-            </ul>
-
-</nav>
-
-
                 </div>
-                <div class="col-lg-9">
-                        
-<nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="/index.html">Document Title</a></li>
-        <li class="breadcrumb-item"><a href="/anotherPage.html">Another Page</a></li>
-            </ol>
-</nav>
+            </nav>
+        </header>
+        <main id="main-content">
+            <div class="container">
+                <div class="container">
+                    <div class="row">
+                        <div class="col-lg-3">
+                            <nav class="nav flex-column">
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="/anotherPage.html"
+                                            class="nav-link current active" aria-current="page">Another Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="/somePage.html"
+                                            class="nav-link">Some Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="/yetAnotherPage.html"
+                                            class="nav-link">Yet Another Page</a>
+                                    </li>
+                                </ul>
+                            </nav>
 
-                    <!-- content start -->
-                        
+                        </div>
+                        <div class="col-lg-9">
 
-<div class="section" id="another-page">
-            <h1>Another Page</h1>
+                            <nav aria-label="breadcrumb">
+                                <ol class="breadcrumb">
+                                    <li class="breadcrumb-item"><a href="/index.html">Document Title</a></li>
+                                    <li class="breadcrumb-item"><a href="/anotherPage.html">Another Page</a></li>
+                                </ol>
+                            </nav>
+                            <!-- content start -->
 
-            <p>Lorem Ipsum Dolor.</p>
-    </div>
+                            <div class="section" id="another-page">
+                                <h1>Another Page</h1>
 
-                    <!-- content end -->
+                                <p>Lorem Ipsum Dolor.</p>
+
+                            </div>
+                            <!-- content end -->
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-    </div>
-</main>
-                <footer class="bg-primary text-light">
+        </main>
+        <footer class="bg-primary text-light">
             <div class="container">
+
                 <p>Generated by <a href="https://www.phpdoc.org/">phpDocumentor</a>.</p>
-</div>
+
+            </div>
         </footer>
-    
-<!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 1: Bootstrap Bundle with Popper -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+        <!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 2: Separate Popper and Bootstrap JS -->
-<!--
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
--->
-</body>
+        <!-- Option 1: Bootstrap Bundle with Popper -->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+        <!-- Option 2: Separate Popper and Bootstrap JS -->
+        <!--
+            <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+            <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+            -->
+    </body>
 </html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-default-menu/expected/index.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-default-menu/expected/index.html
@@ -1,110 +1,106 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
-<head>
-    <title>Document Title - Bootstrap Theme</title>
-    <!-- Required meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-        
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-</head>
-<body>
-<header class="">
-        
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <div class="container">
+    <head>
+        <title>Document Title - Bootstrap Theme</title>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <a class="navbar-brand" href="#">Navbar</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    </head>
+    <body>
+        <header class="">
 
-                                
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="/anotherPage.html" class="nav-link" >
-            Another Page
-        </a>
-        </li><li class="nav-item">
-                <a href="/somePage.html" class="nav-link" >
-            Some Page
-        </a>
-        </li><li class="nav-item">
-                <a href="/yetAnotherPage.html" class="nav-link" >
-            Yet Another Page
-        </a>
-        </li></ul>
+            <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+                <div class="container">
 
+                    <a class="navbar-brand" href="#">Navbar</a>
+                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="/anotherPage.html" class="nav-link">
+                                    Another Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="/somePage.html" class="nav-link">
+                                    Some Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="/yetAnotherPage.html" class="nav-link">
+                                    Yet Another Page
+                                </a>
+                            </li></ul>
 
                     </div>
-    </div>
-</nav>
-</header>
-<main id="main-content">
-    <div class="container">
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-3">
-                                <nav class="nav flex-column">
-                <ul class="menu-level-main">
-    <li><a href="/anotherPage.html"
-           class="nav-link">
-            Another Page
-                </a></li>
-    <li><a href="/somePage.html"
-           class="nav-link">
-            Some Page
-                </a></li>
-    <li><a href="/yetAnotherPage.html"
-           class="nav-link">
-            Yet Another Page
-                </a></li>
-            </ul>
-
-</nav>
-
-
                 </div>
-                <div class="col-lg-9">
-                        
-<nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="/index.html">Document Title</a></li>
-            </ol>
-</nav>
+            </nav>
+        </header>
+        <main id="main-content">
+            <div class="container">
+                <div class="container">
+                    <div class="row">
+                        <div class="col-lg-3">
+                            <nav class="nav flex-column">
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="/anotherPage.html"
+                                            class="nav-link">Another Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="/somePage.html"
+                                            class="nav-link">Some Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="/yetAnotherPage.html"
+                                            class="nav-link">Yet Another Page</a>
+                                    </li>
+                                </ul>
+                            </nav>
 
-                    <!-- content start -->
-                        
+                        </div>
+                        <div class="col-lg-9">
 
-<div class="section" id="document-title">
-            <h1>Document Title</h1>
+                            <nav aria-label="breadcrumb">
+                                <ol class="breadcrumb">
+                                    <li class="breadcrumb-item"><a href="/index.html">Document Title</a></li>
+                                </ol>
+                            </nav>
+                            <!-- content start -->
 
-            <p>Lorem Ipsum Dolor.</p>
-            
-    </div>
+                            <div class="section" id="document-title">
+                                <h1>Document Title</h1>
 
-                    <!-- content end -->
+                                <p>Lorem Ipsum Dolor.</p>
+
+
+                            </div>
+                            <!-- content end -->
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-    </div>
-</main>
-                <footer class="bg-primary text-light">
+        </main>
+        <footer class="bg-primary text-light">
             <div class="container">
+
                 <p>Generated by <a href="https://www.phpdoc.org/">phpDocumentor</a>.</p>
-</div>
+
+            </div>
         </footer>
-    
-<!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 1: Bootstrap Bundle with Popper -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+        <!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 2: Separate Popper and Bootstrap JS -->
-<!--
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
--->
-</body>
+        <!-- Option 1: Bootstrap Bundle with Popper -->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+        <!-- Option 2: Separate Popper and Bootstrap JS -->
+        <!--
+            <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+            <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+            -->
+    </body>
 </html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-default-menu/expected/somePage.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-default-menu/expected/somePage.html
@@ -1,110 +1,106 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
-<head>
-    <title>Some Page - Bootstrap Theme</title>
-    <!-- Required meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-        
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-</head>
-<body>
-<header class="">
-        
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <div class="container">
+    <head>
+        <title>Some Page - Bootstrap Theme</title>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <a class="navbar-brand" href="#">Navbar</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    </head>
+    <body>
+        <header class="">
 
-                                
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="/anotherPage.html" class="nav-link" >
-            Another Page
-        </a>
-        </li><li class="nav-item">
-                <a href="/somePage.html" class="nav-link current active" aria-current="page"  >
-            Some Page
-        </a>
-        </li><li class="nav-item">
-                <a href="/yetAnotherPage.html" class="nav-link" >
-            Yet Another Page
-        </a>
-        </li></ul>
+            <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+                <div class="container">
 
+                    <a class="navbar-brand" href="#">Navbar</a>
+                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="/anotherPage.html" class="nav-link">
+                                    Another Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="/somePage.html" class="nav-link current active" aria-current="page">
+                                    Some Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="/yetAnotherPage.html" class="nav-link">
+                                    Yet Another Page
+                                </a>
+                            </li></ul>
 
                     </div>
-    </div>
-</nav>
-</header>
-<main id="main-content">
-    <div class="container">
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-3">
-                                <nav class="nav flex-column">
-                <ul class="menu-level-main">
-    <li><a href="/anotherPage.html"
-           class="nav-link">
-            Another Page
-                </a></li>
-    <li><a href="/somePage.html"
-           class="nav-link current active" aria-current="page" >
-            Some Page
-                </a></li>
-    <li><a href="/yetAnotherPage.html"
-           class="nav-link">
-            Yet Another Page
-                </a></li>
-            </ul>
-
-</nav>
-
-
                 </div>
-                <div class="col-lg-9">
-                        
-<nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="/index.html">Document Title</a></li>
-        <li class="breadcrumb-item"><a href="/somePage.html">Some Page</a></li>
-            </ol>
-</nav>
+            </nav>
+        </header>
+        <main id="main-content">
+            <div class="container">
+                <div class="container">
+                    <div class="row">
+                        <div class="col-lg-3">
+                            <nav class="nav flex-column">
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="/anotherPage.html"
+                                            class="nav-link">Another Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="/somePage.html"
+                                            class="nav-link current active" aria-current="page">Some Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="/yetAnotherPage.html"
+                                            class="nav-link">Yet Another Page</a>
+                                    </li>
+                                </ul>
+                            </nav>
 
-                    <!-- content start -->
-                        
+                        </div>
+                        <div class="col-lg-9">
 
-<div class="section" id="some-page">
-            <h1>Some Page</h1>
+                            <nav aria-label="breadcrumb">
+                                <ol class="breadcrumb">
+                                    <li class="breadcrumb-item"><a href="/index.html">Document Title</a></li>
+                                    <li class="breadcrumb-item"><a href="/somePage.html">Some Page</a></li>
+                                </ol>
+                            </nav>
+                            <!-- content start -->
 
-            <p>Lorem Ipsum <span class="custom">Dolor</span>.</p>
-    </div>
+                            <div class="section" id="some-page">
+                                <h1>Some Page</h1>
 
-                    <!-- content end -->
+                                <p>Lorem Ipsum <span class="custom">Dolor</span>.</p>
+
+                            </div>
+                            <!-- content end -->
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-    </div>
-</main>
-                <footer class="bg-primary text-light">
+        </main>
+        <footer class="bg-primary text-light">
             <div class="container">
+
                 <p>Generated by <a href="https://www.phpdoc.org/">phpDocumentor</a>.</p>
-</div>
+
+            </div>
         </footer>
-    
-<!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 1: Bootstrap Bundle with Popper -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+        <!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 2: Separate Popper and Bootstrap JS -->
-<!--
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
--->
-</body>
+        <!-- Option 1: Bootstrap Bundle with Popper -->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+        <!-- Option 2: Separate Popper and Bootstrap JS -->
+        <!--
+            <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+            <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+            -->
+    </body>
 </html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-default-subpages-max-1/expected/index.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-default-subpages-max-1/expected/index.html
@@ -1,100 +1,98 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
-<head>
-    <title>Document Title - Bootstrap Theme</title>
-    <!-- Required meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-        
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-</head>
-<body>
-<header class="">
-        
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <div class="container">
+    <head>
+        <title>Document Title - Bootstrap Theme</title>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <a class="navbar-brand" href="#">Navbar</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    </head>
+    <body>
+        <header class="">
 
-                                
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="someDirectory/index.html" class="nav-link" >
-            Some Page
-        </a>
-        </li></ul>
+            <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+                <div class="container">
 
+                    <a class="navbar-brand" href="#">Navbar</a>
+                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="someDirectory/index.html" class="nav-link">
+                                    Some Page
+                                </a>
+                            </li></ul>
 
                     </div>
-    </div>
-</nav>
-</header>
-<main id="main-content">
-    <div class="container">
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-3">
-                                <nav class="nav flex-column">
-                <ul class="menu-level-main">
-    <li><a href="someDirectory/index.html"
-           class="nav-link">
-            Some Page
-                </a></li>
-            </ul>
-
-</nav>
-
-
                 </div>
-                <div class="col-lg-9">
-                        
-<nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="#">Document Title</a></li>
-            </ol>
-</nav>
+            </nav>
+        </header>
+        <main id="main-content">
+            <div class="container">
+                <div class="container">
+                    <div class="row">
+                        <div class="col-lg-3">
+                            <nav class="nav flex-column">
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="someDirectory/index.html"
+                                            class="nav-link">Some Page</a>
+                                    </li>
+                                </ul>
+                            </nav>
 
-                    <!-- content start -->
-                        
+                        </div>
+                        <div class="col-lg-9">
 
-<div class="section" id="document-title">
-            <h1>Document Title</h1>
+                            <nav aria-label="breadcrumb">
+                                <ol class="breadcrumb">
+                                    <li class="breadcrumb-item"><a href="#">Document Title</a></li>
+                                </ol>
+                            </nav>
+                            <!-- content start -->
 
-            <p>Lorem Ipsum Dolor.</p>
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="someDirectory/index.html#some-page">Some Page</a></li>
+                            <div class="section" id="document-title">
+                                <h1>Document Title</h1>
 
-    </ul>
-</div>
+                                <p>Lorem Ipsum Dolor.</p>
 
-    </div>
+                                <div class="toc">
+                                    <ul class="menu-level">
+                                        <li class="toc-item">
+                                            <a href="someDirectory/index.html#some-page">Some Page</a>
 
-                    <!-- content end -->
+
+                                        </li>
+                                    </ul>
+                                </div>
+                            </div>
+                            <!-- content end -->
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-    </div>
-</main>
-                <footer class="bg-primary text-light">
+        </main>
+        <footer class="bg-primary text-light">
             <div class="container">
+
                 <p>Generated by <a href="https://www.phpdoc.org/">phpDocumentor</a>.</p>
-</div>
+
+            </div>
         </footer>
-    
-<!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 1: Bootstrap Bundle with Popper -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+        <!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 2: Separate Popper and Bootstrap JS -->
-<!--
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
--->
-</body>
+        <!-- Option 1: Bootstrap Bundle with Popper -->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+        <!-- Option 2: Separate Popper and Bootstrap JS -->
+        <!--
+            <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+            <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+            -->
+    </body>
 </html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-default-subpages-max-2/expected/index.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-default-subpages-max-2/expected/index.html
@@ -1,112 +1,112 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
-<head>
-    <title>Document Title - Bootstrap Theme</title>
-    <!-- Required meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-        
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-</head>
-<body>
-<header class="">
-        
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <div class="container">
+    <head>
+        <title>Document Title - Bootstrap Theme</title>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <a class="navbar-brand" href="#">Navbar</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    </head>
+    <body>
+        <header class="">
 
-                                
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="someDirectory/index.html" class="nav-link" >
-            Some Page
-        </a>
-        </li>            <ul class="level-">
-    <li class="nav-item"><a href="someDirectory/index.html"
-               class="nav-link" >
-                Some Page
-            </a></li></ul>
-</ul>
+            <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+                <div class="container">
 
+                    <a class="navbar-brand" href="#">Navbar</a>
+                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="someDirectory/index.html" class="nav-link">
+                                    Some Page
+                                </a>
+                            </li>            
+                            <ul class="level-">
+                                <li class="nav-item">
+                                    <a href="someDirectory/index.html"
+                                        class="nav-link">Some Page</a>
+                                </li>
+                            </ul>
+                        </ul>
 
                     </div>
-    </div>
-</nav>
-</header>
-<main id="main-content">
-    <div class="container">
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-3">
-                                <nav class="nav flex-column">
-                <ul class="menu-level-main">
-    <li><a href="someDirectory/index.html"
-           class="nav-link">
-            Some Page
-                </a>            
-<ul class="level-1">
-        <li><a href="someDirectory/anotherDirectory/index.html"
-                       class="nav-link">
-                                Another Page
-                        </a></li>
-        </ul>
-</li>
-            </ul>
-
-</nav>
-
-
                 </div>
-                <div class="col-lg-9">
-                        
-<nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="#">Document Title</a></li>
-            </ol>
-</nav>
+            </nav>
+        </header>
+        <main id="main-content">
+            <div class="container">
+                <div class="container">
+                    <div class="row">
+                        <div class="col-lg-3">
+                            <nav class="nav flex-column">
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="someDirectory/index.html"
+                                            class="nav-link">Some Page</a>                
+                                        <ul class="level-1">
+                                            <li>
+                                                <a href="someDirectory/anotherDirectory/index.html"
+                                                    class="nav-link">Another Page</a>
+                                            </li>
+                                        </ul>
 
-                    <!-- content start -->
-                        
+                                    </li>
+                                </ul>
+                            </nav>
 
-<div class="section" id="document-title">
-            <h1>Document Title</h1>
+                        </div>
+                        <div class="col-lg-9">
 
-            <p>Lorem Ipsum Dolor.</p>
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="someDirectory/index.html#some-page">Some Page</a></li>
+                            <nav aria-label="breadcrumb">
+                                <ol class="breadcrumb">
+                                    <li class="breadcrumb-item"><a href="#">Document Title</a></li>
+                                </ol>
+                            </nav>
+                            <!-- content start -->
 
-    </ul>
-</div>
+                            <div class="section" id="document-title">
+                                <h1>Document Title</h1>
 
-    </div>
+                                <p>Lorem Ipsum Dolor.</p>
 
-                    <!-- content end -->
+                                <div class="toc">
+                                    <ul class="menu-level">
+                                        <li class="toc-item">
+                                            <a href="someDirectory/index.html#some-page">Some Page</a>
+
+
+                                        </li>
+                                    </ul>
+                                </div>
+                            </div>
+                            <!-- content end -->
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-    </div>
-</main>
-                <footer class="bg-primary text-light">
+        </main>
+        <footer class="bg-primary text-light">
             <div class="container">
+
                 <p>Generated by <a href="https://www.phpdoc.org/">phpDocumentor</a>.</p>
-</div>
+
+            </div>
         </footer>
-    
-<!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 1: Bootstrap Bundle with Popper -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+        <!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 2: Separate Popper and Bootstrap JS -->
-<!--
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
--->
-</body>
+        <!-- Option 1: Bootstrap Bundle with Popper -->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+        <!-- Option 2: Separate Popper and Bootstrap JS -->
+        <!--
+            <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+            <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+            -->
+    </body>
 </html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-default-subpages-max-3/expected/index.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-default-subpages-max-3/expected/index.html
@@ -1,119 +1,105 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
-<head>
-    <title>Document Title - Bootstrap Theme</title>
-    <!-- Required meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-        
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-</head>
-<body>
-<header class="">
-        
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <div class="container">
+    <head>
+        <title>Document Title - Bootstrap Theme</title>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <a class="navbar-brand" href="#">Navbar</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
-
-                                
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="someDirectory/index.html" class="nav-link" >
-            Some Page
-        </a>
-        </li>            <ul class="level-">
-    <li class="nav-item"><a href="someDirectory/index.html"
-               class="nav-link" >
-                Some Page
-            </a></li></ul>
-</ul>
-
-
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    </head>
+    <body>
+        <header class="">
+            <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+                <div class="container">
+                    <a class="navbar-brand" href="#">Navbar</a>
+                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="someDirectory/index.html" class="nav-link">
+                                    Some Page
+                                </a>
+                            </li>
+                            <ul class="level-">
+                                <li class="nav-item">
+                                    <a href="someDirectory/index.html"
+                                        class="nav-link">Some Page</a>
+                                </li>
+                            </ul>
+                        </ul>
                     </div>
-    </div>
-</nav>
-</header>
-<main id="main-content">
-    <div class="container">
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-3">
-                                <nav class="nav flex-column">
-                <ul class="menu-level-main">
-    <li><a href="someDirectory/index.html"
-           class="nav-link">
-            Some Page
-                </a>            
-<ul class="level-1">
-        <li><a href="someDirectory/anotherDirectory/index.html"
-                       class="nav-link">
-                                Another Page
-                        </a>                                
-<ul class="level-2">
-        <li><a href="someDirectory/anotherDirectory/yetAnotherDirectory/index.html"
-                       class="nav-link">
-                                Yet Another Page
-                        </a></li>
-        </ul>
-</li>
-        </ul>
-</li>
-            </ul>
-
-</nav>
-
-
                 </div>
-                <div class="col-lg-9">
-                        
-<nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="#">Document Title</a></li>
-            </ol>
-</nav>
+            </nav>
+        </header>
+        <main id="main-content">
+            <div class="container">
+                <div class="container">
+                    <div class="row">
+                        <div class="col-lg-3">
+                            <nav class="nav flex-column">
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="someDirectory/index.html"
+                                            class="nav-link">Some Page</a>            
+                                        <ul class="level-1">
+                                            <li>
+                                                <a href="someDirectory/anotherDirectory/index.html"
+                                                    class="nav-link">Another Page</a>                                
+                                                <ul class="level-2">
+                                                    <li>
+                                                        <a href="someDirectory/anotherDirectory/yetAnotherDirectory/index.html"
+                                                            class="nav-link">Yet Another Page</a>
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                        </ul>
+                                    </li>
+                                </ul>
+                            </nav>
+                        </div>
+                        <div class="col-lg-9">
+                            <nav aria-label="breadcrumb">
+                                <ol class="breadcrumb">
+                                    <li class="breadcrumb-item"><a href="#">Document Title</a></li>
+                                </ol>
+                            </nav>
+                            <!-- content start -->
+                            <div class="section" id="document-title">
+                                <h1>Document Title</h1>
 
-                    <!-- content start -->
-                        
-
-<div class="section" id="document-title">
-            <h1>Document Title</h1>
-
-            <p>Lorem Ipsum Dolor.</p>
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="someDirectory/index.html#some-page">Some Page</a></li>
-
-    </ul>
-</div>
-
-    </div>
-
-                    <!-- content end -->
+                                <p>Lorem Ipsum Dolor.</p>
+                                <div class="toc">
+                                    <ul class="menu-level">
+                                        <li class="toc-item">
+                                            <a href="someDirectory/index.html#some-page">Some Page</a>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </div>
+                            <!-- content end -->
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-    </div>
-</main>
-                <footer class="bg-primary text-light">
+        </main>
+        <footer class="bg-primary text-light">
             <div class="container">
                 <p>Generated by <a href="https://www.phpdoc.org/">phpDocumentor</a>.</p>
-</div>
+            </div>
         </footer>
-    
-<!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 1: Bootstrap Bundle with Popper -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+        <!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 2: Separate Popper and Bootstrap JS -->
-<!--
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
--->
-</body>
+        <!-- Option 1: Bootstrap Bundle with Popper -->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+        <!-- Option 2: Separate Popper and Bootstrap JS -->
+        <!--
+            <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+            <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+            -->
+    </body>
 </html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-default-subpages/expected/index.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-default-subpages/expected/index.html
@@ -1,135 +1,126 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
-<head>
-    <title>Document Title - Bootstrap Theme</title>
-    <!-- Required meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-        
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-</head>
-<body>
-<header class="">
-        
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <div class="container">
+    <head>
+        <title>Document Title - Bootstrap Theme</title>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <a class="navbar-brand" href="#">Navbar</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
-
-                                
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="someDirectory/index.html" class="nav-link" >
-            Some Page
-        </a>
-        </li>            <ul class="level-">
-    <li class="nav-item"><a href="someDirectory/index.html"
-               class="nav-link" >
-                Some Page
-            </a></li></ul>
-</ul>
-
-
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    </head>
+    <body>
+        <header class="">
+            <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+                <div class="container">
+                    <a class="navbar-brand" href="#">Navbar</a>
+                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="someDirectory/index.html" class="nav-link">
+                                    Some Page
+                                </a>
+                            </li>
+                            <ul class="level-">
+                                <li class="nav-item">
+                                    <a href="someDirectory/index.html"
+                                        class="nav-link">Some Page</a>
+                                </li>
+                            </ul>
+                        </ul>
                     </div>
-    </div>
-</nav>
-</header>
-<main id="main-content">
-    <div class="container">
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-3">
-                                <nav class="nav flex-column">
-                <ul class="menu-level-main">
-    <li><a href="someDirectory/index.html"
-           class="nav-link">
-            Some Page
-                </a>            
-<ul class="level-1">
-        <li><a href="someDirectory/anotherDirectory/index.html"
-                       class="nav-link">
-                                Another Page
-                        </a>                                
-<ul class="level-2">
-        <li><a href="someDirectory/anotherDirectory/yetAnotherDirectory/index.html"
-                       class="nav-link">
-                                Yet Another Page
-                        </a>                                
-<ul class="level-3">
-        <li><a href="someDirectory/anotherDirectory/yetAnotherDirectory/andYetAnotherDirectory/index.html"
-                       class="nav-link">
-                                And Yet Another Page
-                        </a></li>
-        </ul>
-</li>
-        </ul>
-</li>
-        </ul>
-</li>
-            </ul>
-
-</nav>
-
-
                 </div>
-                <div class="col-lg-9">
-                        
-<nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="#">Document Title</a></li>
-            </ol>
-</nav>
+            </nav>
+        </header>
+        <main id="main-content">
+            <div class="container">
+                <div class="container">
+                    <div class="row">
+                        <div class="col-lg-3">
+                            <nav class="nav flex-column">
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="someDirectory/index.html"
+                                            class="nav-link">Some Page</a>            
+                                        <ul class="level-1">
+                                            <li>
+                                                <a href="someDirectory/anotherDirectory/index.html"
+                                                    class="nav-link">Another Page</a>                                
+                                                <ul class="level-2">
+                                                    <li>
+                                                        <a href="someDirectory/anotherDirectory/yetAnotherDirectory/index.html"
+                                                            class="nav-link">Yet Another Page</a>                                
+                                                        <ul class="level-3">
+                                                            <li>
+                                                                <a href="someDirectory/anotherDirectory/yetAnotherDirectory/andYetAnotherDirectory/index.html"
+                                                                    class="nav-link">And Yet Another Page</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                        </ul>
+                                    </li>
+                                </ul>
+                            </nav>
+                        </div>
+                        <div class="col-lg-9">
+                            <nav aria-label="breadcrumb">
+                                <ol class="breadcrumb">
+                                    <li class="breadcrumb-item"><a href="#">Document Title</a></li>
+                                </ol>
+                            </nav>
+                            <!-- content start -->
+                            <div class="section" id="document-title">
+                                <h1>Document Title</h1>
 
-                    <!-- content start -->
-                        
-
-<div class="section" id="document-title">
-            <h1>Document Title</h1>
-
-            <p>Lorem Ipsum Dolor.</p>
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="someDirectory/index.html#some-page">Some Page</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="someDirectory/anotherDirectory/index.html#another-page">Another Page</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="someDirectory/anotherDirectory/yetAnotherDirectory/index.html#yet-another-page">Yet Another Page</a>        <ul class="menu-level-3">
-            <li class="toc-item"><a href="someDirectory/anotherDirectory/yetAnotherDirectory/andYetAnotherDirectory/index.html#and-yet-another-page">And Yet Another Page</a></li>
-
-                    </ul></li>
-
-                    </ul></li>
-
-                    </ul></li>
-
-    </ul>
-</div>
-
-    </div>
-
-                    <!-- content end -->
+                                <p>Lorem Ipsum Dolor.</p>
+                                <div class="toc">
+                                    <ul class="menu-level">
+                                        <li class="toc-item">
+                                            <a href="someDirectory/index.html#some-page">Some Page</a>
+                                            <ul class="menu-level-1">
+                                                <li class="toc-item">
+                                                    <a href="someDirectory/anotherDirectory/index.html#another-page">Another Page</a>
+                                                    <ul class="menu-level-2">
+                                                        <li class="toc-item">
+                                                            <a href="someDirectory/anotherDirectory/yetAnotherDirectory/index.html#yet-another-page">Yet Another Page</a>
+                                                            <ul class="menu-level-3">
+                                                                <li class="toc-item">
+                                                                    <a href="someDirectory/anotherDirectory/yetAnotherDirectory/andYetAnotherDirectory/index.html#and-yet-another-page">And Yet Another Page</a>
+                                                                </li>
+                                                            </ul>
+                                                        </li>
+                                                    </ul>
+                                                </li>
+                                            </ul>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </div>
+                            <!-- content end -->
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-    </div>
-</main>
-                <footer class="bg-primary text-light">
+        </main>
+        <footer class="bg-primary text-light">
             <div class="container">
                 <p>Generated by <a href="https://www.phpdoc.org/">phpDocumentor</a>.</p>
-</div>
+            </div>
         </footer>
-    
-<!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 1: Bootstrap Bundle with Popper -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+        <!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 2: Separate Popper and Bootstrap JS -->
-<!--
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
--->
-</body>
+        <!-- Option 1: Bootstrap Bundle with Popper -->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+        <!-- Option 2: Separate Popper and Bootstrap JS -->
+        <!--
+            <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+            <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+            -->
+    </body>
 </html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-index/expected/anotherPage.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-index/expected/anotherPage.html
@@ -1,110 +1,99 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
-<head>
-    <title>Another Page - Bootstrap Theme</title>
-    <!-- Required meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-        
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-</head>
-<body>
-<header class="">
-        
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <div class="container">
+    <head>
+        <title>Another Page - Bootstrap Theme</title>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <a class="navbar-brand" href="#">Navbar</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
-
-                                
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="/anotherPage.html" class="nav-link" >
-            Another Page
-        </a>
-        </li><li class="nav-item">
-                <a href="/somePage.html" class="nav-link" >
-            Some Page
-        </a>
-        </li><li class="nav-item">
-                <a href="/yetAnotherPage.html" class="nav-link" >
-            Yet Another Page
-        </a>
-        </li></ul>
-
-        </div>
-    </div>
-</nav>
-</header>
-<main id="main-content">
-    <div class="container">
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-3">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    </head>
+    <body>
+        <header class="">
+            <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+                <div class="container">
+                    <a class="navbar-brand" href="#">Navbar</a>
+                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="/anotherPage.html" class="nav-link">
+                                    Another Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="/somePage.html" class="nav-link">
+                                    Some Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="/yetAnotherPage.html" class="nav-link">
+                                    Yet Another Page
+                                </a>
+                            </li></ul>
+                    </div>
+                </div>
+            </nav>
+        </header>
+        <main id="main-content">
+            <div class="container">
+                <div class="container">
+                    <div class="row">
+                        <div class="col-lg-3">
                             <div class="rubric">Main Menu</div>
 
-    <nav class="nav flex-column">
-                <ul class="menu-level-main">
-    <li><a href="/anotherPage.html"
-           class="nav-link">
-            Another Page
-                </a></li>
-    <li><a href="/somePage.html"
-           class="nav-link">
-            Some Page
-                </a></li>
-    <li><a href="/yetAnotherPage.html"
-           class="nav-link">
-            Yet Another Page
-                </a></li>
-            </ul>
+                            <nav class="nav flex-column">
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="/anotherPage.html"
+                                            class="nav-link">Another Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="/somePage.html"
+                                            class="nav-link">Some Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="/yetAnotherPage.html"
+                                            class="nav-link">Yet Another Page</a>
+                                    </li>
+                                </ul>
+                            </nav>
+                        </div>
+                        <div class="col-lg-9">
+                            <nav aria-label="breadcrumb">
+                                <ol class="breadcrumb">
+                                    <li class="breadcrumb-item"><a href="/index.html">Document Title</a></li>
+                                    <li class="breadcrumb-item"><a href="/anotherPage.html">Another Page</a></li>
+                                </ol>
+                            </nav>
 
-</nav>
+                            <!-- content start -->
+                            <div class="section" id="another-page">
+                                <h1>Another Page</h1>
 
-                </div>
-                <div class="col-lg-9">
-                        
-<nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="/index.html">Document Title</a></li>
-        <li class="breadcrumb-item"><a href="/anotherPage.html">Another Page</a></li>
-            </ol>
-</nav>
-
-                    <!-- content start -->
-                        
-
-<div class="section" id="another-page">
-            <h1>Another Page</h1>
-
-            <p>Lorem Ipsum Dolor.</p>
-    </div>
-
-                    <!-- content end -->
+                                <p>Lorem Ipsum Dolor.</p>
+                            </div>
+                            <!-- content end -->
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-    </div>
-</main>
-                <footer class="bg-primary text-light">
+        </main>
+        <footer class="bg-primary text-light">
             <div class="container">
                 <p>Generated by <a href="https://www.phpdoc.org/">phpDocumentor</a>.</p>
-</div>
+            </div>
         </footer>
-    
-<!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 1: Bootstrap Bundle with Popper -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+        <!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 2: Separate Popper and Bootstrap JS -->
-<!--
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
--->
-</body>
+        <!-- Option 1: Bootstrap Bundle with Popper -->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+        <!-- Option 2: Separate Popper and Bootstrap JS -->
+        <!--
+            <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+            <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+            -->
+    </body>
 </html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-index/expected/index.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-index/expected/index.html
@@ -1,110 +1,96 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
-<head>
-    <title>Document Title - Bootstrap Theme</title>
-    <!-- Required meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-        
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-</head>
-<body>
-<header class="">
-        
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <div class="container">
+    <head>
+        <title>Document Title - Bootstrap Theme</title>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <a class="navbar-brand" href="#">Navbar</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
-
-                                
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="/anotherPage.html" class="nav-link" >
-            Another Page
-        </a>
-        </li><li class="nav-item">
-                <a href="/somePage.html" class="nav-link" >
-            Some Page
-        </a>
-        </li><li class="nav-item">
-                <a href="/yetAnotherPage.html" class="nav-link" >
-            Yet Another Page
-        </a>
-        </li></ul>
-
-        </div>
-    </div>
-</nav>
-</header>
-<main id="main-content">
-    <div class="container">
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-3">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    </head>
+    <body>
+        <header class="">
+            <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+                <div class="container">
+                    <a class="navbar-brand" href="#">Navbar</a>
+                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="/anotherPage.html" class="nav-link">
+                                    Another Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="/somePage.html" class="nav-link">
+                                    Some Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="/yetAnotherPage.html" class="nav-link">
+                                    Yet Another Page
+                                </a>
+                            </li></ul>
+                    </div>
+                </div>
+            </nav>
+        </header>
+        <main id="main-content">
+            <div class="container">
+                <div class="container">
+                    <div class="row">
+                        <div class="col-lg-3">
                             <div class="rubric">Main Menu</div>
 
-    <nav class="nav flex-column">
-                <ul class="menu-level-main">
-    <li><a href="/anotherPage.html"
-           class="nav-link">
-            Another Page
-                </a></li>
-    <li><a href="/somePage.html"
-           class="nav-link">
-            Some Page
-                </a></li>
-    <li><a href="/yetAnotherPage.html"
-           class="nav-link">
-            Yet Another Page
-                </a></li>
-            </ul>
-
-</nav>
-
-                </div>
-                <div class="col-lg-9">
-                        
-<nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="/index.html">Document Title</a></li>
-            </ol>
-</nav>
-
-                    <!-- content start -->
-                        
-
-<div class="section" id="document-title">
-            <h1>Document Title</h1>
-
-            <p>Lorem Ipsum Dolor.</p>
-            
-    </div>
-
-                    <!-- content end -->
+                            <nav class="nav flex-column">
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="/anotherPage.html"
+                                            class="nav-link">Another Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="/somePage.html"
+                                            class="nav-link">Some Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="/yetAnotherPage.html"
+                                            class="nav-link">Yet Another Page</a>
+                                    </li>
+                                </ul>
+                            </nav>
+                        </div>
+                        <div class="col-lg-9">
+                            <nav aria-label="breadcrumb">
+                                <ol class="breadcrumb">
+                                    <li class="breadcrumb-item"><a href="/index.html">Document Title</a></li>
+                                </ol>
+                            </nav>
+                            <!-- content start -->
+                            <div class="section" id="document-title">
+                                <h1>Document Title</h1>
+                                <p>Lorem Ipsum Dolor.</p>
+                            </div>
+                            <!-- content end -->
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-    </div>
-</main>
-                <footer class="bg-primary text-light">
+        </main>
+        <footer class="bg-primary text-light">
             <div class="container">
                 <p>Generated by <a href="https://www.phpdoc.org/">phpDocumentor</a>.</p>
-</div>
+            </div>
         </footer>
-    
-<!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 1: Bootstrap Bundle with Popper -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+        <!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 2: Separate Popper and Bootstrap JS -->
-<!--
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
--->
-</body>
+        <!-- Option 1: Bootstrap Bundle with Popper -->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+        <!-- Option 2: Separate Popper and Bootstrap JS -->
+        <!--
+            <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+            <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+            -->
+    </body>
 </html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-index/expected/somePage.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-index/expected/somePage.html
@@ -1,110 +1,99 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
-<head>
-    <title>Some Page - Bootstrap Theme</title>
-    <!-- Required meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-        
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-</head>
-<body>
-<header class="">
-        
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <div class="container">
+    <head>
+        <title>Some Page - Bootstrap Theme</title>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <a class="navbar-brand" href="#">Navbar</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
-
-                                
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="/anotherPage.html" class="nav-link" >
-            Another Page
-        </a>
-        </li><li class="nav-item">
-                <a href="/somePage.html" class="nav-link" >
-            Some Page
-        </a>
-        </li><li class="nav-item">
-                <a href="/yetAnotherPage.html" class="nav-link" >
-            Yet Another Page
-        </a>
-        </li></ul>
-
-        </div>
-    </div>
-</nav>
-</header>
-<main id="main-content">
-    <div class="container">
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-3">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    </head>
+    <body>
+        <header class="">
+            <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+                <div class="container">
+                    <a class="navbar-brand" href="#">Navbar</a>
+                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="/anotherPage.html" class="nav-link">
+                                    Another Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="/somePage.html" class="nav-link">
+                                    Some Page
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="/yetAnotherPage.html" class="nav-link">
+                                    Yet Another Page
+                                </a>
+                            </li></ul>
+                    </div>
+                </div>
+            </nav>
+        </header>
+        <main id="main-content">
+            <div class="container">
+                <div class="container">
+                    <div class="row">
+                        <div class="col-lg-3">
                             <div class="rubric">Main Menu</div>
 
-    <nav class="nav flex-column">
-                <ul class="menu-level-main">
-    <li><a href="/anotherPage.html"
-           class="nav-link">
-            Another Page
-                </a></li>
-    <li><a href="/somePage.html"
-           class="nav-link">
-            Some Page
-                </a></li>
-    <li><a href="/yetAnotherPage.html"
-           class="nav-link">
-            Yet Another Page
-                </a></li>
-            </ul>
+                            <nav class="nav flex-column">
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="/anotherPage.html"
+                                            class="nav-link">Another Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="/somePage.html"
+                                            class="nav-link">Some Page</a>
+                                    </li>
+                                    <li>
+                                        <a href="/yetAnotherPage.html"
+                                            class="nav-link">Yet Another Page</a>
+                                    </li>
+                                </ul>
+                            </nav>
+                        </div>
+                        <div class="col-lg-9">
+                            <nav aria-label="breadcrumb">
+                                <ol class="breadcrumb">
+                                    <li class="breadcrumb-item"><a href="/index.html">Document Title</a></li>
+                                    <li class="breadcrumb-item"><a href="/somePage.html">Some Page</a></li>
+                                </ol>
+                            </nav>
 
-</nav>
+                            <!-- content start -->
+                            <div class="section" id="some-page">
+                                <h1>Some Page</h1>
 
-                </div>
-                <div class="col-lg-9">
-                        
-<nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="/index.html">Document Title</a></li>
-        <li class="breadcrumb-item"><a href="/somePage.html">Some Page</a></li>
-            </ol>
-</nav>
-
-                    <!-- content start -->
-                        
-
-<div class="section" id="some-page">
-            <h1>Some Page</h1>
-
-            <p>Lorem Ipsum <span class="custom">Dolor</span>.</p>
-    </div>
-
-                    <!-- content end -->
+                                <p>Lorem Ipsum <span class="custom">Dolor</span>.</p>
+                            </div>
+                            <!-- content end -->
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-    </div>
-</main>
-                <footer class="bg-primary text-light">
+        </main>
+        <footer class="bg-primary text-light">
             <div class="container">
                 <p>Generated by <a href="https://www.phpdoc.org/">phpDocumentor</a>.</p>
-</div>
+            </div>
         </footer>
-    
-<!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 1: Bootstrap Bundle with Popper -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+        <!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 2: Separate Popper and Bootstrap JS -->
-<!--
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
--->
-</body>
+        <!-- Option 1: Bootstrap Bundle with Popper -->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+        <!-- Option 2: Separate Popper and Bootstrap JS -->
+        <!--
+            <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+            <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+            -->
+    </body>
 </html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-external-linktargets/expected/index.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-external-linktargets/expected/index.html
@@ -1,114 +1,115 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
-<head>
-    <title>Document Title</title>
-    <!-- Required meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-        
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-</head>
-<body>
-<header class="">
-        
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <div class="container">
+    <head>
+        <title>Document Title</title>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <a class="navbar-brand" href="#">Navbar</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    </head>
+    <body>
+        <header class="">
 
-                                
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="https://example.com/index.html#debug-settings" class="nav-link" >
-            Title
-        </a>
-        </li><li class="nav-item">
-                <a href="https://example.org" class="nav-link" >
-            https://example.org
-        </a>
-        </li><li class="nav-item">
-                <a href="/page1.html" class="nav-link" >
-            Some Page
-        </a>
-        </li></ul>
+            <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+                <div class="container">
 
+                    <a class="navbar-brand" href="#">Navbar</a>
+                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="https://example.com/index.html#debug-settings" class="nav-link">
+                                    Title
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="https://example.org" class="nav-link">
+                                    https://example.org
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="/page1.html" class="nav-link">
+                                    Some Page
+                                </a>
+                            </li></ul>
 
                     </div>
-    </div>
-</nav>
-</header>
-<main id="main-content">
-    <div class="container">
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-3">
-                                <nav class="nav flex-column">
-                    <h2>Some Caption</h2>
-                <ul class="menu-level-main">
-    <li><a href="https://example.com/index.html#debug-settings"
-           class="nav-link">
-            Title
-                </a></li>
-    <li><a href="https://example.org"
-           class="nav-link">
-            https://example.org
-                </a></li>
-    <li><a href="/page1.html"
-           class="nav-link">
-            Some Page
-                </a></li>
-            </ul>
-
-</nav>
-
-
                 </div>
-                <div class="col-lg-9">
-                        
-<nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="/index.html">Document Title</a></li>
-            </ol>
-</nav>
+            </nav>
+        </header>
+        <main id="main-content">
+            <div class="container">
+                <div class="container">
+                    <div class="row">
+                        <div class="col-lg-3">
+                            <nav class="nav flex-column">
+                                <h2>Some Caption</h2>
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="https://example.com/index.html#debug-settings"
+                                            class="nav-link">Title</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://example.org"
+                                            class="nav-link">https://example.org</a>
+                                    </li>
+                                    <li>
+                                        <a href="/page1.html"
+                                            class="nav-link">Some Page</a>
+                                    </li>
+                                </ul>
+                            </nav>
 
-                    <!-- content start -->
-                        <div class="section" id="document-title">
-            <h1>Document Title</h1>
+                        </div>
+                        <div class="col-lg-9">
 
-            <div class="toc">
-            <p class="caption">Some Caption</p>
-    <ul class="menu-level">
-    <li class="toc-item"><a href="https://example.com/index.html#debug-settings">Title</a></li>
+                            <nav aria-label="breadcrumb">
+                                <ol class="breadcrumb">
+                                    <li class="breadcrumb-item"><a href="/index.html">Document Title</a></li>
+                                </ol>
+                            </nav>
+                            <!-- content start -->
+                            <div class="section" id="document-title">
+                                <h1>Document Title</h1>
+                                <div class="toc">
+                                    <p class="caption">Some Caption</p>
+                                    <ul class="menu-level">
+                                        <li class="toc-item">
+                                            <a href="https://example.com/index.html#debug-settings">Title</a>
 
-    <li class="toc-item"><a href="https://example.org">https://example.org</a></li>
 
-    <li class="toc-item"><a href="/page1.html#">Some Page</a></li>
+                                        </li>
+                                        <li class="toc-item">
+                                            <a href="https://example.org">https://example.org</a>
 
-    </ul>
-</div>
 
-    </div>
+                                        </li>
+                                        <li class="toc-item">
+                                            <a href="/page1.html#">Some Page</a>
 
-                    <!-- content end -->
+
+                                        </li>
+                                    </ul>
+                                </div>
+                            </div>
+                            <!-- content end -->
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-    </div>
-</main>
-        
-<!-- Optional JavaScript; choose one of the two! -->
+        </main>
 
-<!-- Option 1: Bootstrap Bundle with Popper -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+        <!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 2: Separate Popper and Bootstrap JS -->
-<!--
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
--->
-</body>
+        <!-- Option 1: Bootstrap Bundle with Popper -->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+        <!-- Option 2: Separate Popper and Bootstrap JS -->
+        <!--
+            <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+            <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+            -->
+    </body>
 </html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-external-on-subpage/expected/index.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-external-on-subpage/expected/index.html
@@ -1,135 +1,143 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
-<head>
-    <title>Document Title</title>
-    <!-- Required meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-        
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-</head>
-<body>
-<header class="">
-        
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <div class="container">
+    <head>
+        <title>Document Title</title>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <a class="navbar-brand" href="#">Navbar</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    </head>
+    <body>
+        <header class="">
 
-                                
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="https://example.com/index.html#debug-settings" class="nav-link" >
-            Title
-        </a>
-        </li><li class="nav-item">
-                <a href="https://example.org" class="nav-link" >
-            https://example.org
-        </a>
-        </li><li class="nav-item">
-                <a href="/page1.html" class="nav-link" >
-            Some Page
-        </a>
-        </li>            <ul class="level-">
-    <li class="nav-item"><a href="https://example.com/index.html#debug-settings"
-               class="nav-link" >
-                Title
-            </a></li><li class="nav-item"><a href="https://example.org"
-               class="nav-link" >
-                https://example.org
-            </a></li><li class="nav-item"><a href="/page1.html"
-               class="nav-link" >
-                Some Page
-            </a></li></ul>
-</ul>
+            <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+                <div class="container">
 
+                    <a class="navbar-brand" href="#">Navbar</a>
+                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="https://example.com/index.html#debug-settings" class="nav-link">
+                                    Title
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="https://example.org" class="nav-link">
+                                    https://example.org
+                                </a>
+                            </li><li class="nav-item">
+                                <a href="/page1.html" class="nav-link">
+                                    Some Page
+                                </a>
+                            </li>            
+                            <ul class="level-">
+                                <li class="nav-item">
+                                    <a href="https://example.com/index.html#debug-settings"
+                                        class="nav-link">Title</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a href="https://example.org"
+                                        class="nav-link">https://example.org</a>
+                                </li>
+                                <li class="nav-item">
+                                    <a href="/page1.html"
+                                        class="nav-link">Some Page</a>
+                                </li>
+                            </ul>
+                        </ul>
 
                     </div>
-    </div>
-</nav>
-</header>
-<main id="main-content">
-    <div class="container">
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-3">
-                                <nav class="nav flex-column">
-                    <h2>Some Caption</h2>
-                <ul class="menu-level-main">
-    <li><a href="https://example.com/index.html#debug-settings"
-           class="nav-link">
-            Title
-                </a></li>
-    <li><a href="https://example.org"
-           class="nav-link">
-            https://example.org
-                </a></li>
-    <li><a href="/page1.html"
-           class="nav-link">
-            Some Page
-                </a>            
-<ul class="level-1">
-        <li><a href="https://example.com/index.html#another"
-                       class="nav-link">
-                                Title 2
-                        </a></li>
-        </ul>
-</li>
-            </ul>
-
-</nav>
-
-
                 </div>
-                <div class="col-lg-9">
-                        
-<nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="/index.html">Document Title</a></li>
-            </ol>
-</nav>
+            </nav>
+        </header>
+        <main id="main-content">
+            <div class="container">
+                <div class="container">
+                    <div class="row">
+                        <div class="col-lg-3">
+                            <nav class="nav flex-column">
+                                <h2>Some Caption</h2>
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="https://example.com/index.html#debug-settings"
+                                            class="nav-link">Title</a>
+                                    </li>
+                                    <li>
+                                        <a href="https://example.org"
+                                            class="nav-link">https://example.org</a>
+                                    </li>
+                                    <li>
+                                        <a href="/page1.html"
+                                            class="nav-link">Some Page</a>                
+                                        <ul class="level-1">
+                                            <li>
+                                                <a href="https://example.com/index.html#another"
+                                                    class="nav-link">Title 2</a>
+                                            </li>
+                                        </ul>
 
-                    <!-- content start -->
-                        <div class="section" id="document-title">
-            <h1>Document Title</h1>
+                                    </li>
+                                </ul>
+                            </nav>
 
-            <div class="toc">
-            <p class="caption">Some Caption</p>
-    <ul class="menu-level">
-    <li class="toc-item"><a href="https://example.com/index.html#debug-settings">Title</a></li>
+                        </div>
+                        <div class="col-lg-9">
 
-    <li class="toc-item"><a href="https://example.org">https://example.org</a></li>
+                            <nav aria-label="breadcrumb">
+                                <ol class="breadcrumb">
+                                    <li class="breadcrumb-item"><a href="/index.html">Document Title</a></li>
+                                </ol>
+                            </nav>
+                            <!-- content start -->
+                            <div class="section" id="document-title">
+                                <h1>Document Title</h1>
+                                <div class="toc">
+                                    <p class="caption">Some Caption</p>
+                                    <ul class="menu-level">
+                                        <li class="toc-item">
+                                            <a href="https://example.com/index.html#debug-settings">Title</a>
 
-    <li class="toc-item"><a href="/page1.html#">Some Page</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="https://example.com/index.html#another">Title 2</a></li>
 
-                    </ul></li>
+                                        </li>
+                                        <li class="toc-item">
+                                            <a href="https://example.org">https://example.org</a>
 
-    </ul>
-</div>
 
-    </div>
+                                        </li>
+                                        <li class="toc-item">
+                                            <a href="/page1.html#">Some Page</a>
+                                            <ul class="menu-level-1">
+                                                <li class="toc-item">
+                                                    <a href="https://example.com/index.html#another">Title 2</a>
 
-                    <!-- content end -->
+
+                                                </li>
+                                            </ul>
+
+                                        </li>
+                                    </ul>
+                                </div>
+                            </div>
+                            <!-- content end -->
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-    </div>
-</main>
-        
-<!-- Optional JavaScript; choose one of the two! -->
+        </main>
 
-<!-- Option 1: Bootstrap Bundle with Popper -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+        <!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 2: Separate Popper and Bootstrap JS -->
-<!--
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
--->
-</body>
+        <!-- Option 1: Bootstrap Bundle with Popper -->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+        <!-- Option 2: Separate Popper and Bootstrap JS -->
+        <!--
+            <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+            <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+            -->
+    </body>
 </html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-relative/expected/index.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-relative/expected/index.html
@@ -1,163 +1,184 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
-<head>
-    <title>Document Title - Bootstrap Theme</title>
-    <!-- Required meta tags -->
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-        
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-</head>
-<body>
-<header class="">
-        
-<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <div class="container">
+    <head>
+        <title>Document Title - Bootstrap Theme</title>
+        <!-- Required meta tags -->
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <a class="navbar-brand" href="#">Navbar</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+    </head>
+    <body>
+        <header class="">
 
-                                
-<ul class="navbar-nav me-auto mb-2 mb-lg-0">
-    <li class="nav-item">
-                <a href="someDirectory/index.html" class="nav-link" >
-            Some Page
-        </a>
-        </li>            <ul class="level-">
-    <li class="nav-item"><a href="someDirectory/index.html"
-               class="nav-link" >
-                Some Page
-            </a></li></ul>
-</ul>
+            <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+                <div class="container">
 
+                    <a class="navbar-brand" href="#">Navbar</a>
+                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                        <span class="navbar-toggler-icon"></span>
+                    </button>
+                    <div class="collapse navbar-collapse" id="navbarSupportedContent">
+
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item">
+                                <a href="someDirectory/index.html" class="nav-link">
+                                    Some Page
+                                </a>
+                            </li>            
+                            <ul class="level-">
+                                <li class="nav-item">
+                                    <a href="someDirectory/index.html"
+                                        class="nav-link">Some Page</a>
+                                </li>
+                            </ul>
+                        </ul>
 
                     </div>
-    </div>
-</nav>
-</header>
-<main id="main-content">
-    <div class="container">
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-3">
-                                <nav class="nav flex-column">
-                <ul class="menu-level-main">
-    <li><a href="someDirectory/index.html"
-           class="nav-link">
-            Some Page
-                </a>            
-<ul class="level-1">
-        <li><a href="levelup1.html"
-                       class="nav-link">
-                                Level up 1
-                        </a></li>
-        <li><a href="someDirectory/anotherDirectory/index.html"
-                       class="nav-link">
-                                Another Page
-                        </a>                                
-<ul class="level-2">
-        <li><a href="levelup2.html"
-                       class="nav-link">
-                                Level up 2
-                        </a></li>
-        <li><a href="someDirectory/anotherDirectory/yetAnotherDirectory/index.html"
-                       class="nav-link">
-                                Yet Another Page
-                        </a>                                
-<ul class="level-3">
-        <li><a href="levelup3.html"
-                       class="nav-link">
-                                Level up 3
-                        </a></li>
-        <li><a href="someDirectory/anotherDirectory/yetAnotherDirectory/andYetAnotherDirectory/index.html"
-                       class="nav-link">
-                                And Yet Another Page
-                        </a>                                
-<ul class="level-4">
-        <li><a href="levelup4.html"
-                       class="nav-link">
-                                Level up 4
-                        </a></li>
-        </ul>
-</li>
-        </ul>
-</li>
-        </ul>
-</li>
-        </ul>
-</li>
-            </ul>
-
-</nav>
-
-
                 </div>
-                <div class="col-lg-9">
-                        
-<nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="#">Document Title</a></li>
-            </ol>
-</nav>
+            </nav>
+        </header>
+        <main id="main-content">
+            <div class="container">
+                <div class="container">
+                    <div class="row">
+                        <div class="col-lg-3">
+                            <nav class="nav flex-column">
+                                <ul class="menu-level-main">
+                                    <li>
+                                        <a href="someDirectory/index.html"
+                                            class="nav-link">Some Page</a>                
+                                        <ul class="level-1">
+                                            <li>
+                                                <a href="levelup1.html"
+                                                    class="nav-link">Level up 1</a>
+                                            </li>
+                                            <li>
+                                                <a href="someDirectory/anotherDirectory/index.html"
+                                                    class="nav-link">Another Page</a>                    
+                                                <ul class="level-2">
+                                                    <li>
+                                                        <a href="levelup2.html"
+                                                            class="nav-link">Level up 2</a>
+                                                    </li>
+                                                    <li>
+                                                        <a href="someDirectory/anotherDirectory/yetAnotherDirectory/index.html"
+                                                            class="nav-link">Yet Another Page</a>                    
+                                                        <ul class="level-3">
+                                                            <li>
+                                                                <a href="levelup3.html"
+                                                                    class="nav-link">Level up 3</a>
+                                                            </li>
+                                                            <li>
+                                                                <a href="someDirectory/anotherDirectory/yetAnotherDirectory/andYetAnotherDirectory/index.html"
+                                                                    class="nav-link">And Yet Another Page</a>                    
+                                                                <ul class="level-4">
+                                                                    <li>
+                                                                        <a href="levelup4.html"
+                                                                            class="nav-link">Level up 4</a>
+                                                                    </li>
+                                                                </ul>
 
-                    <!-- content start -->
-                        
+                                                            </li>
+                                                        </ul>
 
-<div class="section" id="document-title">
-            <h1>Document Title</h1>
+                                                    </li>
+                                                </ul>
 
-            <p>Lorem Ipsum Dolor.</p>
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="someDirectory/index.html#some-page">Some Page</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="levelup1.html#level-up-1">Level up 1</a></li>
+                                            </li>
+                                        </ul>
 
-            <li class="toc-item"><a href="someDirectory/anotherDirectory/index.html#another-page">Another Page</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="levelup2.html#level-up-2">Level up 2</a></li>
+                                    </li>
+                                </ul>
+                            </nav>
 
-            <li class="toc-item"><a href="someDirectory/anotherDirectory/yetAnotherDirectory/index.html#yet-another-page">Yet Another Page</a>        <ul class="menu-level-3">
-            <li class="toc-item"><a href="levelup3.html#level-up-3">Level up 3</a></li>
+                        </div>
+                        <div class="col-lg-9">
 
-            <li class="toc-item"><a href="someDirectory/anotherDirectory/yetAnotherDirectory/andYetAnotherDirectory/index.html#and-yet-another-page">And Yet Another Page</a>        <ul class="menu-level-4">
-            <li class="toc-item"><a href="levelup4.html#level-up-4">Level up 4</a></li>
+                            <nav aria-label="breadcrumb">
+                                <ol class="breadcrumb">
+                                    <li class="breadcrumb-item"><a href="#">Document Title</a></li>
+                                </ol>
+                            </nav>
+                            <!-- content start -->
 
-                    </ul></li>
+                            <div class="section" id="document-title">
+                                <h1>Document Title</h1>
 
-                    </ul></li>
+                                <p>Lorem Ipsum Dolor.</p>
 
-                    </ul></li>
+                                <div class="toc">
+                                    <ul class="menu-level">
+                                        <li class="toc-item">
+                                            <a href="someDirectory/index.html#some-page">Some Page</a>
+                                            <ul class="menu-level-1">
+                                                <li class="toc-item">
+                                                    <a href="levelup1.html#level-up-1">Level up 1</a>
 
-                    </ul></li>
 
-    </ul>
-</div>
+                                                </li>
+                                                <li class="toc-item">
+                                                    <a href="someDirectory/anotherDirectory/index.html#another-page">Another Page</a>
+                                                    <ul class="menu-level-2">
+                                                        <li class="toc-item">
+                                                            <a href="levelup2.html#level-up-2">Level up 2</a>
 
-    </div>
 
-                    <!-- content end -->
+                                                        </li>
+                                                        <li class="toc-item">
+                                                            <a href="someDirectory/anotherDirectory/yetAnotherDirectory/index.html#yet-another-page">Yet Another Page</a>
+                                                            <ul class="menu-level-3">
+                                                                <li class="toc-item">
+                                                                    <a href="levelup3.html#level-up-3">Level up 3</a>
+
+
+                                                                </li>
+                                                                <li class="toc-item">
+                                                                    <a href="someDirectory/anotherDirectory/yetAnotherDirectory/andYetAnotherDirectory/index.html#and-yet-another-page">And Yet Another Page</a>
+                                                                    <ul class="menu-level-4">
+                                                                        <li class="toc-item">
+                                                                            <a href="levelup4.html#level-up-4">Level up 4</a>
+
+
+                                                                        </li>
+                                                                    </ul>
+
+                                                                </li>
+                                                            </ul>
+
+                                                        </li>
+                                                    </ul>
+
+                                                </li>
+                                            </ul>
+
+                                        </li>
+                                    </ul>
+                                </div>
+                            </div>
+                            <!-- content end -->
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-    </div>
-</main>
-                <footer class="bg-primary text-light">
+        </main>
+        <footer class="bg-primary text-light">
             <div class="container">
+
                 <p>Generated by <a href="https://www.phpdoc.org/">phpDocumentor</a>.</p>
-</div>
+
+            </div>
         </footer>
-    
-<!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 1: Bootstrap Bundle with Popper -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+        <!-- Optional JavaScript; choose one of the two! -->
 
-<!-- Option 2: Separate Popper and Bootstrap JS -->
-<!--
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
--->
-</body>
+        <!-- Option 1: Bootstrap Bundle with Popper -->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+        <!-- Option 2: Separate Popper and Bootstrap JS -->
+        <!--
+            <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+            <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+            -->
+    </body>
 </html>

--- a/tests/Integration/tests/body-elements/block-quotes/expected/index.html
+++ b/tests/Integration/tests/body-elements/block-quotes/expected/index.html
@@ -1,23 +1,22 @@
 <!-- content start -->
-    <div class="section" id="some-blockquotes">
-            <h1>Some Blockquotes</h1>
+<div class="section" id="some-blockquotes">
+        <h1>Some Blockquotes</h1>
 
-            <blockquote class="epigraph"><p>No matter where you go, there you are.</p><p>-- Buckaroo Banzai</p></blockquote>
+        <blockquote class="epigraph">
+            <p>No matter where you go, there you are.</p>
+            <p>-- Buckaroo Banzai</p>
+        </blockquote>
 
-            <blockquote class="highlights">
+        <blockquote class="highlights">
+            <ul>
+                <li>Lorem</li>
+                <li>Ipsum</li>
+                <li>Dolor</li>
+            </ul>
+        </blockquote>
 
-<ul>
-    <li>Lorem</li>
-
-    <li>Ipsum</li>
-
-    <li>Dolor</li>
-
-</ul>
-</blockquote>
-
-            <blockquote class="pull-quote"><p>A pull-quote is a small selection of text &quot;pulled out and quoted&quot;.</p></blockquote>
-
-    </div>
-
+        <blockquote class="pull-quote">
+            <p>A pull-quote is a small selection of text &quot;pulled out and quoted&quot;.</p>
+        </blockquote>
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/body-elements/citation/citation-unknown/expected/index.html
+++ b/tests/Integration/tests/body-elements/citation/citation-unknown/expected/index.html
@@ -2,7 +2,7 @@
     <div class="section" id="document-title">
             <h1>Document Title</h1>
 
-            <p>Lorem ipsum <sup>[UnkownCitation]</sup> dolor sit amet.</p>
+            <p>Lorem ipsum <sup>[UnknownCitation]</sup> dolor sit amet.</p>
     </div>
 
 <!-- content end -->

--- a/tests/Integration/tests/body-elements/citation/citation-unknown/input/index.rst
+++ b/tests/Integration/tests/body-elements/citation/citation-unknown/input/index.rst
@@ -2,4 +2,4 @@
 Document Title
 ==============
 
-Lorem ipsum [UnkownCitation]_ dolor sit amet.
+Lorem ipsum [UnknownCitation]_ dolor sit amet.

--- a/tests/Integration/tests/class/class-directive-non-block/expected/index.html
+++ b/tests/Integration/tests/class/class-directive-non-block/expected/index.html
@@ -1,50 +1,47 @@
 <!-- content start -->
-    <div class="section" id="class-directives">
-            <h1>Class directives</h1>
+<div class="section" id="class-directives">
+    <h1>Class directives</h1>
 
-            <p>Class directives are applied to the next node if they have not content.</p>
-            <p class="special-paragraph1">Test special-paragraph1 1.</p>
-            <p>Test special-paragraph1 2.</p>
-            <p class="special-paragraph2">Test special-paragraph2 1.</p><p class="special-paragraph2">Test special-paragraph2 2.</p>
+    <p>Class directives are applied to the next node if they have not content.</p>
+    <p class="special-paragraph1">Test special-paragraph1 1.</p>
+    <p>Test special-paragraph1 2.</p>
+    <p class="special-paragraph2">Test special-paragraph2 1.</p>
+    <p class="special-paragraph2">Test special-paragraph2 2.</p>
 
-            <div class="admonition note">
-            <p class="special-paragraph3">Test</p>
-</div>
-
-
-
-<ul class="special-list">
-    <li class="dash">Test list item 1.</li>
-
-    <li class="dash">Test list item 2.</li>
-
-</ul>
-
-            <p class="rot-gelb-blau gr-n-2008">Weird class names.</p>
-            <p class="level1">Level 1</p><blockquote class="level1"><p class="level2">Level2 1</p><p class="level2">Level2 2</p>
-</blockquote>
-
-
-            <dl class="special-definition-list">
-                        <dt>term 1</dt>
-
-        <dd>Definition 1</dd>    </dl>
-
-            <table class="special-table">
-                <thead>
-            <tr>
-                            <th>First col</th>
-                            <th>Second col</th>
-                    </tr>
-        </thead>
-    <tbody>
-    <tr>
-            <td>Second row</td>
-            <td>Other col</td>
-    </tr>
-</tbody>
-</table>
-
+    <div class="admonition note">
+        <p class="special-paragraph3">Test</p>
     </div>
 
+    <ul class="special-list">
+        <li class="dash">Test list item 1.</li>
+        <li class="dash">Test list item 2.</li>
+    </ul>
+
+    <p class="rot-gelb-blau gr-n-2008">Weird class names.</p>
+    <p class="level1">Level 1</p>
+    <blockquote class="level1">
+        <p class="level2">Level2 1</p>
+        <p class="level2">Level2 2</p>
+    </blockquote>
+
+    <dl class="special-definition-list">
+        <dt>term 1</dt>
+        <dd>Definition 1</dd>
+    </dl>
+
+    <table class="special-table">
+        <thead>
+            <tr>
+                <th>First col</th>
+                <th>Second col</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Second row</td>
+                <td>Other col</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/class/class-directive-sections/expected/index.html
+++ b/tests/Integration/tests/class/class-directive-sections/expected/index.html
@@ -1,11 +1,10 @@
 <!-- content start -->
-    <p class="special">This is a &quot;special&quot; paragraph.</p>
+<p class="special">This is a &quot;special&quot; paragraph.</p>
 <div class="section exceptional remarkable" id="an-exceptional-section">
-            <h1>An Exceptional Section</h1>
+    <h1>An Exceptional Section</h1>
 
-            <p>This is an ordinary paragraph.</p>
-            <p class="multiple">First paragraph.</p><p class="multiple">Second paragraph.</p>
-
-    </div>
-
+    <p>This is an ordinary paragraph.</p>
+    <p class="multiple">First paragraph.</p>
+    <p class="multiple">Second paragraph.</p>
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/class/class-directive/expected/index.html
+++ b/tests/Integration/tests/class/class-directive/expected/index.html
@@ -1,25 +1,28 @@
 <!-- content start -->
-    <div class="section" id="document-title">
-            <h1>Document title</h1>
+<div class="section" id="document-title">
+    <h1>Document title</h1>
 
-            <p class="special-paragraph2">Test special-paragraph 1.</p><p class="special-paragraph2">Test special-paragraph 2.</p>
+    <p class="special-paragraph2">Test special-paragraph 1.</p>
 
-            <p class="rot-gelb-gr-n-2008">Classes get escaped</p>
+    <p class="special-paragraph2">Test special-paragraph 2.</p>
 
-            <p class="steps">Classes get escaped</p>
+    <p class="rot-gelb-gr-n-2008">Classes get escaped</p>
 
-            <p class="level1">Level 1</p><blockquote class="level1"><p class="level2">Level2 1</p><p class="level2">Level2 2</p>
-</blockquote>
+    <p class="steps">Classes get escaped</p>
 
+    <p class="level1">Level 1</p>
 
-            <div class="admonition note my-class">
+    <blockquote class="level1">
+        <p class="level2">Level2 1</p>
+        <p class="level2">Level2 2</p>
+    </blockquote>
+
+    <div class="admonition note my-class">
         <p>A Note with a class</p>
-</div>
-
-            <div class="admonition note">
-        <p>A note without a class</p>
-</div>
-
     </div>
 
+    <div class="admonition note">
+        <p>A note without a class</p>
+    </div>
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/class/class-in-list/expected/index.html
+++ b/tests/Integration/tests/class/class-in-list/expected/index.html
@@ -1,34 +1,30 @@
 <!-- content start -->
-    <div class="section" id="rst-class-within-list">
-            <h1>rst-class within list</h1>
+<div class="section" id="rst-class-within-list">
+    <h1>rst-class within list</h1>
 
-
-
-<ol class="bignums-xxl">
-    <li><p>ONE One one bignums-xxl</p><p>This is the story of my life ...</p>
-
-<ol class="bignums">
-    <li><p>When I was young</p>
-
-<ol>
-    <li>this</li>
-
-    <li>and that</li>
-
-    <li>and this</li>
-
-</ol>
-</li>
-
-    <li><p>When I was grown</p><p>Oops, ...</p></li>
-
-    <li><p>When I was old</p><p>Oh dear, ...</p></li>
-
-</ol>
-</li>
-
-</ol>
-
-    </div>
-
+    <ol class="bignums-xxl">
+        <li>
+            <p>ONE One one bignums-xxl</p>
+            <p>This is the story of my life ...</p>
+            <ol class="bignums">
+                <li>
+                    <p>When I was young</p>
+                    <ol>
+                        <li>this</li>
+                        <li>and that</li>
+                        <li>and this</li>
+                    </ol>
+                </li>
+                <li>
+                    <p>When I was grown</p>
+                    <p>Oops, ...</p>
+                </li>
+                <li>
+                    <p>When I was old</p>
+                    <p>Oh dear, ...</p>
+                </li>
+            </ol>
+        </li>
+    </ol>
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/comments/comment-nested/expected/index.html
+++ b/tests/Integration/tests/comments/comment-nested/expected/index.html
@@ -1,12 +1,12 @@
 <!-- content start -->
-    <div class="section" id="some-title">
-            <h1>Some Title</h1>
+<div class="section" id="some-title">
+    <h1>Some Title</h1>
 
-            <div class="admonition note">
-            <p>No comment!</p><p>This text is no comment</p>
-</div>
-
-            <p>After the node</p>
+    <div class="admonition note">
+        <p>No comment!</p>
+        <p>This text is no comment</p>
     </div>
 
+    <p>After the node</p>
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/configuration/config-project/expected/index.html
+++ b/tests/Integration/tests/configuration/config-project/expected/index.html
@@ -1,19 +1,20 @@
 <!-- content start -->
-    <div class="section" id="document-title">
-            <h1>Document Title</h1>
+<div class="section" id="document-title">
+    <h1>Document Title</h1>
 
-            <p>Lorem Ipsum Dolor.</p>
-            <dl>
-                        <dt>title:</dt>
+    <p>Lorem Ipsum Dolor.</p>
+    <dl>
+        <dt>title:</dt>
+        <dd>Title</dd>
 
-        <dd>Title</dd>                        <dt>version:</dt>
+        <dt>version:</dt>
+        <dd>12.4</dd>
 
-        <dd>12.4</dd>                        <dt>release:</dt>
+        <dt>release:</dt>
+        <dd>12.4.9-dev</dd>
 
-        <dd>12.4.9-dev</dd>                        <dt>copyright:</dt>
-
-        <dd>since 1998 phpDocumentor Team and Contributors</dd>    </dl>
-
-    </div>
-
+        <dt>copyright:</dt>
+        <dd>since 1998 phpDocumentor Team and Contributors</dd>
+    </dl>
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/confval/confval-name/expected/another.html
+++ b/tests/Integration/tests/confval/confval-name/expected/another.html
@@ -1,32 +1,31 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <title>Confval directive</title>
+    <head>
+        <title>Confval directive</title>
 
-</head>
-<body>
-<!-- content start -->
-    <div class="section" id="confval-directive">
+    </head>
+    <body>
+        <!-- content start -->
+        <div class="section" id="confval-directive">
             <h1>Confval directive</h1>
 
             <dl class="confval">
-    <dt id="another-demo">
-        <code class="sig-name descname"><span class="pre">demo</span></code></dt>
-    <dd>
-        <div class="line-block">
-             <div class="line"><strong>Type:</strong>  <code>&quot;Hello World&quot;</code></div>
-             <div class="line"><strong>Required:</strong> true</div>
-            <div class="line"><strong>Custom Info:</strong> <strong>custom</strong></div>
-
-            </div>
-        <div class="confval-description">
-            <p>This is the confval <code>demo</code> content!</p><p>Another paragraph.</p>
-        </div>
-    </dd>
-</dl>
+                <dt id="another-demo">
+                    <code class="sig-name descname"><span class="pre">demo</span></code></dt>
+                <dd>
+                    <div class="line-block">
+                        <div class="line"><strong>Type:</strong>  <code>&quot;Hello World&quot;</code></div>
+                        <div class="line"><strong>Required:</strong> true</div>
+                        <div class="line"><strong>Custom Info:</strong> <strong>custom</strong></div>
+                    </div>
+                    <div class="confval-description">
+                        <p>This is the confval <code>demo</code> content!</p>
+                        <p>Another paragraph.</p>
+                    </div>
+                </dd>
+            </dl>
             <p>See option <a href="/index.html#demo">demo</a>.</p>
-    </div>
-
-<!-- content end -->
-</body>
+        </div>
+        <!-- content end -->
+    </body>
 </html>

--- a/tests/Integration/tests/confval/confval-name/expected/index.html
+++ b/tests/Integration/tests/confval/confval-name/expected/index.html
@@ -1,39 +1,37 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <title>Confval directive</title>
-
-</head>
-<body>
-<!-- content start -->
-    <div class="section" id="confval-directive">
+    <head>
+        <title>Confval directive</title>
+    </head>
+    <body>
+        <!-- content start -->
+        <div class="section" id="confval-directive">
             <h1>Confval directive</h1>
 
             <dl class="confval">
-    <dt id="demo">
-        <code class="sig-name descname"><span class="pre">demo</span></code></dt>
-    <dd>
-        <div class="line-block">
-             <div class="line"><strong>Type:</strong>  <code>&quot;Hello World&quot;</code></div>
-             <div class="line"><strong>Required:</strong> true</div>
-            <div class="line"><strong>Custom Info:</strong> <strong>custom</strong></div>
-
-            </div>
-        <div class="confval-description">
-            <p>This is the confval <code>demo</code> content!</p><p>Another paragraph.</p>
-        </div>
-    </dd>
-</dl>
+                <dt id="demo">
+                    <code class="sig-name descname"><span class="pre">demo</span></code></dt>
+                <dd>
+                    <div class="line-block">
+                        <div class="line"><strong>Type:</strong>  <code>&quot;Hello World&quot;</code></div>
+                        <div class="line"><strong>Required:</strong> true</div>
+                        <div class="line"><strong>Custom Info:</strong> <strong>custom</strong></div>
+                    </div>
+                    <div class="confval-description">
+                        <p>This is the confval <code>demo</code> content!</p>
+                        <p>Another paragraph.</p>
+                    </div>
+                </dd>
+            </dl>
             <p>See option <a href="/index.html#demo">demo</a>.</p>
             <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/another.html#confval-directive">Confval directive</a></li>
-
-    </ul>
-</div>
-
-    </div>
-
-<!-- content end -->
-</body>
+                <ul class="menu-level">
+                    <li class="toc-item">
+                        <a href="/another.html#confval-directive">Confval directive</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+        <!-- content end -->
+    </body>
 </html>

--- a/tests/Integration/tests/confval/confval-warning/expected/another.html
+++ b/tests/Integration/tests/confval/confval-warning/expected/another.html
@@ -1,32 +1,31 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <title>Confval directive</title>
+    <head>
+        <title>Confval directive</title>
 
-</head>
-<body>
-<!-- content start -->
-    <div class="section" id="confval-directive">
+    </head>
+    <body>
+        <!-- content start -->
+        <div class="section" id="confval-directive">
             <h1>Confval directive</h1>
 
             <dl class="confval">
-    <dt id="demo">
-        <code class="sig-name descname"><span class="pre">demo</span></code></dt>
-    <dd>
-        <div class="line-block">
-             <div class="line"><strong>Type:</strong>  <code>&quot;Hello World&quot;</code></div>
-             <div class="line"><strong>Required:</strong> true</div>
-            <div class="line"><strong>Custom Info:</strong> <strong>custom</strong></div>
-
-            </div>
-        <div class="confval-description">
-            <p>This is the confval <code>demo</code> content!</p><p>Another paragraph.</p>
-        </div>
-    </dd>
-</dl>
+                <dt id="demo">
+                    <code class="sig-name descname"><span class="pre">demo</span></code></dt>
+                <dd>
+                    <div class="line-block">
+                        <div class="line"><strong>Type:</strong>  <code>&quot;Hello World&quot;</code></div>
+                        <div class="line"><strong>Required:</strong> true</div>
+                        <div class="line"><strong>Custom Info:</strong> <strong>custom</strong></div>
+                    </div>
+                    <div class="confval-description">
+                        <p>This is the confval <code>demo</code> content!</p>
+                        <p>Another paragraph.</p>
+                    </div>
+                </dd>
+            </dl>
             <p>See option <a href="/another.html#demo">demo</a>.</p>
-    </div>
-
-<!-- content end -->
-</body>
+        </div>
+        <!-- content end -->
+    </body>
 </html>

--- a/tests/Integration/tests/confval/confval-warning/expected/index.html
+++ b/tests/Integration/tests/confval/confval-warning/expected/index.html
@@ -1,39 +1,38 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <title>Confval directive</title>
+    <head>
+        <title>Confval directive</title>
 
-</head>
-<body>
-<!-- content start -->
-    <div class="section" id="confval-directive">
+    </head>
+    <body>
+        <!-- content start -->
+        <div class="section" id="confval-directive">
             <h1>Confval directive</h1>
 
             <dl class="confval">
-    <dt id="demo">
-        <code class="sig-name descname"><span class="pre">demo</span></code></dt>
-    <dd>
-        <div class="line-block">
-             <div class="line"><strong>Type:</strong>  <code>&quot;Hello World&quot;</code></div>
-             <div class="line"><strong>Required:</strong> true</div>
-            <div class="line"><strong>Custom Info:</strong> <strong>custom</strong></div>
-
-            </div>
-        <div class="confval-description">
-            <p>This is the confval <code>demo</code> content!</p><p>Another paragraph.</p>
-        </div>
-    </dd>
-</dl>
+                <dt id="demo">
+                    <code class="sig-name descname"><span class="pre">demo</span></code></dt>
+                <dd>
+                    <div class="line-block">
+                        <div class="line"><strong>Type:</strong>  <code>&quot;Hello World&quot;</code></div>
+                        <div class="line"><strong>Required:</strong> true</div>
+                        <div class="line"><strong>Custom Info:</strong> <strong>custom</strong></div>
+                    </div>
+                    <div class="confval-description">
+                        <p>This is the confval <code>demo</code> content!</p>
+                        <p>Another paragraph.</p>
+                    </div>
+                </dd>
+            </dl>
             <p>See option <a href="/another.html#demo">demo</a>.</p>
             <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/another.html#confval-directive">Confval directive</a></li>
-
-    </ul>
-</div>
-
-    </div>
-
-<!-- content end -->
-</body>
+                <ul class="menu-level">
+                    <li class="toc-item">
+                        <a href="/another.html#confval-directive">Confval directive</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+        <!-- content end -->
+    </body>
 </html>

--- a/tests/Integration/tests/directives/directive-glossary/expected/index.html
+++ b/tests/Integration/tests/directives/directive-glossary/expected/index.html
@@ -1,19 +1,17 @@
 <!-- content start -->
-    <div class="section" id="directive-tests">
-            <h1>Directive tests</h1>
+<div class="section" id="directive-tests">
+    <h1>Directive tests</h1>
 
-            <div class=""><dl>
-                        <dt>environment</dt>
+    <div class=""><dl>
+            <dt>environment</dt>
+            <dd>A structure where information about all documents under the root is
+                saved, and used for cross-referencing. The environment is pickled
+                after the parsing stage, so that successive runs only need to read
+                and parse new and changed documents.</dd>
 
-        <dd>A structure where information about all documents under the root is
-saved, and used for cross-referencing. The environment is pickled
-after the parsing stage, so that successive runs only need to read
-and parse new and changed documents.</dd>                        <dt>source directory</dt>
-
-        <dd>The directory which, including its subdirectories, contains all
-source files for one documentation project.</dd>    </dl>
+            <dt>source directory</dt>
+            <dd>The directory which, including its subdirectories, contains all
+                source files for one documentation project.</dd>
+        </dl></div>
 </div>
-
-    </div>
-
 <!-- content end -->

--- a/tests/Integration/tests/directives/directive-topic/expected/index.html
+++ b/tests/Integration/tests/directives/directive-topic/expected/index.html
@@ -1,14 +1,12 @@
 <!-- content start -->
-    <div class="section" id="directive-tests">
-            <h1>Directive tests</h1>
+<div class="section" id="directive-tests">
+    <h1>Directive tests</h1>
 
-
-<div class="topic someclass">
-    <p class="topic-title">This is the <strong>topic</strong></p>
-    <p>Lorem Ipsum Dolor</p><div class="rubric">Some Rubric</div>
-<p>Dolor sit!</p>
-</div>
-
+    <div class="topic someclass">
+        <p class="topic-title">This is the <strong>topic</strong></p>
+        <p>Lorem Ipsum Dolor</p>
+        <div class="rubric">Some Rubric</div>
+        <p>Dolor sit!</p>
     </div>
-
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/directives/directive-wrap/expected/index.html
+++ b/tests/Integration/tests/directives/directive-wrap/expected/index.html
@@ -1,9 +1,10 @@
 <!-- content start -->
-    <div class="section" id="directive-tests">
-            <h1>Directive tests</h1>
+<div class="section" id="directive-tests">
+    <h1>Directive tests</h1>
 
-                <div class="someclass"><p>Lorem Ipsum Dolor</p></div>
-
+    <div class="someclass">
+        <p>Lorem Ipsum Dolor</p>
     </div>
+</div>
 
 <!-- content end -->

--- a/tests/Integration/tests/graphs/plantuml-external/expected/index.html
+++ b/tests/Integration/tests/graphs/plantuml-external/expected/index.html
@@ -1,24 +1,26 @@
 <!-- content start -->
-    <div class="section" id="uml-directive">
-            <h1>Uml Directive</h1>
+<div class="section" id="uml-directive">
+    <h1>Uml Directive</h1>
 
-            <figure
+    <figure
         class="uml-diagram"
         style="width: 1000"    >
         75038c5ec593504a90a100f9668e1138
-    <figcaption>Figure 1-1: Application flow</figcaption></figure>
-            <figure
+        <figcaption>Figure 1-1: Application flow</figcaption></figure>
+    <figure
         class="uml-diagram"
         style="width: 1000"    >
         75038c5ec593504a90a100f9668e1138
-    <figcaption>Figure 1-1: Application flow</figcaption></figure>
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/Plantuml/index.html#uml-directive">Uml Directive</a></li>
+        <figcaption>Figure 1-1: Application flow</figcaption></figure>
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/Plantuml/index.html#uml-directive">Uml Directive</a>
+            </li>
 
-    </ul>
-</div>
-
+        </ul>
     </div>
+
+</div>
 
 <!-- content end -->

--- a/tests/Integration/tests/images/figure-relative/expected/index.html
+++ b/tests/Integration/tests/images/figure-relative/expected/index.html
@@ -1,57 +1,46 @@
 <!-- content start -->
-    <div class="section" id="document-title">
-            <h1>Document Title</h1>
+<div class="section" id="document-title">
+    <h1>Document Title</h1>
 
-            <p>Lorem Ipsum Dolor.</p>
-            <div class="section" id="a-local-image">
-            <h2>A local image</h2>
+    <p>Lorem Ipsum Dolor.</p>
+    <div class="section" id="a-local-image">
+        <h2>A local image</h2>
 
-            <figure>
-    <img
-    src="hero-illustration.svg"
-    width="400"            alt="Alternative text"        />
-
-
-
-                    <figcaption><p>Description</p>
-</figcaption>
-            </figure>
-
+        <figure>
+            <img
+            src="hero-illustration.svg"
+            width="400"            alt="Alternative text"        />
+            <figcaption>
+                <p>Description</p>
+            </figcaption>
+        </figure>
     </div>
 
-            <div class="section" id="an-image-with-absolute-paths">
-            <h2>An image with absolute paths</h2>
+    <div class="section" id="an-image-with-absolute-paths">
+        <h2>An image with absolute paths</h2>
 
-            <figure>
-    <img
-    src="images/hero2-illustration.svg"
-    width="400"            alt="Alternative text"        />
-
-
-
-                    <figcaption><p>Description</p>
-</figcaption>
-            </figure>
-
+        <figure>
+            <img
+            src="images/hero2-illustration.svg"
+            width="400"            alt="Alternative text"        />
+            <figcaption>
+                <p>Description</p>
+            </figcaption>
+        </figure>
     </div>
 
-            <div class="section" id="an-image-with-relative-paths">
-            <h2>An image with relative paths</h2>
+    <div class="section" id="an-image-with-relative-paths">
+        <h2>An image with relative paths</h2>
 
-            <figure>
-    <img
-    src="images/hero2-illustration.svg"
-    width="400"            alt="Alternative text"        />
-
-
-
-                    <figcaption><p>Description</p>
-</figcaption>
-            </figure>
-
-
+        <figure>
+            <img
+            src="images/hero2-illustration.svg"
+            width="400"            alt="Alternative text"        />
+            <figcaption>
+                <p>Description</p>
+            </figcaption>
+        </figure>
     </div>
-
-    </div>
+</div>
 
 <!-- content end -->

--- a/tests/Integration/tests/images/figure-relative/expected/subfolder/subpage.html
+++ b/tests/Integration/tests/images/figure-relative/expected/subfolder/subpage.html
@@ -1,41 +1,32 @@
 <!-- content start -->
-    <div class="section" id="subpage">
-            <h1>Subpage</h1>
+<div class="section" id="subpage">
+    <h1>Subpage</h1>
 
-            <p>Lorem Ipsum Dolor.</p>
-            <div class="section" id="an-image-with-absolute-paths">
-            <h2>An image with absolute paths</h2>
+    <p>Lorem Ipsum Dolor.</p>
+    <div class="section" id="an-image-with-absolute-paths">
+        <h2>An image with absolute paths</h2>
 
-            <figure>
-    <img
-    src="../images/hero2-illustration.svg"
-    width="400"            alt="Alternative text"        />
-
-
-
-                    <figcaption><p>Description</p>
-</figcaption>
-            </figure>
-
+        <figure>
+            <img
+            src="../images/hero2-illustration.svg"
+            width="400"            alt="Alternative text"        />
+            <figcaption>
+                <p>Description</p>
+            </figcaption>
+        </figure>
     </div>
 
-            <div class="section" id="an-image-with-relative-paths">
-            <h2>An image with relative paths</h2>
+    <div class="section" id="an-image-with-relative-paths">
+        <h2>An image with relative paths</h2>
 
-            <figure>
-    <img
-    src="../images/hero2-illustration.svg"
-    width="400"            alt="Alternative text"        />
-
-
-
-                    <figcaption><p>Description</p>
-</figcaption>
-            </figure>
-
-
+        <figure>
+            <img
+            src="../images/hero2-illustration.svg"
+            width="400"            alt="Alternative text"        />
+            <figcaption>
+                <p>Description</p>
+            </figcaption>
+        </figure>
     </div>
-
-    </div>
-
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/images/image-target/expected/index.html
+++ b/tests/Integration/tests/images/image-target/expected/index.html
@@ -1,61 +1,59 @@
 <!-- content start -->
-    <div class="section" id="document-title">
-            <a id="start"></a>
-            <h1>Document Title</h1>
+<div class="section" id="document-title">
+    <a id="start"></a>
+    <h1>Document Title</h1>
 
-            <p>Lorem Ipsum Dolor.</p>
-            <div class="section" id="link-image-to-external-url">
-            <h2>Link image to external URL</h2>
+    <p>Lorem Ipsum Dolor.</p>
+    <div class="section" id="link-image-to-external-url">
+        <h2>Link image to external URL</h2>
 
-            <a href="https://example.org/"><img
-    src="images/hero2-illustration.svg"
-    width="400"            alt="Alternative text"        />
-</a>
+        <a href="https://example.org/"><img
+            src="images/hero2-illustration.svg"
+            width="400"            alt="Alternative text"        />
+        </a>
     </div>
 
-            <div class="section" id="link-image-to-email">
-            <h2>Link image to email</h2>
+    <div class="section" id="link-image-to-email">
+        <h2>Link image to email</h2>
 
-            <a href="mailto:mail@example.org"><img
-    src="images/hero2-illustration.svg"
-    width="400"            alt="Alternative text"        />
-</a>
+        <a href="mailto:mail@example.org"><img
+            src="images/hero2-illustration.svg"
+            width="400"            alt="Alternative text"        />
+        </a>
     </div>
 
-            <div class="section" id="link-image-to-relative-url">
-            <h2>Link image to relative URL</h2>
+    <div class="section" id="link-image-to-relative-url">
+        <h2>Link image to relative URL</h2>
 
-            <a href="subfolder/subpage.html"><img
-    src="images/hero2-illustration.svg"
-    width="400"            alt="Alternative text"        />
-</a>
+        <a href="subfolder/subpage.html"><img
+            src="images/hero2-illustration.svg"
+            width="400"            alt="Alternative text"        />
+        </a>
     </div>
 
-            <div class="section" id="link-image-to-reference">
-            <h2>Link image to reference</h2>
+    <div class="section" id="link-image-to-reference">
+        <h2>Link image to reference</h2>
 
-            <a href="#start"><img
-    src="images/hero2-illustration.svg"
-    width="400"            alt="Alternative text"        />
-</a>
+        <a href="#start"><img
+            src="images/hero2-illustration.svg"
+            width="400"            alt="Alternative text"        />
+        </a>
     </div>
 
-            <div class="section" id="link-image-to-reference">
-            <h2>Link image to reference</h2>
+    <div class="section" id="link-image-to-reference">
+        <h2>Link image to reference</h2>
 
-            <a href="#document-title"><img
-    src="images/hero2-illustration.svg"
-    width="400"            alt="Alternative text"        />
-</a>
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="subfolder/subpage.html#subpage">Subpage</a></li>
-
-    </ul>
+        <a href="#document-title"><img
+            src="images/hero2-illustration.svg"
+            width="400"            alt="Alternative text"        />
+        </a>
+        <div class="toc">
+            <ul class="menu-level">
+                <li class="toc-item">
+                    <a href="subfolder/subpage.html#subpage">Subpage</a>
+                </li>
+            </ul>
+        </div>
+    </div>
 </div>
-
-    </div>
-
-    </div>
-
 <!-- content end -->

--- a/tests/Integration/tests/inline-combinations/expected/index.html
+++ b/tests/Integration/tests/inline-combinations/expected/index.html
@@ -1,13 +1,12 @@
 <!-- content start -->
-    <div class="section" id="document-title">
-            <a id="start"></a>
-            <h1>Document Title</h1>
+<div class="section" id="document-title">
+    <a id="start"></a>
+    <h1>Document Title</h1>
 
-            <p>Lorem Ipsum Dolor.</p>
-            <p><strong>all</strong>&#32;<a href="/index.html#start">data</a></p>
-            <p><em>all</em>&#32;<a href="/index.html#start">data</a></p>
-            <p><strong>bold</strong> and <em>italic</em></p>
-            <p><strong>bold</strong>&#32;<em>italic</em></p>
-    </div>
-
+    <p>Lorem Ipsum Dolor.</p>
+    <p><strong>all</strong> <a href="/index.html#start">data</a></p>
+    <p><em>all</em> <a href="/index.html#start">data</a></p>
+    <p><strong>bold</strong> and <em>italic</em></p>
+    <p><strong>bold</strong> <em>italic</em></p>
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/inline-combinations/expected/index.html
+++ b/tests/Integration/tests/inline-combinations/expected/index.html
@@ -1,0 +1,13 @@
+<!-- content start -->
+    <div class="section" id="document-title">
+            <a id="start"></a>
+            <h1>Document Title</h1>
+
+            <p>Lorem Ipsum Dolor.</p>
+            <p><strong>all</strong>&#32;<a href="/index.html#start">data</a></p>
+            <p><em>all</em>&#32;<a href="/index.html#start">data</a></p>
+            <p><strong>bold</strong> and <em>italic</em></p>
+            <p><strong>bold</strong>&#32;<em>italic</em></p>
+    </div>
+
+<!-- content end -->

--- a/tests/Integration/tests/inline-combinations/input/index.rst
+++ b/tests/Integration/tests/inline-combinations/input/index.rst
@@ -1,0 +1,15 @@
+..  _start:
+
+==============
+Document Title
+==============
+
+Lorem Ipsum Dolor.
+
+**all** :ref:`data <start>`
+
+*all* :ref:`data <start>`
+
+**bold** and *italic*
+
+**bold** *italic*

--- a/tests/Integration/tests/lists/big-numbers/expected/index.html
+++ b/tests/Integration/tests/lists/big-numbers/expected/index.html
@@ -1,25 +1,27 @@
 <!-- content start -->
-    <div class="section" id="some-document">
-            <h1>Some Document</h1>
+<div class="section" id="some-document">
+    <h1>Some Document</h1>
 
+    <ol class="bignums">
+        <li>
+            <p>First Item</p>
+            <p>This is the body text</p>
+        </li>
+        <li>
+            <p>Second Item</p>
+            <p>More body text</p>
+        </li>
+    </ol>
 
-
-<ol class="bignums">
-    <li><p>First Item</p><p>This is the body text</p></li>
-
-    <li><p>Second Item</p><p>More body text</p></li>
-
-</ol>
-
-
-
-<ol class="bignums-xxl">
-    <li><p>And then with xxl big numbers</p><p>This is the body text</p></li>
-
-    <li><p>The second xxl item</p><p>More body text ....</p></li>
-
-</ol>
-
-    </div>
-
+    <ol class="bignums-xxl">
+        <li>
+            <p>And then with xxl big numbers</p>
+            <p>This is the body text</p>
+        </li>
+        <li>
+            <p>The second xxl item</p>
+            <p>More body text ....</p>
+        </li>
+    </ol>
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/lists/definition-lists/expected/index.html
+++ b/tests/Integration/tests/lists/definition-lists/expected/index.html
@@ -1,18 +1,22 @@
 <!-- content start -->
-    <div class="section" id="definition-list-with-textrole-in-term">
-            <h1>Definition list with textrole in term</h1>
+<div class="section" id="definition-list-with-textrole-in-term">
+    <h1>Definition list with textrole in term</h1>
 
-            <dl>
-                        <dt><code>One definition</code></dt>
+    <dl>
+        <dt><code>One definition</code></dt>
+        <dd>
+            <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam</p>
+            <p>Nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat.</p>
+        </dd>
 
-        <dd><p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam</p><p>Nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat.</p></dd>                        <dt><code>Another definition</code></dt>
-
-        <dd><div class="admonition note">
-            <p>sed diam voluptua. At vero eos et accusam et justo duo dolores
-et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est.</p>
+        <dt><code>Another definition</code></dt>
+        <dd>
+            <div class="admonition note">
+                <p>sed diam voluptua. At vero eos et accusam et justo duo dolores
+                et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est.</p>
+            </div>
+            <p>Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur.</p>
+        </dd>
+    </dl>
 </div>
-<p>Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur.</p></dd>    </dl>
-
-    </div>
-
 <!-- content end -->

--- a/tests/Integration/tests/lists/field-list-empty-lines/expected/index.html
+++ b/tests/Integration/tests/lists/field-list-empty-lines/expected/index.html
@@ -1,35 +1,33 @@
 <!-- content start -->
-    <div class="section" id="test">
-            <h1>Test</h1>
+<div class="section" id="test">
+    <h1>Test</h1>
 
-            <table>
-            <tr>
+    <table>
+        <tr>
             <th>Version</th>
-
             <td>
-                            </td>
+            </td>
         </tr>
-            <tr>
+        <tr>
             <th>Language</th>
-
             <td>
-                <p>en</p>            </td>
+                <p>en</p>
+            </td>
         </tr>
-            <tr>
+        <tr>
             <th>Author</th>
-
             <td>
-                <p>Contributors</p>            </td>
+                <p>Contributors</p>
+            </td>
         </tr>
-            <tr>
+        <tr>
             <th>Rendered</th>
-
             <td>
-                <p>Sun, 01 Jan 2023 12:00:00 +0000</p>            </td>
+                <p>Sun, 01 Jan 2023 12:00:00 +0000</p>
+            </td>
         </tr>
     </table>
 
-            <p>Something else.</p>
-    </div>
-
+    <p>Something else.</p>
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/lists/lists-nested/expected/index.html
+++ b/tests/Integration/tests/lists/lists-nested/expected/index.html
@@ -1,28 +1,18 @@
 <!-- content start -->
-    <div class="section" id="document-title">
-            <h1>Document Title</h1>
+<div class="section" id="document-title">
+    <h1>Document Title</h1>
 
-
-
-<ul>
-    <li>List item 1</li>
-
-    <li>This is list item two</li>
-
-    <li>And finally, list item three.</li>
-
-    <li><p>Another list</p>
-
-<ul>
-    <li>that is indented</li>
-
-    <li>indented list item</li>
-
-</ul>
-</li>
-
-</ul>
-
-    </div>
-
+    <ul>
+        <li>List item 1</li>
+        <li>This is list item two</li>
+        <li>And finally, list item three.</li>
+        <li>
+            <p>Another list</p>
+            <ul>
+                <li>that is indented</li>
+                <li>indented list item</li>
+            </ul>
+        </li>
+    </ul>
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/lists/numbered-lists/expected/index.html
+++ b/tests/Integration/tests/lists/numbered-lists/expected/index.html
@@ -1,32 +1,20 @@
 <!-- content start -->
-    <div class="section" id="document-title">
-            <h1>Document Title</h1>
+<div class="section" id="document-title">
+    <h1>Document Title</h1>
 
-
-
-<ol>
-    <li>First numbered list item.</li>
-
-    <li>This is the second numbered list item.</li>
-
-    <li>and then the third numbered list item.</li>
-
-    <li>First numbered list item.</li>
-
-    <li>This is the second numbered list item.</li>
-
-    <li><p>and then the third numbered list item.</p>
-
-<ol>
-    <li>This is an indented numbered list.</li>
-
-    <li>This is the second item.</li>
-
-</ol>
-</li>
-
-</ol>
-
-    </div>
-
+    <ol>
+        <li>First numbered list item.</li>
+        <li>This is the second numbered list item.</li>
+        <li>and then the third numbered list item.</li>
+        <li>First numbered list item.</li>
+        <li>This is the second numbered list item.</li>
+        <li>
+            <p>and then the third numbered list item.</p>
+            <ol>
+                <li>This is an indented numbered list.</li>
+                <li>This is the second item.</li>
+            </ol>
+        </li>
+    </ol>
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/markdown/blockquote-md/expected/index.html
+++ b/tests/Integration/tests/markdown/blockquote-md/expected/index.html
@@ -1,40 +1,47 @@
 <!-- content start -->
-    <div class="section" id="markdown-blockquotes">
-            <h1>Markdown Blockquotes</h1>
+<div class="section" id="markdown-blockquotes">
+    <h1>Markdown Blockquotes</h1>
 
-            <blockquote><p>This is a blockquote.It can span multiple lines.</p></blockquote>
+    <blockquote>
+        <p>This is a blockquote.It can span multiple lines.</p>
+    </blockquote>
 
-            <div class="section" id="blockquotes-with-multiple-paragraphs">
-            <h2>Blockquotes with Multiple Paragraphs</h2>
+    <div class="section" id="blockquotes-with-multiple-paragraphs">
+        <h2>Blockquotes with Multiple Paragraphs</h2>
 
-            <blockquote><p>Dorothy followed her through many of the beautiful rooms in her castle.</p><p>The Witch bade her clean the pots and kettles and sweep the floor and keep the fire fed with wood.</p></blockquote>
-
+        <blockquote>
+            <p>Dorothy followed her through many of the beautiful rooms in her castle.</p>
+            <p>The Witch bade her clean the pots and kettles and sweep the floor and keep the fire fed with wood.</p>
+        </blockquote>
     </div>
 
-            <div class="section" id="blockquotes-with-other-elements">
-            <h2>Blockquotes with Other Elements</h2>
+    <div class="section" id="blockquotes-with-other-elements">
+        <h2>Blockquotes with Other Elements</h2>
 
-            <blockquote><p>The quarterly results look great!</p>
-
-<ul>
-    <li class="dash"><p>Revenue was off the chart.</p></li>
-
-    <li class="dash"><p>Profits were higher than ever.</p></li>
-
-</ul>
-<p><em>Everything</em> is going according to <strong>plan</strong>.</p></blockquote>
-
+        <blockquote>
+            <p>The quarterly results look great!</p>
+            <ul>
+                <li class="dash">
+                    <p>Revenue was off the chart.</p>
+                </li>
+                <li class="dash">
+                    <p>Profits were higher than ever.</p>
+                </li>
+            </ul>
+            <p><em>Everything</em> is going according to <strong>plan</strong>.</p>
+        </blockquote>
     </div>
 
-            <div class="section" id="blockquotes-best-practices">
-            <h2>Blockquotes Best Practices</h2>
+    <div class="section" id="blockquotes-best-practices">
+        <h2>Blockquotes Best Practices</h2>
 
-            <p>Try to put a blank line before...</p>
-            <blockquote><p>This is a blockquote</p></blockquote>
+        <p>Try to put a blank line before...</p>
+        <blockquote>
+            <p>This is a blockquote</p>
+        </blockquote>
 
-            <p>...and after a blockquote.</p>
+        <p>...and after a blockquote.</p>
     </div>
-
-    </div>
+</div>
 
 <!-- content end -->

--- a/tests/Integration/tests/markdown/link-page-md/expected/index.html
+++ b/tests/Integration/tests/markdown/link-page-md/expected/index.html
@@ -1,19 +1,18 @@
 <!-- content start -->
-    <div class="section" id="markdown-with-links">
-            <h1>Markdown with links</h1>
+<div class="section" id="markdown-with-links">
+    <h1>Markdown with links</h1>
 
-            <p>This is a Markdown document with some basic formatting.</p>
-
-
-<ul>
-    <li><p><a href="/page1.html">Page 1</a></p></li>
-
-    <li><p><a href="/page1.html">Page 1</a></p></li>
-
-    <li><p><a href="/subpages/subpage1.html">Subpage 1</a></p></li>
-
-</ul>
-
-    </div>
-
+    <p>This is a Markdown document with some basic formatting.</p>
+    <ul>
+        <li>
+            <p><a href="/page1.html">Page 1</a></p>
+        </li>
+        <li>
+            <p><a href="/page1.html">Page 1</a></p>
+        </li>
+        <li>
+            <p><a href="/subpages/subpage1.html">Subpage 1</a></p>
+        </li>
+    </ul>
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/markdown/link-page-md/expected/subpages/index.html
+++ b/tests/Integration/tests/markdown/link-page-md/expected/subpages/index.html
@@ -1,29 +1,30 @@
 <!-- content start -->
-    <div class="section" id="page-1">
-            <h1>Page 1</h1>
+<div class="section" id="page-1">
+    <h1>Page 1</h1>
 
-            <p>This is a Markdown document with some basic formatting.</p>
-    </div>
+    <p>This is a Markdown document with some basic formatting.</p>
+</div>
 
 <div class="section" id="markdown-with-links">
-            <h1>Markdown with links</h1>
+    <h1>Markdown with links</h1>
 
-            <p>This is a Markdown document with some basic formatting.</p>
-
-
-<ul>
-    <li><p><a href="/subpages/subpage1.html">Subpage 1</a></p></li>
-
-    <li><p><a href="/page1.html">Page 1</a></p></li>
-
-    <li><p><a href="/page1.html">Page 1</a></p></li>
-
-    <li><p><a href="/page1.html">Page 1</a></p></li>
-
-    <li><p><a href="/page1.html">Page 1</a></p></li>
-
-</ul>
-
-    </div>
-
+    <p>This is a Markdown document with some basic formatting.</p>
+    <ul>
+        <li>
+            <p><a href="/subpages/subpage1.html">Subpage 1</a></p>
+        </li>
+        <li>
+            <p><a href="/page1.html">Page 1</a></p>
+        </li>
+        <li>
+            <p><a href="/page1.html">Page 1</a></p>
+        </li>
+        <li>
+            <p><a href="/page1.html">Page 1</a></p>
+        </li>
+        <li>
+            <p><a href="/page1.html">Page 1</a></p>
+        </li>
+    </ul>
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/markdown/lists-md/expected/index.html
+++ b/tests/Integration/tests/markdown/lists-md/expected/index.html
@@ -1,55 +1,53 @@
 <!-- content start -->
-    <div class="section" id="markdown-lists">
-            <h1>Markdown Lists</h1>
+<div class="section" id="markdown-lists">
+    <h1>Markdown Lists</h1>
 
-            <div class="section" id="unordered">
-            <h2>Unordered</h2>
+    <div class="section" id="unordered">
+        <h2>Unordered</h2>
 
-
-
-<ul>
-    <li class="dash"><p>Item 1</p></li>
-
-    <li class="dash"><p>Item 2</p>
-
-<ul>
-    <li class="dash"><p>Subitem A</p></li>
-
-    <li class="dash"><p>Subitem B</p></li>
-
-</ul>
-</li>
-
-    <li class="dash"><p>Item 3</p></li>
-
-</ul>
-
+        <ul>
+            <li class="dash">
+                <p>Item 1</p>
+            </li>
+            <li class="dash">
+                <p>Item 2</p>
+                <ul>
+                    <li class="dash">
+                        <p>Subitem A</p>
+                    </li>
+                    <li class="dash">
+                        <p>Subitem B</p>
+                    </li>
+                </ul>
+            </li>
+            <li class="dash">
+                <p>Item 3</p>
+            </li>
+        </ul>
     </div>
 
-            <div class="section" id="ordered">
-            <h2>Ordered</h2>
+    <div class="section" id="ordered">
+        <h2>Ordered</h2>
 
-
-
-<ol>
-    <li><p>First item</p></li>
-
-    <li><p>Second item</p>
-
-<ol>
-    <li><p>Subitem A</p></li>
-
-    <li><p>Subitem B</p></li>
-
-</ol>
-</li>
-
-    <li><p>Third item</p></li>
-
-</ol>
-
+        <ol>
+            <li>
+                <p>First item</p>
+            </li>
+            <li>
+                <p>Second item</p>
+                <ol>
+                    <li>
+                        <p>Subitem A</p>
+                    </li>
+                    <li>
+                        <p>Subitem B</p>
+                    </li>
+                </ol>
+            </li>
+            <li>
+                <p>Third item</p>
+            </li>
+        </ol>
     </div>
-
-    </div>
-
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/markdown/readme-md/expected/index.html
+++ b/tests/Integration/tests/markdown/readme-md/expected/index.html
@@ -1,139 +1,144 @@
 <!-- content start -->
-    <div class="section" id="child-s-swing-usage-guide">
-            <h1>Child&#039;s Swing Usage Guide</h1>
+<div class="section" id="child-s-swing-usage-guide">
+    <h1>Child&#039;s Swing Usage Guide</h1>
 
-            <p>Welcome to the world of fun and laughter with our child&#039;s swing! Follow thesimple steps below to ensure a safe and enjoyable experience for your littleone.</p>
-            <div class="section" id="table-of-contents">
-            <h2>Table of Contents</h2>
+    <p>Welcome to the world of fun and laughter with our child&#039;s swing! Follow thesimple steps below to ensure a safe and enjoyable experience for your littleone.</p>
+    <div class="section" id="table-of-contents">
+        <h2>Table of Contents</h2>
 
+        <ul>
+            <li class="dash">
+                <p><a href="#installation">Installation</a></p>
+            </li>
+            <li class="dash">
+                <p><a href="#usage">Usage</a></p>
+            </li>
+            <li class="dash">
+                <p><a href="#safety-guidelines">Safety Guidelines</a></p>
+            </li>
+            <li class="dash">
+                <p><a href="#maintenance">Maintenance</a></p>
+            </li>
+            <li class="dash">
+                <p><a href="#troubleshooting">Troubleshooting</a></p>
+            </li>
+        </ul>
 
-
-<ul>
-    <li class="dash"><p><a href="#installation">Installation</a></p></li>
-
-    <li class="dash"><p><a href="#usage">Usage</a></p></li>
-
-    <li class="dash"><p><a href="#safety-guidelines">Safety Guidelines</a></p></li>
-
-    <li class="dash"><p><a href="#maintenance">Maintenance</a></p></li>
-
-    <li class="dash"><p><a href="#troubleshooting">Troubleshooting</a></p></li>
-
-</ul>
-
-            <hr />
-
+        <hr />
     </div>
 
-            <div class="section" id="installation">
-            <h2>Installation</h2>
+    <div class="section" id="installation">
+        <h2>Installation</h2>
 
-            <p><img src="https://upload.wikimedia.org/wikipedia/commons/a/a3/Forgiveness_5.gif" alt="Swing Image"/></p>
-
-
-<ol>
-    <li><p><strong>Choose a Sturdy Location:</strong> Select a location with a sturdy beam or swingset structure capable of supporting the weight of the swing and the child.</p></li>
-
-    <li><p><strong>Securely Attach the Swing:</strong> Use strong and reliable <a href="https://example.com/ropes">ropes</a>or chains to securely attach the swing to the chosen location. Double-checkthe knots or hardware to ensure they are tight and safe.</p></li>
-
-    <li><p><strong>Adjust the Height:</strong> Adjust the height of the swing to a level that iscomfortable for your child. Ensure that it is not too high or too low.</p></li>
-
-</ol>
-
+        <p><img src="https://upload.wikimedia.org/wikipedia/commons/a/a3/Forgiveness_5.gif" alt="Swing Image"/></p>
+        <ol>
+            <li>
+                <p><strong>Choose a Sturdy Location:</strong> Select a location with a sturdy beam or swingset structure capable of supporting the weight of the swing and the child.</p>
+            </li>
+            <li>
+                <p><strong>Securely Attach the Swing:</strong> Use strong and reliable <a href="https://example.com/ropes">ropes</a>or chains to securely attach the swing to the chosen location. Double-checkthe knots or hardware to ensure they are tight and safe.</p>
+            </li>
+            <li>
+                <p><strong>Adjust the Height:</strong> Adjust the height of the swing to a level that iscomfortable for your child. Ensure that it is not too high or too low.</p>
+            </li>
+        </ol>
     </div>
 
-            <div class="section" id="usage">
-            <h2>Usage</h2>
+    <div class="section" id="usage">
+        <h2>Usage</h2>
 
-
-
-<ol>
-    <li><p><strong>Place the Child in the Swing:</strong> Gently place your child in the swing seat,ensuring they are properly seated and secure.</p></li>
-
-    <li><p><strong>Hold onto the Swing:</strong> Provide support and hold onto the swing until yourchild is comfortably seated and ready to swing.</p></li>
-
-    <li><p><strong>Start Swinging:</strong> Give a gentle push to start the swinging motion. Observeyour child&#039;s comfort level and adjust the swinging speed accordingly.</p><pre><code class="language-">procedure startSwinging(swing, child)
+        <ol>
+            <li>
+                <p><strong>Place the Child in the Swing:</strong> Gently place your child in the swing seat,ensuring they are properly seated and secure.</p>
+            </li>
+            <li>
+                <p><strong>Hold onto the Swing:</strong> Provide support and hold onto the swing until yourchild is comfortably seated and ready to swing.</p>
+            </li>
+            <li>
+                <p><strong>Start Swinging:</strong> Give a gentle push to start the swinging motion. Observeyour child&#039;s comfort level and adjust the swinging speed accordingly.</p>
+                    <pre><code class="language-">procedure startSwinging(swing, child)
     while child.isComfortable()
         swing.giveGentlePush()
         waitForNextIteration()
     end while
 end procedure
+                </code></pre>
+            </li>
+            <li>
+                <p><strong>Supervise Always:</strong> Always supervise your child while they are using theswing. Ensure they are using it safely and within the recommended age and weightlimits.</p>
+            </li>
+        </ol>
 
-</code></pre></li>
+        <blockquote>
+            <p>&quot;Swinging is not just a physical activity; it&#039;s a journey into the world ofimagination and joy.&quot;</p>
+        </blockquote>
 
-    <li><p><strong>Supervise Always:</strong> Always supervise your child while they are using theswing. Ensure they are using it safely and within the recommended age and weightlimits.</p></li>
-
-</ol>
-
-            <blockquote><p>&quot;Swinging is not just a physical activity; it&#039;s a journey into the world ofimagination and joy.&quot;</p></blockquote>
-
-            <div class="section" id="additional-tips">
+        <div class="section" id="additional-tips">
             <h3>Additional Tips:</h3>
 
-
-
-<ul>
-    <li class="dash"><p>Bring your child&#039;s favorite toys to make swinging even more enjoyable.</p></li>
-
-    <li class="dash"><p>Consider creating a soft landing area with cushions or grass underneath the swing.</p></li>
-
-</ul>
-
+            <ul>
+                <li class="dash">
+                    <p>Bring your child&#039;s favorite toys to make swinging even more enjoyable.</p>
+                </li>
+                <li class="dash">
+                    <p>Consider creating a soft landing area with cushions or grass underneath the swing.</p>
+                </li>
+            </ul>
+        </div>
     </div>
 
+    <div class="section" id="safety-guidelines">
+        <h2>Safety Guidelines</h2>
+
+        <ol>
+            <li>
+                <p><strong>Check Hardware Regularly:</strong> Periodically inspect the ropes or chains, aswell as any hardware used to attach the swing. Replace any damaged or worn-outparts immediately.</p>
+            </li>
+            <li>
+                <p><strong>Set Age and Weight Limits:</strong> Follow the manufacturer&#039;s recommended age andweight limits for the swing. Do not exceed these limits to ensure safety.</p>
+            </li>
+            <li>
+                <p><strong>Use Proper Attire:</strong> Encourage your child to wear appropriate clothing,including closed-toe shoes, to prevent any injuries.</p>
+            </li>
+            <li>
+                <p><strong>No Rough Play:</strong> Instruct your child not to engage in rough play or attemptto stand up in the swing.</p>
+            </li>
+        </ol>
     </div>
 
-            <div class="section" id="safety-guidelines">
-            <h2>Safety Guidelines</h2>
+    <div class="section" id="maintenance">
+        <h2>Maintenance</h2>
 
-
-
-<ol>
-    <li><p><strong>Check Hardware Regularly:</strong> Periodically inspect the ropes or chains, aswell as any hardware used to attach the swing. Replace any damaged or worn-outparts immediately.</p></li>
-
-    <li><p><strong>Set Age and Weight Limits:</strong> Follow the manufacturer&#039;s recommended age andweight limits for the swing. Do not exceed these limits to ensure safety.</p></li>
-
-    <li><p><strong>Use Proper Attire:</strong> Encourage your child to wear appropriate clothing,including closed-toe shoes, to prevent any injuries.</p></li>
-
-    <li><p><strong>No Rough Play:</strong> Instruct your child not to engage in rough play or attemptto stand up in the swing.</p></li>
-
-</ol>
-
+        <ol>
+            <li>
+                <p><strong>Clean the Swing:</strong> Wipe down the swing seat regularly to keep it clean andfree from dirt or debris.</p>
+            </li>
+            <li>
+                <p><strong>Inspect for Wear:</strong> Check the swing&#039;s components for signs of wear ordamage. Replace any worn-out parts promptly.</p>
+            </li>
+            <li>
+                <p><strong>Tighten Loose Hardware:</strong> Ensure that all nuts and bolts are securelytightened to maintain stability.</p>
+            </li>
+        </ol>
     </div>
 
-            <div class="section" id="maintenance">
-            <h2>Maintenance</h2>
+    <div class="section" id="troubleshooting">
+        <h2>Troubleshooting</h2>
 
+        <ul>
+            <li class="dash">
+                <p><strong>Swing Doesn&#039;t Move Smoothly:</strong> Check for any knots or tangles in the ropesor chains. Untangle and ensure a smooth swinging motion.</p>
+            </li>
+            <li class="dash">
+                <p><strong>Unusual Sounds:</strong> If you hear any creaking or unusual sounds, inspect thehardware for any loose or damaged parts.</p>
+                <p>If you hear screaming or crying, untangle the child.</p>
+            </li>
+            <li class="dash">
+                <p><strong>Uneven Swinging:</strong> Adjust the height of the swing to achieve a balanced andeven swinging motion.</p>
+            </li>
+        </ul>
 
-
-<ol>
-    <li><p><strong>Clean the Swing:</strong> Wipe down the swing seat regularly to keep it clean andfree from dirt or debris.</p></li>
-
-    <li><p><strong>Inspect for Wear:</strong> Check the swing&#039;s components for signs of wear ordamage. Replace any worn-out parts promptly.</p></li>
-
-    <li><p><strong>Tighten Loose Hardware:</strong> Ensure that all nuts and bolts are securelytightened to maintain stability.</p></li>
-
-</ol>
-
+        <p>Remember, safety first! Enjoy your time on the swing with your little one.</p>
     </div>
-
-            <div class="section" id="troubleshooting">
-            <h2>Troubleshooting</h2>
-
-
-
-<ul>
-    <li class="dash"><p><strong>Swing Doesn&#039;t Move Smoothly:</strong> Check for any knots or tangles in the ropesor chains. Untangle and ensure a smooth swinging motion.</p></li>
-
-    <li class="dash"><p><strong>Unusual Sounds:</strong> If you hear any creaking or unusual sounds, inspect thehardware for any loose or damaged parts.</p><p>If you hear screaming or crying, untangle the child.</p></li>
-
-    <li class="dash"><p><strong>Uneven Swinging:</strong> Adjust the height of the swing to achieve a balanced andeven swinging motion.</p></li>
-
-</ul>
-
-            <p>Remember, safety first! Enjoy your time on the swing with your little one.</p>
-    </div>
-
-    </div>
-
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/navigation/breadcrumb/expected/index.html
+++ b/tests/Integration/tests/navigation/breadcrumb/expected/index.html
@@ -1,49 +1,81 @@
 <!-- content start -->
-    <div class="section" id="document-title">
-            <h1>Document Title</h1>
+<div class="section" id="document-title">
+    <h1>Document Title</h1>
 
-            <nav aria-label="breadcrumb">
-                <span class="breadcrumb active level-0">Document Title</span>
-        </nav>
+    <nav aria-label="breadcrumb">
+        <span class="breadcrumb active level-0">Document Title</span>
+    </nav>
 
-            <p>Lorem Ipsum Dolor.</p>
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
+    <p>Lorem Ipsum Dolor.</p>
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/page1.html#page-1">Page 1</a>
+            </li>
 
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
+            <li class="toc-item">
+                <a href="/page2.html#page-2">Page 2</a>
+            </li>
 
-    <li class="toc-item"><a href="/level-1-1/index.html#level-1-1">Level 1-1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a></li>
+            <li class="toc-item">
+                <a href="/level-1-1/index.html#level-1-1">Level 1-1</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a>
+                    </li>
 
-            <li class="toc-item"><a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a></li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a>
+                    </li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a></li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>
+                        <ul class="menu-level-2">
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a>
+                            </li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a></li>
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a>
+                            </li>
 
-                    </ul></li>
+                        </ul>
+                    </li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>
+                        <ul class="menu-level-2">
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a>
+                            </li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a></li>
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-2/subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a>
+                            </li>
 
-                    </ul></li>
+                        </ul>
+                    </li>
 
-                    </ul></li>
+                </ul>
+            </li>
 
-    <li class="toc-item"><a href="/level-1-2/index.html#level-1-2">Level 1-2</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
+            <li class="toc-item">
+                <a href="/level-1-2/index.html#level-1-2">Level 1-2</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a>
+                    </li>
 
-            <li class="toc-item"><a href="/level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a></li>
+                    <li class="toc-item">
+                        <a href="/level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a>
+                    </li>
 
-                    </ul></li>
+                </ul>
+            </li>
 
-    </ul>
-</div>
-
+        </ul>
     </div>
+
+</div>
 
 <!-- content end -->

--- a/tests/Integration/tests/navigation/breadcrumb/expected/page1.html
+++ b/tests/Integration/tests/navigation/breadcrumb/expected/page1.html
@@ -1,66 +1,98 @@
 <!-- content start -->
-    <div class="section" id="page-1">
-            <h1>Page 1</h1>
+<div class="section" id="page-1">
+    <h1>Page 1</h1>
 
-            <nav aria-label="breadcrumb">
-    <a href="/index.html"
-               class="breadcrumb level-0">Document Title</a> &gt;
-                    <span class="breadcrumb active level-1">Page 1</span>
-        </nav>
+    <nav aria-label="breadcrumb">
+        <a href="/index.html"
+            class="breadcrumb level-0">Document Title</a> &gt;
+        <span class="breadcrumb active level-1">Page 1</span>
+    </nav>
 
-            <p>Lorem Ipsum Dolor.</p>
-            <div class="menu">
-    <ul class="menu-level">
-    <li class="toc-item current active"><a href="/page1.html#page-1">Page 1</a></li>
+    <p>Lorem Ipsum Dolor.</p>
+    <div class="menu">
+        <ul class="menu-level">
+            <li class="toc-item current active">
+                <a href="/page1.html#page-1">Page 1</a>
+            </li>
 
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
+            <li class="toc-item">
+                <a href="/page2.html#page-2">Page 2</a>
+            </li>
 
-    <li class="toc-item"><a href="/level-1-1/index.html#level-1-1">Level 1-1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a></li>
+            <li class="toc-item">
+                <a href="/level-1-1/index.html#level-1-1">Level 1-1</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a>
+                    </li>
 
-            <li class="toc-item"><a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a></li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a>
+                    </li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a></li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>
+                        <ul class="menu-level-2">
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a>
+                            </li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a></li>
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a>
+                            </li>
 
-                    </ul></li>
+                        </ul>
+                    </li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>
+                        <ul class="menu-level-2">
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a>
+                            </li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a></li>
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-2/subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a>
+                            </li>
 
-                    </ul></li>
+                        </ul>
+                    </li>
 
-                    </ul></li>
+                </ul>
+            </li>
 
-    <li class="toc-item"><a href="/level-1-2/index.html#level-1-2">Level 1-2</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
+            <li class="toc-item">
+                <a href="/level-1-2/index.html#level-1-2">Level 1-2</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a>
+                    </li>
 
-            <li class="toc-item"><a href="/level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a></li>
+                    <li class="toc-item">
+                        <a href="/level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a>
+                    </li>
 
-                    </ul></li>
+                </ul>
+            </li>
 
-    </ul>
-</div>
+        </ul>
+    </div>
 
-            <div class="section" id="page-1-level-2">
-            <h2>Page 1 Level 2</h2>
+    <div class="section" id="page-1-level-2">
+        <h2>Page 1 Level 2</h2>
 
-            <div class="section" id="page-1-level-3">
+        <div class="section" id="page-1-level-3">
             <h3>Page 1 Level 3</h3>
 
             <div class="section" id="page-1-level-4">
-            <h4>Page 1 Level 4</h4>
+                <h4>Page 1 Level 4</h4>
+
+            </div>
+
+        </div>
 
     </div>
 
-    </div>
-
-    </div>
-
-    </div>
+</div>
 
 <!-- content end -->

--- a/tests/Integration/tests/navigation/contents/contents-depth-1/expected/index.html
+++ b/tests/Integration/tests/navigation/contents/contents-depth-1/expected/index.html
@@ -1,56 +1,60 @@
 <!-- content start -->
-    <div class="section" id="title">
-            <h1>Title</h1>
+<div class="section" id="title">
+    <h1>Title</h1>
 
-            <div class="contents">
+    <div class="contents">
         <ul class="menu-level">
-    <li class="toc-item"><a href="/index.html#depth-level-1">Depth Level 1</a></li>
+            <li class="toc-item">
+                <a href="/index.html#depth-level-1">Depth Level 1</a>
+            </li>
 
-    <li class="toc-item"><a href="/index.html#2-depth-level-1">2. Depth Level 1</a></li>
+            <li class="toc-item">
+                <a href="/index.html#2-depth-level-1">2. Depth Level 1</a>
+            </li>
 
-    </ul>
-</div>
+        </ul>
+    </div>
 
-            <div class="section" id="depth-level-1">
-            <h2>Depth Level 1</h2>
+    <div class="section" id="depth-level-1">
+        <h2>Depth Level 1</h2>
 
-            <div class="section" id="depth-level-2">
+        <div class="section" id="depth-level-2">
             <h3>Depth Level 2</h3>
 
             <div class="section" id="depth-level-3">
-            <h4>Depth Level 3</h4>
+                <h4>Depth Level 3</h4>
 
-            <div class="section" id="depth-level-4">
-            <h5>Depth Level 4</h5>
+                <div class="section" id="depth-level-4">
+                    <h5>Depth Level 4</h5>
+
+                </div>
+
+            </div>
+
+        </div>
 
     </div>
 
-    </div>
+    <div class="section" id="2-depth-level-1">
+        <h2>2. Depth Level 1</h2>
 
-    </div>
-
-    </div>
-
-            <div class="section" id="2-depth-level-1">
-            <h2>2. Depth Level 1</h2>
-
-            <div class="section" id="2-depth-level-2">
+        <div class="section" id="2-depth-level-2">
             <h3>2. Depth Level 2</h3>
 
             <div class="section" id="2-depth-level-3">
-            <h4>2. Depth Level 3</h4>
+                <h4>2. Depth Level 3</h4>
 
-            <div class="section" id="2-depth-level-4">
-            <h5>2. Depth Level 4</h5>
+                <div class="section" id="2-depth-level-4">
+                    <h5>2. Depth Level 4</h5>
 
-    </div>
+                </div>
 
-    </div>
+            </div>
 
-    </div>
-
-    </div>
+        </div>
 
     </div>
+
+</div>
 
 <!-- content end -->

--- a/tests/Integration/tests/navigation/contents/contents-depth-2/expected/index.html
+++ b/tests/Integration/tests/navigation/contents/contents-depth-2/expected/index.html
@@ -1,62 +1,72 @@
 <!-- content start -->
-    <div class="section" id="title">
-            <h1>Title</h1>
+<div class="section" id="title">
+    <h1>Title</h1>
 
-            <div class="contents">
+    <div class="contents">
         <ul class="menu-level">
-    <li class="toc-item"><a href="/index.html#depth-level-1">Depth Level 1</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/index.html#depth-level-2">Depth Level 2</a></li>
+            <li class="toc-item">
+                <a href="/index.html#depth-level-1">Depth Level 1</a>
+                <ul class="section-level-2">
+                    <li class="toc-item">
+                        <a href="/index.html#depth-level-2">Depth Level 2</a>
+                    </li>
 
-                    </ul></li>
+                </ul>
+            </li>
 
-    <li class="toc-item"><a href="/index.html#2-depth-level-1">2. Depth Level 1</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/index.html#2-depth-level-2">2. Depth Level 2</a></li>
+            <li class="toc-item">
+                <a href="/index.html#2-depth-level-1">2. Depth Level 1</a>
+                <ul class="section-level-2">
+                    <li class="toc-item">
+                        <a href="/index.html#2-depth-level-2">2. Depth Level 2</a>
+                    </li>
 
-                    </ul></li>
+                </ul>
+            </li>
 
-    </ul>
-</div>
+        </ul>
+    </div>
 
-            <div class="section" id="depth-level-1">
-            <h2>Depth Level 1</h2>
+    <div class="section" id="depth-level-1">
+        <h2>Depth Level 1</h2>
 
-            <div class="section" id="depth-level-2">
+        <div class="section" id="depth-level-2">
             <h3>Depth Level 2</h3>
 
             <div class="section" id="depth-level-3">
-            <h4>Depth Level 3</h4>
+                <h4>Depth Level 3</h4>
 
-            <div class="section" id="depth-level-4">
-            <h5>Depth Level 4</h5>
+                <div class="section" id="depth-level-4">
+                    <h5>Depth Level 4</h5>
+
+                </div>
+
+            </div>
+
+        </div>
 
     </div>
 
-    </div>
+    <div class="section" id="2-depth-level-1">
+        <h2>2. Depth Level 1</h2>
 
-    </div>
-
-    </div>
-
-            <div class="section" id="2-depth-level-1">
-            <h2>2. Depth Level 1</h2>
-
-            <div class="section" id="2-depth-level-2">
+        <div class="section" id="2-depth-level-2">
             <h3>2. Depth Level 2</h3>
 
             <div class="section" id="2-depth-level-3">
-            <h4>2. Depth Level 3</h4>
+                <h4>2. Depth Level 3</h4>
 
-            <div class="section" id="2-depth-level-4">
-            <h5>2. Depth Level 4</h5>
+                <div class="section" id="2-depth-level-4">
+                    <h5>2. Depth Level 4</h5>
 
-    </div>
+                </div>
 
-    </div>
+            </div>
 
-    </div>
-
-    </div>
+        </div>
 
     </div>
+
+</div>
 
 <!-- content end -->

--- a/tests/Integration/tests/navigation/contents/contents-depth-3/expected/index.html
+++ b/tests/Integration/tests/navigation/contents/contents-depth-3/expected/index.html
@@ -1,68 +1,84 @@
 <!-- content start -->
-    <div class="section" id="title">
-            <h1>Title</h1>
+<div class="section" id="title">
+    <h1>Title</h1>
 
-            <div class="contents">
+    <div class="contents">
         <ul class="menu-level">
-    <li class="toc-item"><a href="/index.html#depth-level-1">Depth Level 1</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/index.html#depth-level-2">Depth Level 2</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/index.html#depth-level-3">Depth Level 3</a></li>
+            <li class="toc-item">
+                <a href="/index.html#depth-level-1">Depth Level 1</a>
+                <ul class="section-level-2">
+                    <li class="toc-item">
+                        <a href="/index.html#depth-level-2">Depth Level 2</a>
+                        <ul class="section-level-2">
+                            <li class="toc-item">
+                                <a href="/index.html#depth-level-3">Depth Level 3</a>
+                            </li>
 
-                    </ul></li>
+                        </ul>
+                    </li>
 
-                    </ul></li>
+                </ul>
+            </li>
 
-    <li class="toc-item"><a href="/index.html#2-depth-level-1">2. Depth Level 1</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/index.html#2-depth-level-2">2. Depth Level 2</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/index.html#2-depth-level-3">2. Depth Level 3</a></li>
+            <li class="toc-item">
+                <a href="/index.html#2-depth-level-1">2. Depth Level 1</a>
+                <ul class="section-level-2">
+                    <li class="toc-item">
+                        <a href="/index.html#2-depth-level-2">2. Depth Level 2</a>
+                        <ul class="section-level-2">
+                            <li class="toc-item">
+                                <a href="/index.html#2-depth-level-3">2. Depth Level 3</a>
+                            </li>
 
-                    </ul></li>
+                        </ul>
+                    </li>
 
-                    </ul></li>
+                </ul>
+            </li>
 
-    </ul>
-</div>
+        </ul>
+    </div>
 
-            <div class="section" id="depth-level-1">
-            <h2>Depth Level 1</h2>
+    <div class="section" id="depth-level-1">
+        <h2>Depth Level 1</h2>
 
-            <div class="section" id="depth-level-2">
+        <div class="section" id="depth-level-2">
             <h3>Depth Level 2</h3>
 
             <div class="section" id="depth-level-3">
-            <h4>Depth Level 3</h4>
+                <h4>Depth Level 3</h4>
 
-            <div class="section" id="depth-level-4">
-            <h5>Depth Level 4</h5>
+                <div class="section" id="depth-level-4">
+                    <h5>Depth Level 4</h5>
+
+                </div>
+
+            </div>
+
+        </div>
 
     </div>
 
-    </div>
+    <div class="section" id="2-depth-level-1">
+        <h2>2. Depth Level 1</h2>
 
-    </div>
-
-    </div>
-
-            <div class="section" id="2-depth-level-1">
-            <h2>2. Depth Level 1</h2>
-
-            <div class="section" id="2-depth-level-2">
+        <div class="section" id="2-depth-level-2">
             <h3>2. Depth Level 2</h3>
 
             <div class="section" id="2-depth-level-3">
-            <h4>2. Depth Level 3</h4>
+                <h4>2. Depth Level 3</h4>
 
-            <div class="section" id="2-depth-level-4">
-            <h5>2. Depth Level 4</h5>
+                <div class="section" id="2-depth-level-4">
+                    <h5>2. Depth Level 4</h5>
 
-    </div>
+                </div>
 
-    </div>
+            </div>
 
-    </div>
-
-    </div>
+        </div>
 
     </div>
+
+</div>
 
 <!-- content end -->

--- a/tests/Integration/tests/navigation/contents/contents-no-depth/expected/index.html
+++ b/tests/Integration/tests/navigation/contents/contents-no-depth/expected/index.html
@@ -1,74 +1,96 @@
 <!-- content start -->
-    <div class="section" id="title">
-            <h1>Title</h1>
+<div class="section" id="title">
+    <h1>Title</h1>
 
-            <div class="contents">
+    <div class="contents">
         <ul class="menu-level">
-    <li class="toc-item"><a href="/index.html#depth-level-1">Depth Level 1</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/index.html#depth-level-2">Depth Level 2</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/index.html#depth-level-3">Depth Level 3</a>        <ul class="section-level-3">
-            <li class="toc-item"><a href="/index.html#depth-level-4">Depth Level 4</a></li>
+            <li class="toc-item">
+                <a href="/index.html#depth-level-1">Depth Level 1</a>
+                <ul class="section-level-2">
+                    <li class="toc-item">
+                        <a href="/index.html#depth-level-2">Depth Level 2</a>
+                        <ul class="section-level-2">
+                            <li class="toc-item">
+                                <a href="/index.html#depth-level-3">Depth Level 3</a>
+                                <ul class="section-level-3">
+                                    <li class="toc-item">
+                                        <a href="/index.html#depth-level-4">Depth Level 4</a>
+                                    </li>
 
-                    </ul></li>
+                                </ul>
+                            </li>
 
-                    </ul></li>
+                        </ul>
+                    </li>
 
-                    </ul></li>
+                </ul>
+            </li>
 
-    <li class="toc-item"><a href="/index.html#2-depth-level-1">2. Depth Level 1</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/index.html#2-depth-level-2">2. Depth Level 2</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/index.html#2-depth-level-3">2. Depth Level 3</a>        <ul class="section-level-3">
-            <li class="toc-item"><a href="/index.html#2-depth-level-4">2. Depth Level 4</a></li>
+            <li class="toc-item">
+                <a href="/index.html#2-depth-level-1">2. Depth Level 1</a>
+                <ul class="section-level-2">
+                    <li class="toc-item">
+                        <a href="/index.html#2-depth-level-2">2. Depth Level 2</a>
+                        <ul class="section-level-2">
+                            <li class="toc-item">
+                                <a href="/index.html#2-depth-level-3">2. Depth Level 3</a>
+                                <ul class="section-level-3">
+                                    <li class="toc-item">
+                                        <a href="/index.html#2-depth-level-4">2. Depth Level 4</a>
+                                    </li>
 
-                    </ul></li>
+                                </ul>
+                            </li>
 
-                    </ul></li>
+                        </ul>
+                    </li>
 
-                    </ul></li>
+                </ul>
+            </li>
 
-    </ul>
-</div>
+        </ul>
+    </div>
 
-            <div class="section" id="depth-level-1">
-            <h2>Depth Level 1</h2>
+    <div class="section" id="depth-level-1">
+        <h2>Depth Level 1</h2>
 
-            <div class="section" id="depth-level-2">
+        <div class="section" id="depth-level-2">
             <h3>Depth Level 2</h3>
 
             <div class="section" id="depth-level-3">
-            <h4>Depth Level 3</h4>
+                <h4>Depth Level 3</h4>
 
-            <div class="section" id="depth-level-4">
-            <h5>Depth Level 4</h5>
+                <div class="section" id="depth-level-4">
+                    <h5>Depth Level 4</h5>
+
+                </div>
+
+            </div>
+
+        </div>
 
     </div>
 
-    </div>
+    <div class="section" id="2-depth-level-1">
+        <h2>2. Depth Level 1</h2>
 
-    </div>
-
-    </div>
-
-            <div class="section" id="2-depth-level-1">
-            <h2>2. Depth Level 1</h2>
-
-            <div class="section" id="2-depth-level-2">
+        <div class="section" id="2-depth-level-2">
             <h3>2. Depth Level 2</h3>
 
             <div class="section" id="2-depth-level-3">
-            <h4>2. Depth Level 3</h4>
+                <h4>2. Depth Level 3</h4>
 
-            <div class="section" id="2-depth-level-4">
-            <h5>2. Depth Level 4</h5>
+                <div class="section" id="2-depth-level-4">
+                    <h5>2. Depth Level 4</h5>
 
-    </div>
+                </div>
 
-    </div>
+            </div>
 
-    </div>
-
-    </div>
+        </div>
 
     </div>
+
+</div>
 
 <!-- content end -->

--- a/tests/Integration/tests/navigation/contents/contents-with-title/expected/index.html
+++ b/tests/Integration/tests/navigation/contents/contents-with-title/expected/index.html
@@ -1,44 +1,55 @@
 <!-- content start -->
-    <div class="section" id="title">
-            <h1>Title</h1>
+<div class="section" id="title">
+    <h1>Title</h1>
 
-            <div class="contents">
+    <div class="contents">
         <p class="topic-title"><strong>Table of Content</strong></p>
         <ul class="menu-level">
-    <li class="toc-item"><a href="/index.html#depth-level-1">Depth Level 1</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/index.html#depth-level-2">Depth Level 2</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/index.html#depth-level-3">Depth Level 3</a>        <ul class="section-level-3">
-            <li class="toc-item"><a href="/index.html#depth-level-4">Depth Level 4</a></li>
+            <li class="toc-item">
+                <a href="/index.html#depth-level-1">Depth Level 1</a>
+                <ul class="section-level-2">
+                    <li class="toc-item">
+                        <a href="/index.html#depth-level-2">Depth Level 2</a>
+                        <ul class="section-level-2">
+                            <li class="toc-item">
+                                <a href="/index.html#depth-level-3">Depth Level 3</a>
+                                <ul class="section-level-3">
+                                    <li class="toc-item">
+                                        <a href="/index.html#depth-level-4">Depth Level 4</a>
+                                    </li>
 
-                    </ul></li>
+                                </ul>
+                            </li>
 
-                    </ul></li>
+                        </ul>
+                    </li>
 
-                    </ul></li>
+                </ul>
+            </li>
 
-    </ul>
-</div>
+        </ul>
+    </div>
 
-            <div class="section" id="depth-level-1">
-            <h2>Depth Level 1</h2>
+    <div class="section" id="depth-level-1">
+        <h2>Depth Level 1</h2>
 
-            <div class="section" id="depth-level-2">
+        <div class="section" id="depth-level-2">
             <h3>Depth Level 2</h3>
 
             <div class="section" id="depth-level-3">
-            <h4>Depth Level 3</h4>
+                <h4>Depth Level 3</h4>
 
-            <div class="section" id="depth-level-4">
-            <h5>Depth Level 4</h5>
+                <div class="section" id="depth-level-4">
+                    <h5>Depth Level 4</h5>
 
-    </div>
+                </div>
 
-    </div>
+            </div>
 
-    </div>
-
-    </div>
+        </div>
 
     </div>
+
+</div>
 
 <!-- content end -->

--- a/tests/Integration/tests/navigation/menu-level-3/expected/level-1-1/level-2-2/subpage1.html
+++ b/tests/Integration/tests/navigation/menu-level-3/expected/level-1-1/level-2-2/subpage1.html
@@ -1,45 +1,77 @@
 <!-- content start -->
-    <div class="section" id="subpage-1-level-2-2">
-            <h1>Subpage 1, Level 2-2</h1>
+<div class="section" id="subpage-1-level-2-2">
+    <h1>Subpage 1, Level 2-2</h1>
 
-            <p>Lorem Ipsum Dolor.</p>
-            <div class="menu">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
+    <p>Lorem Ipsum Dolor.</p>
+    <div class="menu">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/page1.html#page-1">Page 1</a>
+            </li>
 
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
+            <li class="toc-item">
+                <a href="/page2.html#page-2">Page 2</a>
+            </li>
 
-    <li class="toc-item active"><a href="/level-1-1/index.html#level-1-1">Level 1-1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a></li>
+            <li class="toc-item active">
+                <a href="/level-1-1/index.html#level-1-1">Level 1-1</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a>
+                    </li>
 
-            <li class="toc-item"><a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a></li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a>
+                    </li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a></li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>
+                        <ul class="menu-level-2">
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a>
+                            </li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a></li>
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a>
+                            </li>
 
-                    </ul></li>
+                        </ul>
+                    </li>
 
-            <li class="toc-item active"><a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>        <ul class="menu-level-2">
-            <li class="toc-item current active"><a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
+                    <li class="toc-item active">
+                        <a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>
+                        <ul class="menu-level-2">
+                            <li class="toc-item current active">
+                                <a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a>
+                            </li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a></li>
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-2/subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a>
+                            </li>
 
-                    </ul></li>
+                        </ul>
+                    </li>
 
-                    </ul></li>
+                </ul>
+            </li>
 
-    <li class="toc-item"><a href="/level-1-2/index.html#level-1-2">Level 1-2</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
+            <li class="toc-item">
+                <a href="/level-1-2/index.html#level-1-2">Level 1-2</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a>
+                    </li>
 
-            <li class="toc-item"><a href="/level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a></li>
+                    <li class="toc-item">
+                        <a href="/level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a>
+                    </li>
 
-                    </ul></li>
+                </ul>
+            </li>
 
-    </ul>
-</div>
-
+        </ul>
     </div>
+
+</div>
 
 <!-- content end -->

--- a/tests/Integration/tests/navigation/menu-level-3/expected/level-1-2/subpage1.html
+++ b/tests/Integration/tests/navigation/menu-level-3/expected/level-1-2/subpage1.html
@@ -1,45 +1,77 @@
 <!-- content start -->
-    <div class="section" id="subpage-1-level-1-2">
-            <h1>Subpage 1, Level 1-2</h1>
+<div class="section" id="subpage-1-level-1-2">
+    <h1>Subpage 1, Level 1-2</h1>
 
-            <p>Lorem Ipsum Dolor.</p>
-            <div class="menu">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
+    <p>Lorem Ipsum Dolor.</p>
+    <div class="menu">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/page1.html#page-1">Page 1</a>
+            </li>
 
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
+            <li class="toc-item">
+                <a href="/page2.html#page-2">Page 2</a>
+            </li>
 
-    <li class="toc-item"><a href="/level-1-1/index.html#level-1-1">Level 1-1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a></li>
+            <li class="toc-item">
+                <a href="/level-1-1/index.html#level-1-1">Level 1-1</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a>
+                    </li>
 
-            <li class="toc-item"><a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a></li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a>
+                    </li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a></li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>
+                        <ul class="menu-level-2">
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a>
+                            </li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a></li>
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a>
+                            </li>
 
-                    </ul></li>
+                        </ul>
+                    </li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>
+                        <ul class="menu-level-2">
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a>
+                            </li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a></li>
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-2/subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a>
+                            </li>
 
-                    </ul></li>
+                        </ul>
+                    </li>
 
-                    </ul></li>
+                </ul>
+            </li>
 
-    <li class="toc-item active"><a href="/level-1-2/index.html#level-1-2">Level 1-2</a>        <ul class="menu-level-1">
-            <li class="toc-item current active"><a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
+            <li class="toc-item active">
+                <a href="/level-1-2/index.html#level-1-2">Level 1-2</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item current active">
+                        <a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a>
+                    </li>
 
-            <li class="toc-item"><a href="/level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a></li>
+                    <li class="toc-item">
+                        <a href="/level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a>
+                    </li>
 
-                    </ul></li>
+                </ul>
+            </li>
 
-    </ul>
-</div>
-
+        </ul>
     </div>
+
+</div>
 
 <!-- content end -->

--- a/tests/Integration/tests/navigation/menu-level-3/expected/page1.html
+++ b/tests/Integration/tests/navigation/menu-level-3/expected/page1.html
@@ -1,60 +1,92 @@
 <!-- content start -->
-    <div class="section" id="page-1">
-            <h1>Page 1</h1>
+<div class="section" id="page-1">
+    <h1>Page 1</h1>
 
-            <p>Lorem Ipsum Dolor.</p>
-            <div class="menu">
-    <ul class="menu-level">
-    <li class="toc-item current active"><a href="/page1.html#page-1">Page 1</a></li>
+    <p>Lorem Ipsum Dolor.</p>
+    <div class="menu">
+        <ul class="menu-level">
+            <li class="toc-item current active">
+                <a href="/page1.html#page-1">Page 1</a>
+            </li>
 
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
+            <li class="toc-item">
+                <a href="/page2.html#page-2">Page 2</a>
+            </li>
 
-    <li class="toc-item"><a href="/level-1-1/index.html#level-1-1">Level 1-1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a></li>
+            <li class="toc-item">
+                <a href="/level-1-1/index.html#level-1-1">Level 1-1</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a>
+                    </li>
 
-            <li class="toc-item"><a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a></li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a>
+                    </li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a></li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>
+                        <ul class="menu-level-2">
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a>
+                            </li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a></li>
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a>
+                            </li>
 
-                    </ul></li>
+                        </ul>
+                    </li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>
+                        <ul class="menu-level-2">
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a>
+                            </li>
 
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a></li>
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-2/subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a>
+                            </li>
 
-                    </ul></li>
+                        </ul>
+                    </li>
 
-                    </ul></li>
+                </ul>
+            </li>
 
-    <li class="toc-item"><a href="/level-1-2/index.html#level-1-2">Level 1-2</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
+            <li class="toc-item">
+                <a href="/level-1-2/index.html#level-1-2">Level 1-2</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a>
+                    </li>
 
-            <li class="toc-item"><a href="/level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a></li>
+                    <li class="toc-item">
+                        <a href="/level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a>
+                    </li>
 
-                    </ul></li>
+                </ul>
+            </li>
 
-    </ul>
-</div>
+        </ul>
+    </div>
 
-            <div class="section" id="page-1-level-2">
-            <h2>Page 1 Level 2</h2>
+    <div class="section" id="page-1-level-2">
+        <h2>Page 1 Level 2</h2>
 
-            <div class="section" id="page-1-level-3">
+        <div class="section" id="page-1-level-3">
             <h3>Page 1 Level 3</h3>
 
             <div class="section" id="page-1-level-4">
-            <h4>Page 1 Level 4</h4>
+                <h4>Page 1 Level 4</h4>
+
+            </div>
+
+        </div>
 
     </div>
 
-    </div>
-
-    </div>
-
-    </div>
+</div>
 
 <!-- content end -->

--- a/tests/Integration/tests/navigation/menu-relative/expected/level-1-1/level-2-2/subpage1.html
+++ b/tests/Integration/tests/navigation/menu-relative/expected/level-1-1/level-2-2/subpage1.html
@@ -1,45 +1,77 @@
 <!-- content start -->
-    <div class="section" id="subpage-1-level-2-2">
-            <h1>Subpage 1, Level 2-2</h1>
+<div class="section" id="subpage-1-level-2-2">
+    <h1>Subpage 1, Level 2-2</h1>
 
-            <p>Lorem Ipsum Dolor.</p>
-            <div class="menu">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="../../page1.html#page-1">Page 1</a></li>
+    <p>Lorem Ipsum Dolor.</p>
+    <div class="menu">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="../../page1.html#page-1">Page 1</a>
+            </li>
 
-    <li class="toc-item"><a href="../../page2.html#page-2">Page 2</a></li>
+            <li class="toc-item">
+                <a href="../../page2.html#page-2">Page 2</a>
+            </li>
 
-    <li class="toc-item active"><a href="../index.html#level-1-1">Level 1-1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="../subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a></li>
+            <li class="toc-item active">
+                <a href="../index.html#level-1-1">Level 1-1</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="../subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a>
+                    </li>
 
-            <li class="toc-item"><a href="../subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a></li>
+                    <li class="toc-item">
+                        <a href="../subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a>
+                    </li>
 
-            <li class="toc-item"><a href="../level-2-1/index.html#level-2-1">Level 2-1</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="../level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a></li>
+                    <li class="toc-item">
+                        <a href="../level-2-1/index.html#level-2-1">Level 2-1</a>
+                        <ul class="menu-level-2">
+                            <li class="toc-item">
+                                <a href="../level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a>
+                            </li>
 
-            <li class="toc-item"><a href="../level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a></li>
+                            <li class="toc-item">
+                                <a href="../level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a>
+                            </li>
 
-                    </ul></li>
+                        </ul>
+                    </li>
 
-            <li class="toc-item active"><a href="index.html#level-2-2">Level 2-2</a>        <ul class="menu-level-2">
-            <li class="toc-item current active"><a href="#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
+                    <li class="toc-item active">
+                        <a href="index.html#level-2-2">Level 2-2</a>
+                        <ul class="menu-level-2">
+                            <li class="toc-item current active">
+                                <a href="#subpage-1-level-2-2">Subpage 1, Level 2-2</a>
+                            </li>
 
-            <li class="toc-item"><a href="subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a></li>
+                            <li class="toc-item">
+                                <a href="subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a>
+                            </li>
 
-                    </ul></li>
+                        </ul>
+                    </li>
 
-                    </ul></li>
+                </ul>
+            </li>
 
-    <li class="toc-item"><a href="../../level-1-2/index.html#level-1-2">Level 1-2</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="../../level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
+            <li class="toc-item">
+                <a href="../../level-1-2/index.html#level-1-2">Level 1-2</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="../../level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a>
+                    </li>
 
-            <li class="toc-item"><a href="../../level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a></li>
+                    <li class="toc-item">
+                        <a href="../../level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a>
+                    </li>
 
-                    </ul></li>
+                </ul>
+            </li>
 
-    </ul>
-</div>
-
+        </ul>
     </div>
+
+</div>
 
 <!-- content end -->

--- a/tests/Integration/tests/navigation/menu-relative/expected/level-1-2/subpage1.html
+++ b/tests/Integration/tests/navigation/menu-relative/expected/level-1-2/subpage1.html
@@ -1,45 +1,77 @@
 <!-- content start -->
-    <div class="section" id="subpage-1-level-1-2">
-            <h1>Subpage 1, Level 1-2</h1>
+<div class="section" id="subpage-1-level-1-2">
+    <h1>Subpage 1, Level 1-2</h1>
 
-            <p>Lorem Ipsum Dolor.</p>
-            <div class="menu">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="../page1.html#page-1">Page 1</a></li>
+    <p>Lorem Ipsum Dolor.</p>
+    <div class="menu">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="../page1.html#page-1">Page 1</a>
+            </li>
 
-    <li class="toc-item"><a href="../page2.html#page-2">Page 2</a></li>
+            <li class="toc-item">
+                <a href="../page2.html#page-2">Page 2</a>
+            </li>
 
-    <li class="toc-item"><a href="../level-1-1/index.html#level-1-1">Level 1-1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="../level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a></li>
+            <li class="toc-item">
+                <a href="../level-1-1/index.html#level-1-1">Level 1-1</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="../level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a>
+                    </li>
 
-            <li class="toc-item"><a href="../level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a></li>
+                    <li class="toc-item">
+                        <a href="../level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a>
+                    </li>
 
-            <li class="toc-item"><a href="../level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="../level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a></li>
+                    <li class="toc-item">
+                        <a href="../level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>
+                        <ul class="menu-level-2">
+                            <li class="toc-item">
+                                <a href="../level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a>
+                            </li>
 
-            <li class="toc-item"><a href="../level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a></li>
+                            <li class="toc-item">
+                                <a href="../level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a>
+                            </li>
 
-                    </ul></li>
+                        </ul>
+                    </li>
 
-            <li class="toc-item"><a href="../level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="../level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
+                    <li class="toc-item">
+                        <a href="../level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>
+                        <ul class="menu-level-2">
+                            <li class="toc-item">
+                                <a href="../level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a>
+                            </li>
 
-            <li class="toc-item"><a href="../level-1-1/level-2-2/subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a></li>
+                            <li class="toc-item">
+                                <a href="../level-1-1/level-2-2/subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a>
+                            </li>
 
-                    </ul></li>
+                        </ul>
+                    </li>
 
-                    </ul></li>
+                </ul>
+            </li>
 
-    <li class="toc-item active"><a href="index.html#level-1-2">Level 1-2</a>        <ul class="menu-level-1">
-            <li class="toc-item current active"><a href="#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
+            <li class="toc-item active">
+                <a href="index.html#level-1-2">Level 1-2</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item current active">
+                        <a href="#subpage-1-level-1-2">Subpage 1, Level 1-2</a>
+                    </li>
 
-            <li class="toc-item"><a href="subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a></li>
+                    <li class="toc-item">
+                        <a href="subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a>
+                    </li>
 
-                    </ul></li>
+                </ul>
+            </li>
 
-    </ul>
-</div>
-
+        </ul>
     </div>
+
+</div>
 
 <!-- content end -->

--- a/tests/Integration/tests/navigation/menu-relative/expected/page1.html
+++ b/tests/Integration/tests/navigation/menu-relative/expected/page1.html
@@ -1,60 +1,92 @@
 <!-- content start -->
-    <div class="section" id="page-1">
-            <h1>Page 1</h1>
+<div class="section" id="page-1">
+    <h1>Page 1</h1>
 
-            <p>Lorem Ipsum Dolor.</p>
-            <div class="menu">
-    <ul class="menu-level">
-    <li class="toc-item current active"><a href="#page-1">Page 1</a></li>
+    <p>Lorem Ipsum Dolor.</p>
+    <div class="menu">
+        <ul class="menu-level">
+            <li class="toc-item current active">
+                <a href="#page-1">Page 1</a>
+            </li>
 
-    <li class="toc-item"><a href="page2.html#page-2">Page 2</a></li>
+            <li class="toc-item">
+                <a href="page2.html#page-2">Page 2</a>
+            </li>
 
-    <li class="toc-item"><a href="level-1-1/index.html#level-1-1">Level 1-1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a></li>
+            <li class="toc-item">
+                <a href="level-1-1/index.html#level-1-1">Level 1-1</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a>
+                    </li>
 
-            <li class="toc-item"><a href="level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a></li>
+                    <li class="toc-item">
+                        <a href="level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a>
+                    </li>
 
-            <li class="toc-item"><a href="level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a></li>
+                    <li class="toc-item">
+                        <a href="level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>
+                        <ul class="menu-level-2">
+                            <li class="toc-item">
+                                <a href="level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a>
+                            </li>
 
-            <li class="toc-item"><a href="level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a></li>
+                            <li class="toc-item">
+                                <a href="level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a>
+                            </li>
 
-                    </ul></li>
+                        </ul>
+                    </li>
 
-            <li class="toc-item"><a href="level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
+                    <li class="toc-item">
+                        <a href="level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>
+                        <ul class="menu-level-2">
+                            <li class="toc-item">
+                                <a href="level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a>
+                            </li>
 
-            <li class="toc-item"><a href="level-1-1/level-2-2/subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a></li>
+                            <li class="toc-item">
+                                <a href="level-1-1/level-2-2/subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a>
+                            </li>
 
-                    </ul></li>
+                        </ul>
+                    </li>
 
-                    </ul></li>
+                </ul>
+            </li>
 
-    <li class="toc-item"><a href="level-1-2/index.html#level-1-2">Level 1-2</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
+            <li class="toc-item">
+                <a href="level-1-2/index.html#level-1-2">Level 1-2</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a>
+                    </li>
 
-            <li class="toc-item"><a href="level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a></li>
+                    <li class="toc-item">
+                        <a href="level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a>
+                    </li>
 
-                    </ul></li>
+                </ul>
+            </li>
 
-    </ul>
-</div>
+        </ul>
+    </div>
 
-            <div class="section" id="page-1-level-2">
-            <h2>Page 1 Level 2</h2>
+    <div class="section" id="page-1-level-2">
+        <h2>Page 1 Level 2</h2>
 
-            <div class="section" id="page-1-level-3">
+        <div class="section" id="page-1-level-3">
             <h3>Page 1 Level 3</h3>
 
             <div class="section" id="page-1-level-4">
-            <h4>Page 1 Level 4</h4>
+                <h4>Page 1 Level 4</h4>
+
+            </div>
+
+        </div>
 
     </div>
 
-    </div>
-
-    </div>
-
-    </div>
+</div>
 
 <!-- content end -->

--- a/tests/Integration/tests/navigation/reference-with-angle-bracket/expected/index.html
+++ b/tests/Integration/tests/navigation/reference-with-angle-bracket/expected/index.html
@@ -1,16 +1,18 @@
 <!-- content start -->
-    <div class="section" id="overview">
-            <h1>Overview</h1>
+<div class="section" id="overview">
+    <h1>Overview</h1>
 
-            <p>The uid must be given as a positive integer.
-For new records, use the <a href="/page.html#typo3-backend-link-newrecord">&lt;be:link.newRecordViewHelper&gt;</a>.</p>
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/page.html#link-newrecord">link.newRecord</a></li>
+    <p>The uid must be given as a positive integer.
+    For new records, use the <a href="/page.html#typo3-backend-link-newrecord">&lt;be:link.newRecordViewHelper&gt;</a>.</p>
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/page.html#link-newrecord">link.newRecord</a>
+            </li>
 
-    </ul>
-</div>
-
+        </ul>
     </div>
+
+</div>
 
 <!-- content end -->

--- a/tests/Integration/tests/references/reference-level-3-relative/expected/index.html
+++ b/tests/Integration/tests/references/reference-level-3-relative/expected/index.html
@@ -1,56 +1,68 @@
 <!-- content start -->
-    <div class="section" id="document-title">
-            <h1>Document Title</h1>
+<div class="section" id="document-title">
+    <h1>Document Title</h1>
 
-            <p>Lorem Ipsum Dolor.</p>
+    <p>Lorem Ipsum Dolor.</p>
 
-
-<ul>
-    <li><a href="page1.html#page_1">Page 1, same level</a></li>
-
-    <li><a href="level-1-1/level-2-1/subpage1.html#level-2-1-subpage1">Subpage 1, Level 2-1</a></li>
-
-    <li><a href="level-1-2/subpage2.html#level-1-2-subpage2">Subpage 2, Level 1-2</a></li>
-
-</ul>
-
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="page1.html#page-1">Page 1</a></li>
-
-    <li class="toc-item"><a href="page2.html#page-2">Page 2</a></li>
-
-    <li class="toc-item"><a href="level-1-1/index.html#level-1-1">Level 1-1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a></li>
-
-            <li class="toc-item"><a href="level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a></li>
-
-            <li class="toc-item"><a href="level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a></li>
-
-            <li class="toc-item"><a href="level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
-
-            <li class="toc-item"><a href="level-1-1/level-2-2/subpage2.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
-
-                    </ul></li>
-
-                    </ul></li>
-
-    <li class="toc-item"><a href="level-1-2/index.html#level-1-2">Level 1-2</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
-
-            <li class="toc-item"><a href="level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a></li>
-
-                    </ul></li>
-
+    <ul>
+        <li><a href="page1.html#page_1">Page 1, same level</a></li>
+        <li><a href="level-1-1/level-2-1/subpage1.html#level-2-1-subpage1">Subpage 1, Level 2-1</a></li>
+        <li><a href="level-1-2/subpage2.html#level-1-2-subpage2">Subpage 2, Level 1-2</a></li>
     </ul>
-</div>
 
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="page1.html#page-1">Page 1</a>
+            </li>
+            <li class="toc-item">
+                <a href="page2.html#page-2">Page 2</a>
+            </li>
+            <li class="toc-item">
+                <a href="level-1-1/index.html#level-1-1">Level 1-1</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a>
+                    </li>
+                    <li class="toc-item">
+                        <a href="level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a>
+                    </li>
+                    <li class="toc-item">
+                        <a href="level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>
+                        <ul class="menu-level-2">
+                            <li class="toc-item">
+                                <a href="level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a>
+                            </li>
+                            <li class="toc-item">
+                                <a href="level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="toc-item">
+                        <a href="level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>
+                        <ul class="menu-level-2">
+                            <li class="toc-item">
+                                <a href="level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a>
+                            </li>
+                            <li class="toc-item">
+                                <a href="level-1-1/level-2-2/subpage2.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+            </li>
+            <li class="toc-item">
+                <a href="level-1-2/index.html#level-1-2">Level 1-2</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a>
+                    </li>
+                    <li class="toc-item">
+                        <a href="level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a>
+                    </li>
+                </ul>
+            </li>
+        </ul>
     </div>
-
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/references/reference-level-3/expected/index.html
+++ b/tests/Integration/tests/references/reference-level-3/expected/index.html
@@ -1,56 +1,68 @@
 <!-- content start -->
-    <div class="section" id="document-title">
-            <h1>Document Title</h1>
+<div class="section" id="document-title">
+    <h1>Document Title</h1>
 
-            <p>Lorem Ipsum Dolor.</p>
+    <p>Lorem Ipsum Dolor.</p>
 
-
-<ul>
-    <li><a href="/page1.html#page_1">Page 1, same level</a></li>
-
-    <li><a href="/level-1-1/level-2-1/subpage1.html#level-2-1-subpage1">Subpage 1, Level 2-1</a></li>
-
-    <li><a href="/level-1-2/subpage2.html#level-1-2-subpage2">Subpage 2, Level 1-2</a></li>
-
-</ul>
-
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
-
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
-
-    <li class="toc-item"><a href="/level-1-1/index.html#level-1-1">Level 1-1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a></li>
-
-            <li class="toc-item"><a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage2.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
-
-                    </ul></li>
-
-                    </ul></li>
-
-    <li class="toc-item"><a href="/level-1-2/index.html#level-1-2">Level 1-2</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
-
-            <li class="toc-item"><a href="/level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a></li>
-
-                    </ul></li>
-
+    <ul>
+        <li><a href="/page1.html#page_1">Page 1, same level</a></li>
+        <li><a href="/level-1-1/level-2-1/subpage1.html#level-2-1-subpage1">Subpage 1, Level 2-1</a></li>
+        <li><a href="/level-1-2/subpage2.html#level-1-2-subpage2">Subpage 2, Level 1-2</a></li>
     </ul>
-</div>
 
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/page1.html#page-1">Page 1</a>
+            </li>
+            <li class="toc-item">
+                <a href="/page2.html#page-2">Page 2</a>
+            </li>
+            <li class="toc-item">
+                <a href="/level-1-1/index.html#level-1-1">Level 1-1</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>
+                        <ul class="menu-level-2">
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a>
+                            </li>
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>
+                        <ul class="menu-level-2">
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a>
+                            </li>
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-2/subpage2.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+            </li>
+            <li class="toc-item">
+                <a href="/level-1-2/index.html#level-1-2">Level 1-2</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a>
+                    </li>
+                </ul>
+            </li>
+        </ul>
     </div>
-
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/tables/simple-table-with-variable/expected/index.html
+++ b/tests/Integration/tests/tables/simple-table-with-variable/expected/index.html
@@ -12,7 +12,7 @@
     <tbody>
     <tr>
             <td>TSconfig Reference (full)</td>
-            <td>|unkown| and another |known| variable</td>
+            <td>|unknown| and another |known| variable</td>
     </tr>
 </tbody>
 </table>

--- a/tests/Integration/tests/tables/simple-table-with-variable/input/index.rst
+++ b/tests/Integration/tests/tables/simple-table-with-variable/input/index.rst
@@ -4,7 +4,7 @@ Some table with long lines
 =========================  ==================================================
 Project                    Links
 =========================  ==================================================
-TSconfig Reference (full)  |unkown| and another |known| variable
+TSconfig Reference (full)  |unknown| and another |known| variable
 =========================  ==================================================
 
 .. |known| replace:: reStructuredText

--- a/tests/Integration/tests/tables/table-csv-table-with-content/expected/index.html
+++ b/tests/Integration/tests/tables/table-csv-table-with-content/expected/index.html
@@ -1,30 +1,28 @@
 <!-- content start -->
-    <div class="section" id="csv-table-with-content">
-            <h1>Csv table with content</h1>
+<div class="section" id="csv-table-with-content">
+    <h1>Csv table with content</h1>
 
-            <table class="colwidths-grid">
-            <colgroup>
-                                    <col style="width: 30%">
-                                                <col style="width: 70%">
-                        </colgroup>
+    <table class="colwidths-grid">
+        <colgroup>
+            <col style="width: 30%">
+            <col style="width: 70%">
+        </colgroup>
         <thead>
             <tr>
-                            <th>Header 1</th>
-                            <th>Header 2</th>
-                    </tr>
+                <th>Header 1</th>
+                <th>Header 2</th>
+            </tr>
         </thead>
-    <tbody>
-    <tr>
-            <td>1</td>
-            <td>one</td>
-    </tr>
-    <tr>
-            <td>2</td>
-            <td>two</td>
-    </tr>
-</tbody>
-</table>
-
-    </div>
-
+        <tbody>
+            <tr>
+                <td>1</td>
+                <td>one</td>
+            </tr>
+            <tr>
+                <td>2</td>
+                <td>two</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/toctree/toctree-caption/expected/index.html
+++ b/tests/Integration/tests/toctree/toctree-caption/expected/index.html
@@ -1,17 +1,17 @@
 <!-- content start -->
-    <div class="section" id="document-title">
-            <h1>Document Title</h1>
+<div class="section" id="document-title">
+    <h1>Document Title</h1>
 
-            <div class="toc">
-            <p class="caption"><strong>Table of Contents</strong></p>
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
-
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
-
-    </ul>
-</div>
-
+    <div class="toc">
+        <p class="caption"><strong>Table of Contents</strong></p>
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/page1.html#page-1">Page 1</a>
+            </li>
+            <li class="toc-item">
+                <a href="/page2.html#page-2">Page 2</a>
+            </li>
+        </ul>
     </div>
-
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/toctree/toctree-entry-not-found/expected/index.html
+++ b/tests/Integration/tests/toctree/toctree-entry-not-found/expected/index.html
@@ -1,17 +1,17 @@
 <!-- content start -->
-    <div class="section" id="document-title">
-            <h1>Document Title</h1>
+<div class="section" id="document-title">
+    <h1>Document Title</h1>
 
-            <div class="toc">
-            <p class="caption"><strong>Table of Contents</strong></p>
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
-
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
-
-    </ul>
-</div>
-
+    <div class="toc">
+        <p class="caption"><strong>Table of Contents</strong></p>
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/page1.html#page-1">Page 1</a>
+            </li>
+            <li class="toc-item">
+                <a href="/page2.html#page-2">Page 2</a>
+            </li>
+        </ul>
     </div>
-
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/toctree/toctree-external-linktargets/expected/index.html
+++ b/tests/Integration/tests/toctree/toctree-external-linktargets/expected/index.html
@@ -1,19 +1,20 @@
 <!-- content start -->
-    <div class="section" id="document-title">
-            <h1>Document Title</h1>
+<div class="section" id="document-title">
+    <h1>Document Title</h1>
 
-            <div class="toc">
-            <p class="caption">Some Caption</p>
-    <ul class="menu-level">
-    <li class="toc-item"><a href="https://example.com/index.html#debug-settings">Title</a></li>
-
-    <li class="toc-item"><a href="https://example.org">https://example.org</a></li>
-
-    <li class="toc-item"><a href="/page1.html#">Some Page</a></li>
-
-    </ul>
-</div>
-
+    <div class="toc">
+        <p class="caption">Some Caption</p>
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="https://example.com/index.html#debug-settings">Title</a>
+            </li>
+            <li class="toc-item">
+                <a href="https://example.org">https://example.org</a>
+            </li>
+            <li class="toc-item">
+                <a href="/page1.html#">Some Page</a>
+            </li>
+        </ul>
     </div>
-
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/toctree/toctree-glob-level-1/expected/index.html
+++ b/tests/Integration/tests/toctree/toctree-glob-level-1/expected/index.html
@@ -1,17 +1,17 @@
 <!-- content start -->
-    <div class="section" id="document-title">
-            <h1>Document Title</h1>
+<div class="section" id="document-title">
+    <h1>Document Title</h1>
 
-            <p>Lorem Ipsum Dolor.</p>
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
-
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
-
-    </ul>
-</div>
-
+    <p>Lorem Ipsum Dolor.</p>
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/page1.html#page-1">Page 1</a>
+            </li>
+            <li class="toc-item">
+                <a href="/page2.html#page-2">Page 2</a>
+            </li>
+        </ul>
     </div>
-
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/toctree/toctree-glob-level-2/expected/index.html
+++ b/tests/Integration/tests/toctree/toctree-glob-level-2/expected/index.html
@@ -1,31 +1,39 @@
 <!-- content start -->
-    <div class="section" id="document-title">
-            <h1>Document Title</h1>
+<div class="section" id="document-title">
+    <h1>Document Title</h1>
 
-            <p>Lorem Ipsum Dolor.</p>
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
-
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
-
-    <li class="toc-item"><a href="/subfolder/index.html#subfolder-index">Subfolder Index</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/subfolder/subpage1.html#subpage-1">Subpage 1</a></li>
-
-            <li class="toc-item"><a href="/subfolder/subpage2.html#subpage-2">Subpage 2</a></li>
-
-                    </ul></li>
-
-    <li class="toc-item"><a href="/subfolder2/index.html#subfolder-index">Subfolder Index</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/subfolder2/subpage1.html#subpage-1">Subpage 1</a></li>
-
-            <li class="toc-item"><a href="/subfolder2/subpage2.html#subpage-2">Subpage 2</a></li>
-
-                    </ul></li>
-
-    </ul>
-</div>
-
+    <p>Lorem Ipsum Dolor.</p>
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/page1.html#page-1">Page 1</a>
+            </li>
+            <li class="toc-item">
+                <a href="/page2.html#page-2">Page 2</a>
+            </li>
+            <li class="toc-item">
+                <a href="/subfolder/index.html#subfolder-index">Subfolder Index</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/subfolder/subpage1.html#subpage-1">Subpage 1</a>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/subfolder/subpage2.html#subpage-2">Subpage 2</a>
+                    </li>
+                </ul>
+            </li>
+            <li class="toc-item">
+                <a href="/subfolder2/index.html#subfolder-index">Subfolder Index</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/subfolder2/subpage1.html#subpage-1">Subpage 1</a>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/subfolder2/subpage2.html#subpage-2">Subpage 2</a>
+                    </li>
+                </ul>
+            </li>
+        </ul>
     </div>
-
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/toctree/toctree-glob-level-2/expected/subfolder/index.html
+++ b/tests/Integration/tests/toctree/toctree-glob-level-2/expected/subfolder/index.html
@@ -1,22 +1,23 @@
 <!-- content start -->
-    <div class="section" id="subfolder-index">
-            <h1>Subfolder Index</h1>
+<div class="section" id="subfolder-index">
+    <h1>Subfolder Index</h1>
 
-            <p>Lorem Ipsum Dolor.</p>
-            <dl>
-                        <dt>A Definition List</dt>
+    <p>Lorem Ipsum Dolor.</p>
 
-        <dd>Some definition.</dd>    </dl>
+    <dl>
+        <dt>A Definition List</dt>
+        <dd>Some definition.</dd>
+    </dl>
 
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/subfolder/subpage1.html#subpage-1">Subpage 1</a></li>
-
-    <li class="toc-item"><a href="/subfolder/subpage2.html#subpage-2">Subpage 2</a></li>
-
-    </ul>
-</div>
-
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/subfolder/subpage1.html#subpage-1">Subpage 1</a>
+            </li>
+            <li class="toc-item">
+                <a href="/subfolder/subpage2.html#subpage-2">Subpage 2</a>
+            </li>
+        </ul>
     </div>
-
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/toctree/toctree-glob-level-3/expected/index.html
+++ b/tests/Integration/tests/toctree/toctree-glob-level-3/expected/index.html
@@ -1,45 +1,61 @@
 <!-- content start -->
-    <div class="section" id="document-title">
-            <h1>Document Title</h1>
+<div class="section" id="document-title">
+    <h1>Document Title</h1>
 
-            <p>Lorem Ipsum Dolor.</p>
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
-
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
-
-    <li class="toc-item"><a href="/level-1-1/index.html#level-1-1">Level 1-1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a></li>
-
-            <li class="toc-item"><a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage2.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
-
-                    </ul></li>
-
-                    </ul></li>
-
-    <li class="toc-item"><a href="/level-1-2/index.html#level-1-2">Level 1-2</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
-
-            <li class="toc-item"><a href="/level-1-2/subpage2.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
-
-                    </ul></li>
-
-    </ul>
-</div>
-
+    <p>Lorem Ipsum Dolor.</p>
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/page1.html#page-1">Page 1</a>
+            </li>
+            <li class="toc-item">
+                <a href="/page2.html#page-2">Page 2</a>
+            </li>
+            <li class="toc-item">
+                <a href="/level-1-1/index.html#level-1-1">Level 1-1</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>
+                        <ul class="menu-level-2">
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a>
+                            </li>
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>
+                        <ul class="menu-level-2">
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a>
+                            </li>
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-2/subpage2.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+            </li>
+            <li class="toc-item">
+                <a href="/level-1-2/index.html#level-1-2">Level 1-2</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/level-1-2/subpage2.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a>
+                    </li>
+                </ul>
+            </li>
+        </ul>
     </div>
-
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/toctree/toctree-level-2/expected/index.html
+++ b/tests/Integration/tests/toctree/toctree-level-2/expected/index.html
@@ -1,31 +1,39 @@
 <!-- content start -->
-    <div class="section" id="document-title">
-            <h1>Document Title</h1>
+<div class="section" id="document-title">
+    <h1>Document Title</h1>
 
-            <p>Lorem Ipsum Dolor.</p>
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
-
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
-
-    <li class="toc-item"><a href="/subfolder/index.html#subfolder-index">Subfolder Index</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/subfolder/subpage1.html#subpage-1">Subpage 1</a></li>
-
-            <li class="toc-item"><a href="/subfolder/subpage2.html#subpage-2">Subpage 2</a></li>
-
-                    </ul></li>
-
-    <li class="toc-item"><a href="/subfolder2/index.html#subfolder-index">Subfolder Index</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/subfolder2/subpage1.html#subpage-1">Subpage 1</a></li>
-
-            <li class="toc-item"><a href="/subfolder2/subpage2.html#subpage-2">Subpage 2</a></li>
-
-                    </ul></li>
-
-    </ul>
-</div>
-
+    <p>Lorem Ipsum Dolor.</p>
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/page1.html#page-1">Page 1</a>
+            </li>
+            <li class="toc-item">
+                <a href="/page2.html#page-2">Page 2</a>
+            </li>
+            <li class="toc-item">
+                <a href="/subfolder/index.html#subfolder-index">Subfolder Index</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/subfolder/subpage1.html#subpage-1">Subpage 1</a>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/subfolder/subpage2.html#subpage-2">Subpage 2</a>
+                    </li>
+                </ul>
+            </li>
+            <li class="toc-item">
+                <a href="/subfolder2/index.html#subfolder-index">Subfolder Index</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/subfolder2/subpage1.html#subpage-1">Subpage 1</a>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/subfolder2/subpage2.html#subpage-2">Subpage 2</a>
+                    </li>
+                </ul>
+            </li>
+        </ul>
     </div>
-
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/toctree/toctree-level-2/expected/subfolder/index.html
+++ b/tests/Integration/tests/toctree/toctree-level-2/expected/subfolder/index.html
@@ -1,22 +1,23 @@
 <!-- content start -->
-    <div class="section" id="subfolder-index">
-            <h1>Subfolder Index</h1>
+<div class="section" id="subfolder-index">
+    <h1>Subfolder Index</h1>
 
-            <p>Lorem Ipsum Dolor.</p>
-            <dl>
-                        <dt>A Definition List</dt>
+    <p>Lorem Ipsum Dolor.</p>
 
-        <dd>Some definition.</dd>    </dl>
+    <dl>
+        <dt>A Definition List</dt>
+        <dd>Some definition.</dd>
+    </dl>
 
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/subfolder/subpage1.html#subpage-1">Subpage 1</a></li>
-
-    <li class="toc-item"><a href="/subfolder/subpage2.html#subpage-2">Subpage 2</a></li>
-
-    </ul>
-</div>
-
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/subfolder/subpage1.html#subpage-1">Subpage 1</a>
+            </li>
+            <li class="toc-item">
+                <a href="/subfolder/subpage2.html#subpage-2">Subpage 2</a>
+            </li>
+        </ul>
     </div>
-
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/toctree/toctree-level-3-maxdepth-1/expected/index.html
+++ b/tests/Integration/tests/toctree/toctree-level-3-maxdepth-1/expected/index.html
@@ -1,21 +1,23 @@
 <!-- content start -->
-    <div class="section" id="document-title">
-            <h1>Document Title</h1>
+<div class="section" id="document-title">
+    <h1>Document Title</h1>
 
-            <p>Lorem Ipsum Dolor.</p>
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
-
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
-
-    <li class="toc-item"><a href="/level-1-1/index.html#level-1-1">Level 1-1</a></li>
-
-    <li class="toc-item"><a href="/level-1-2/index.html#level-1-2">Level 1-2</a></li>
-
-    </ul>
-</div>
-
+    <p>Lorem Ipsum Dolor.</p>
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/page1.html#page-1">Page 1</a>
+            </li>
+            <li class="toc-item">
+                <a href="/page2.html#page-2">Page 2</a>
+            </li>
+            <li class="toc-item">
+                <a href="/level-1-1/index.html#level-1-1">Level 1-1</a>
+            </li>
+            <li class="toc-item">
+                <a href="/level-1-2/index.html#level-1-2">Level 1-2</a>
+            </li>
+        </ul>
     </div>
-
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/toctree/toctree-level-3-maxdepth-2/expected/index.html
+++ b/tests/Integration/tests/toctree/toctree-level-3-maxdepth-2/expected/index.html
@@ -1,35 +1,45 @@
 <!-- content start -->
-    <div class="section" id="document-title">
-            <h1>Document Title</h1>
+<div class="section" id="document-title">
+    <h1>Document Title</h1>
 
-            <p>Lorem Ipsum Dolor.</p>
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
-
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
-
-    <li class="toc-item"><a href="/level-1-1/index.html#level-1-1">Level 1-1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a></li>
-
-            <li class="toc-item"><a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a></li>
-
-                    </ul></li>
-
-    <li class="toc-item"><a href="/level-1-2/index.html#level-1-2">Level 1-2</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
-
-            <li class="toc-item"><a href="/level-1-2/subpage2.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
-
-                    </ul></li>
-
-    </ul>
-</div>
-
+    <p>Lorem Ipsum Dolor.</p>
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/page1.html#page-1">Page 1</a>
+            </li>
+            <li class="toc-item">
+                <a href="/page2.html#page-2">Page 2</a>
+            </li>
+            <li class="toc-item">
+                <a href="/level-1-1/index.html#level-1-1">Level 1-1</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>
+                    </li>
+                </ul>
+            </li>
+            <li class="toc-item">
+                <a href="/level-1-2/index.html#level-1-2">Level 1-2</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/level-1-2/subpage2.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a>
+                    </li>
+                </ul>
+            </li>
+        </ul>
     </div>
-
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/toctree/toctree-level-3/expected/index.html
+++ b/tests/Integration/tests/toctree/toctree-level-3/expected/index.html
@@ -1,45 +1,61 @@
 <!-- content start -->
-    <div class="section" id="document-title">
-            <h1>Document Title</h1>
+<div class="section" id="document-title">
+    <h1>Document Title</h1>
 
-            <p>Lorem Ipsum Dolor.</p>
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
-
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
-
-    <li class="toc-item"><a href="/level-1-1/index.html#level-1-1">Level 1-1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a></li>
-
-            <li class="toc-item"><a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>        <ul class="menu-level-2">
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
-
-            <li class="toc-item"><a href="/level-1-1/level-2-2/subpage2.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a></li>
-
-                    </ul></li>
-
-                    </ul></li>
-
-    <li class="toc-item"><a href="/level-1-2/index.html#level-1-2">Level 1-2</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
-
-            <li class="toc-item"><a href="/level-1-2/subpage2.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a></li>
-
-                    </ul></li>
-
-    </ul>
-</div>
-
+    <p>Lorem Ipsum Dolor.</p>
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/page1.html#page-1">Page 1</a>
+            </li>
+            <li class="toc-item">
+                <a href="/page2.html#page-2">Page 2</a>
+            </li>
+            <li class="toc-item">
+                <a href="/level-1-1/index.html#level-1-1">Level 1-1</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>
+                        <ul class="menu-level-2">
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a>
+                            </li>
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>
+                        <ul class="menu-level-2">
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a>
+                            </li>
+                            <li class="toc-item">
+                                <a href="/level-1-1/level-2-2/subpage2.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+            </li>
+            <li class="toc-item">
+                <a href="/level-1-2/index.html#level-1-2">Level 1-2</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/level-1-2/subpage2.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a>
+                    </li>
+                </ul>
+            </li>
+        </ul>
     </div>
-
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/toctree/toctree-maxdepth/expected/index.html
+++ b/tests/Integration/tests/toctree/toctree-maxdepth/expected/index.html
@@ -1,258 +1,384 @@
 <!-- content start -->
-    <div class="section" id="index">
-            <h1>Index</h1>
-
-            <p>Maxdepth 1</p>
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1-level-1">Page 1, Level 1</a></li>
-
-    <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-1">Subpage 2, Page 1, Level 1</a></li>
-
-    </ul>
-</div>
-
-            <p>Maxdepth 2</p>
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1-level-1">Page 1, Level 1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/subpage1/page1.html#subpage-1-page-1-level-1">Subpage 1, Page 1, Level 1</a></li>
-
-            <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-2-level-1">Subpage 1, Page 2, Level 1</a></li>
-
-                    </ul>        <ul class="section-level-1">
-            <li class="toc-item"><a href="/page1.html#page-1-level-2-1">Page 1, Level 2.1</a></li>
-
-            <li class="toc-item"><a href="/page1.html#page-1-level-2-2">Page 1, Level 2.2</a></li>
-
-                    </ul></li>
-
-    <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-1">Subpage 2, Page 1, Level 1</a>        <ul class="section-level-1">
-            <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-2-1">Subpage 2, Page 1, Level 2.1</a></li>
-
-            <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-2-2">Subpage 2, Page 1, Level 2.2</a></li>
-
-                    </ul></li>
-
-    </ul>
-</div>
-
-            <p>Maxdepth 3</p>
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1-level-1">Page 1, Level 1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/subpage1/page1.html#subpage-1-page-1-level-1">Subpage 1, Page 1, Level 1</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/subpage1/page1.html#subpage-1-page-1-level-2-1">Subpage 1, Page 1, Level 2.1</a></li>
-
-            <li class="toc-item"><a href="/subpage1/page1.html#subpage-1-page-1-level-2-2">Subpage 1, Page 1, Level 2.2</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-2-level-1">Subpage 1, Page 2, Level 1</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-2-level-2-1">Subpage 1, Page 2, Level 2.1</a></li>
-
-            <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-2-level-2-2">Subpage 1, Page 2, Level 2.2</a></li>
-
-                    </ul></li>
-
-                    </ul>        <ul class="section-level-1">
-            <li class="toc-item"><a href="/page1.html#page-1-level-2-1">Page 1, Level 2.1</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/page1.html#page-1-level-3">Page 1, Level 3</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/page1.html#page-1-level-2-2">Page 1, Level 2.2</a></li>
-
-                    </ul></li>
-
-    <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-1">Subpage 2, Page 1, Level 1</a>        <ul class="section-level-1">
-            <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-2-1">Subpage 2, Page 1, Level 2.1</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-3">Subpage 2, Page 1, Level 3</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-2-2">Subpage 2, Page 1, Level 2.2</a></li>
-
-                    </ul></li>
-
-    </ul>
-</div>
-
-            <p>Maxdepth 4</p>
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1-level-1">Page 1, Level 1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/subpage1/page1.html#subpage-1-page-1-level-1">Subpage 1, Page 1, Level 1</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/subpage1/page1.html#subpage-1-page-1-level-2-1">Subpage 1, Page 1, Level 2.1</a>        <ul class="section-level-3">
-            <li class="toc-item"><a href="/subpage1/page1.html#subpage-1-page-1-level-3">Subpage 1, Page 1, Level 3</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/subpage1/page1.html#subpage-1-page-1-level-2-2">Subpage 1, Page 1, Level 2.2</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-2-level-1">Subpage 1, Page 2, Level 1</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-2-level-2-1">Subpage 1, Page 2, Level 2.1</a>        <ul class="section-level-3">
-            <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-2-level-3">Subpage 1, Page 2, Level 3</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-2-level-2-2">Subpage 1, Page 2, Level 2.2</a></li>
-
-                    </ul></li>
-
-                    </ul>        <ul class="section-level-1">
-            <li class="toc-item"><a href="/page1.html#page-1-level-2-1">Page 1, Level 2.1</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/page1.html#page-1-level-3">Page 1, Level 3</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/page1.html#page-1-level-4">Page 1, Level 4</a></li>
-
-                    </ul></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/page1.html#page-1-level-2-2">Page 1, Level 2.2</a></li>
-
-                    </ul></li>
-
-    <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-1">Subpage 2, Page 1, Level 1</a>        <ul class="section-level-1">
-            <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-2-1">Subpage 2, Page 1, Level 2.1</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-3">Subpage 2, Page 1, Level 3</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-2-2">Subpage 2, Page 1, Level 2.2</a></li>
-
-                    </ul></li>
-
-    </ul>
-</div>
-
-            <p>Maxdepth 5</p>
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1-level-1">Page 1, Level 1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/subpage1/page1.html#subpage-1-page-1-level-1">Subpage 1, Page 1, Level 1</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/subpage1/page1.html#subpage-1-page-1-level-2-1">Subpage 1, Page 1, Level 2.1</a>        <ul class="section-level-3">
-            <li class="toc-item"><a href="/subpage1/page1.html#subpage-1-page-1-level-3">Subpage 1, Page 1, Level 3</a>        <ul class="section-level-3">
-            <li class="toc-item"><a href="/subpage1/page1.html#subpage-1-page-1-level-4">Subpage 1, Page 1, Level 4</a></li>
-
-                    </ul></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/subpage1/page1.html#subpage-1-page-1-level-2-2">Subpage 1, Page 1, Level 2.2</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-2-level-1">Subpage 1, Page 2, Level 1</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-2-level-2-1">Subpage 1, Page 2, Level 2.1</a>        <ul class="section-level-3">
-            <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-2-level-3">Subpage 1, Page 2, Level 3</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-2-level-2-2">Subpage 1, Page 2, Level 2.2</a></li>
-
-                    </ul></li>
-
-                    </ul>        <ul class="section-level-1">
-            <li class="toc-item"><a href="/page1.html#page-1-level-2-1">Page 1, Level 2.1</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/page1.html#page-1-level-3">Page 1, Level 3</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/page1.html#page-1-level-4">Page 1, Level 4</a>        <ul class="section-level-3">
-            <li class="toc-item"><a href="/page1.html#page-1-level-5">Page 1, Level 5</a></li>
-
-                    </ul></li>
-
-                    </ul></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/page1.html#page-1-level-2-2">Page 1, Level 2.2</a></li>
-
-                    </ul></li>
-
-    <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-1">Subpage 2, Page 1, Level 1</a>        <ul class="section-level-1">
-            <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-2-1">Subpage 2, Page 1, Level 2.1</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-3">Subpage 2, Page 1, Level 3</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-2-2">Subpage 2, Page 1, Level 2.2</a></li>
-
-                    </ul></li>
-
-    </ul>
-</div>
-
-            <p>No Maxdepth</p>
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1-level-1">Page 1, Level 1</a>        <ul class="menu-level-1">
-            <li class="toc-item"><a href="/subpage1/page1.html#subpage-1-page-1-level-1">Subpage 1, Page 1, Level 1</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/subpage1/page1.html#subpage-1-page-1-level-2-1">Subpage 1, Page 1, Level 2.1</a>        <ul class="section-level-3">
-            <li class="toc-item"><a href="/subpage1/page1.html#subpage-1-page-1-level-3">Subpage 1, Page 1, Level 3</a>        <ul class="section-level-3">
-            <li class="toc-item"><a href="/subpage1/page1.html#subpage-1-page-1-level-4">Subpage 1, Page 1, Level 4</a>        <ul class="section-level-4">
-            <li class="toc-item"><a href="/subpage1/page1.html#subpage-1-page-1-level-5">Subpage 1, Page 1, Level 5</a></li>
-
-                    </ul></li>
-
-                    </ul></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/subpage1/page1.html#subpage-1-page-1-level-2-2">Subpage 1, Page 1, Level 2.2</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-2-level-1">Subpage 1, Page 2, Level 1</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-2-level-2-1">Subpage 1, Page 2, Level 2.1</a>        <ul class="section-level-3">
-            <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-2-level-3">Subpage 1, Page 2, Level 3</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/subpage1/page2.html#subpage-1-page-2-level-2-2">Subpage 1, Page 2, Level 2.2</a></li>
-
-                    </ul></li>
-
-                    </ul>        <ul class="section-level-1">
-            <li class="toc-item"><a href="/page1.html#page-1-level-2-1">Page 1, Level 2.1</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/page1.html#page-1-level-3">Page 1, Level 3</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/page1.html#page-1-level-4">Page 1, Level 4</a>        <ul class="section-level-3">
-            <li class="toc-item"><a href="/page1.html#page-1-level-5">Page 1, Level 5</a></li>
-
-                    </ul></li>
-
-                    </ul></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/page1.html#page-1-level-2-2">Page 1, Level 2.2</a></li>
-
-                    </ul></li>
-
-    <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-1">Subpage 2, Page 1, Level 1</a>        <ul class="section-level-1">
-            <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-2-1">Subpage 2, Page 1, Level 2.1</a>        <ul class="section-level-2">
-            <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-3">Subpage 2, Page 1, Level 3</a></li>
-
-                    </ul></li>
-
-            <li class="toc-item"><a href="/subpage2/page1.html#subpage-2-page-1-level-2-2">Subpage 2, Page 1, Level 2.2</a></li>
-
-                    </ul></li>
-
-    </ul>
-</div>
-
-            <p>Glob</p>
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/subpages/page1.html#page-1">Page 1</a></li>
-
-    <li class="toc-item"><a href="/subpages/page2.html#page-2">Page 2</a></li>
-
-    </ul>
-</div>
-
+<div class="section" id="index">
+    <h1>Index</h1>
+
+    <p>Maxdepth 1</p>
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/page1.html#page-1-level-1">Page 1, Level 1</a>
+            </li>
+            <li class="toc-item">
+                <a href="/subpage2/page1.html#subpage-2-page-1-level-1">Subpage 2, Page 1, Level 1</a>
+            </li>
+        </ul>
     </div>
 
+    <p>Maxdepth 2</p>
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/page1.html#page-1-level-1">Page 1, Level 1</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/subpage1/page1.html#subpage-1-page-1-level-1">Subpage 1, Page 1, Level 1</a>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/subpage1/page2.html#subpage-1-page-2-level-1">Subpage 1, Page 2, Level 1</a>
+                    </li>
+                </ul>
+                <ul class="section-level-1">
+                    <li class="toc-item">
+                        <a href="/page1.html#page-1-level-2-1">Page 1, Level 2.1</a>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/page1.html#page-1-level-2-2">Page 1, Level 2.2</a>
+                    </li>
+                </ul>
+            </li>
+            <li class="toc-item">
+                <a href="/subpage2/page1.html#subpage-2-page-1-level-1">Subpage 2, Page 1, Level 1</a>
+                <ul class="section-level-1">
+                    <li class="toc-item">
+                        <a href="/subpage2/page1.html#subpage-2-page-1-level-2-1">Subpage 2, Page 1, Level 2.1</a>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/subpage2/page1.html#subpage-2-page-1-level-2-2">Subpage 2, Page 1, Level 2.2</a>
+                    </li>
+                </ul>
+            </li>
+        </ul>
+    </div>
+
+    <p>Maxdepth 3</p>
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/page1.html#page-1-level-1">Page 1, Level 1</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/subpage1/page1.html#subpage-1-page-1-level-1">Subpage 1, Page 1, Level 1</a>
+                        <ul class="section-level-2">
+                            <li class="toc-item">
+                                <a href="/subpage1/page1.html#subpage-1-page-1-level-2-1">Subpage 1, Page 1, Level 2.1</a>
+                            </li>
+                            <li class="toc-item">
+                                <a href="/subpage1/page1.html#subpage-1-page-1-level-2-2">Subpage 1, Page 1, Level 2.2</a>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/subpage1/page2.html#subpage-1-page-2-level-1">Subpage 1, Page 2, Level 1</a>
+                        <ul class="section-level-2">
+                            <li class="toc-item">
+                                <a href="/subpage1/page2.html#subpage-1-page-2-level-2-1">Subpage 1, Page 2, Level 2.1</a>
+                            </li>
+                            <li class="toc-item">
+                                <a href="/subpage1/page2.html#subpage-1-page-2-level-2-2">Subpage 1, Page 2, Level 2.2</a>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+                <ul class="section-level-1">
+                    <li class="toc-item">
+                        <a href="/page1.html#page-1-level-2-1">Page 1, Level 2.1</a>
+                        <ul class="section-level-2">
+                            <li class="toc-item">
+                                <a href="/page1.html#page-1-level-3">Page 1, Level 3</a>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/page1.html#page-1-level-2-2">Page 1, Level 2.2</a>
+                    </li>
+                </ul>
+            </li>
+
+            <li class="toc-item">
+                <a href="/subpage2/page1.html#subpage-2-page-1-level-1">Subpage 2, Page 1, Level 1</a>
+                <ul class="section-level-1">
+                    <li class="toc-item">
+                        <a href="/subpage2/page1.html#subpage-2-page-1-level-2-1">Subpage 2, Page 1, Level 2.1</a>
+                        <ul class="section-level-2">
+                            <li class="toc-item">
+                                <a href="/subpage2/page1.html#subpage-2-page-1-level-3">Subpage 2, Page 1, Level 3</a>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/subpage2/page1.html#subpage-2-page-1-level-2-2">Subpage 2, Page 1, Level 2.2</a>
+                    </li>
+                </ul>
+            </li>
+        </ul>
+    </div>
+
+    <p>Maxdepth 4</p>
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/page1.html#page-1-level-1">Page 1, Level 1</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/subpage1/page1.html#subpage-1-page-1-level-1">Subpage 1, Page 1, Level 1</a>
+                        <ul class="section-level-2">
+                            <li class="toc-item">
+                                <a href="/subpage1/page1.html#subpage-1-page-1-level-2-1">Subpage 1, Page 1, Level 2.1</a>
+                                <ul class="section-level-3">
+                                    <li class="toc-item">
+                                        <a href="/subpage1/page1.html#subpage-1-page-1-level-3">Subpage 1, Page 1, Level 3</a>
+                                    </li>
+                                </ul>
+                            </li>
+                            <li class="toc-item">
+                                <a href="/subpage1/page1.html#subpage-1-page-1-level-2-2">Subpage 1, Page 1, Level 2.2</a>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/subpage1/page2.html#subpage-1-page-2-level-1">Subpage 1, Page 2, Level 1</a>
+                        <ul class="section-level-2">
+                            <li class="toc-item">
+                                <a href="/subpage1/page2.html#subpage-1-page-2-level-2-1">Subpage 1, Page 2, Level 2.1</a>
+                                <ul class="section-level-3">
+                                    <li class="toc-item">
+                                        <a href="/subpage1/page2.html#subpage-1-page-2-level-3">Subpage 1, Page 2, Level 3</a>
+                                    </li>
+                                </ul>
+                            </li>
+                            <li class="toc-item">
+                                <a href="/subpage1/page2.html#subpage-1-page-2-level-2-2">Subpage 1, Page 2, Level 2.2</a>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+                <ul class="section-level-1">
+                    <li class="toc-item">
+                        <a href="/page1.html#page-1-level-2-1">Page 1, Level 2.1</a>
+                        <ul class="section-level-2">
+                            <li class="toc-item">
+                                <a href="/page1.html#page-1-level-3">Page 1, Level 3</a>
+                                <ul class="section-level-2">
+                                    <li class="toc-item">
+                                        <a href="/page1.html#page-1-level-4">Page 1, Level 4</a>
+                                    </li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/page1.html#page-1-level-2-2">Page 1, Level 2.2</a>
+                    </li>
+                </ul>
+            </li>
+            <li class="toc-item">
+                <a href="/subpage2/page1.html#subpage-2-page-1-level-1">Subpage 2, Page 1, Level 1</a>
+                <ul class="section-level-1">
+                    <li class="toc-item">
+                        <a href="/subpage2/page1.html#subpage-2-page-1-level-2-1">Subpage 2, Page 1, Level 2.1</a>
+                        <ul class="section-level-2">
+                            <li class="toc-item">
+                                <a href="/subpage2/page1.html#subpage-2-page-1-level-3">Subpage 2, Page 1, Level 3</a>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/subpage2/page1.html#subpage-2-page-1-level-2-2">Subpage 2, Page 1, Level 2.2</a>
+                    </li>
+                </ul>
+            </li>
+        </ul>
+    </div>
+
+    <p>Maxdepth 5</p>
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/page1.html#page-1-level-1">Page 1, Level 1</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/subpage1/page1.html#subpage-1-page-1-level-1">Subpage 1, Page 1, Level 1</a>
+                        <ul class="section-level-2">
+                            <li class="toc-item">
+                                <a href="/subpage1/page1.html#subpage-1-page-1-level-2-1">Subpage 1, Page 1, Level 2.1</a>
+                                <ul class="section-level-3">
+                                    <li class="toc-item">
+                                        <a href="/subpage1/page1.html#subpage-1-page-1-level-3">Subpage 1, Page 1, Level 3</a>
+                                        <ul class="section-level-3">
+                                            <li class="toc-item">
+                                                <a href="/subpage1/page1.html#subpage-1-page-1-level-4">Subpage 1, Page 1, Level 4</a>
+                                            </li>
+                                        </ul>
+                                    </li>
+                                </ul>
+                            </li>
+                            <li class="toc-item">
+                                <a href="/subpage1/page1.html#subpage-1-page-1-level-2-2">Subpage 1, Page 1, Level 2.2</a>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/subpage1/page2.html#subpage-1-page-2-level-1">Subpage 1, Page 2, Level 1</a>
+                        <ul class="section-level-2">
+                            <li class="toc-item">
+                                <a href="/subpage1/page2.html#subpage-1-page-2-level-2-1">Subpage 1, Page 2, Level 2.1</a>
+                                <ul class="section-level-3">
+                                    <li class="toc-item">
+                                        <a href="/subpage1/page2.html#subpage-1-page-2-level-3">Subpage 1, Page 2, Level 3</a>
+                                    </li>
+                                </ul>
+                            </li>
+                            <li class="toc-item">
+                                <a href="/subpage1/page2.html#subpage-1-page-2-level-2-2">Subpage 1, Page 2, Level 2.2</a>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+                <ul class="section-level-1">
+                    <li class="toc-item">
+                        <a href="/page1.html#page-1-level-2-1">Page 1, Level 2.1</a>
+                        <ul class="section-level-2">
+                            <li class="toc-item">
+                                <a href="/page1.html#page-1-level-3">Page 1, Level 3</a>
+                                <ul class="section-level-2">
+                                    <li class="toc-item">
+                                        <a href="/page1.html#page-1-level-4">Page 1, Level 4</a>
+                                        <ul class="section-level-3">
+                                            <li class="toc-item">
+                                                <a href="/page1.html#page-1-level-5">Page 1, Level 5</a>
+                                            </li>
+                                        </ul>
+                                    </li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/page1.html#page-1-level-2-2">Page 1, Level 2.2</a>
+                    </li>
+                </ul>
+            </li>
+            <li class="toc-item">
+                <a href="/subpage2/page1.html#subpage-2-page-1-level-1">Subpage 2, Page 1, Level 1</a>
+                <ul class="section-level-1">
+                    <li class="toc-item">
+                        <a href="/subpage2/page1.html#subpage-2-page-1-level-2-1">Subpage 2, Page 1, Level 2.1</a>
+                        <ul class="section-level-2">
+                            <li class="toc-item">
+                                <a href="/subpage2/page1.html#subpage-2-page-1-level-3">Subpage 2, Page 1, Level 3</a>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/subpage2/page1.html#subpage-2-page-1-level-2-2">Subpage 2, Page 1, Level 2.2</a>
+                    </li>
+                </ul>
+            </li>
+        </ul>
+    </div>
+
+    <p>No Maxdepth</p>
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/page1.html#page-1-level-1">Page 1, Level 1</a>
+                <ul class="menu-level-1">
+                    <li class="toc-item">
+                        <a href="/subpage1/page1.html#subpage-1-page-1-level-1">Subpage 1, Page 1, Level 1</a>
+                        <ul class="section-level-2">
+                            <li class="toc-item">
+                                <a href="/subpage1/page1.html#subpage-1-page-1-level-2-1">Subpage 1, Page 1, Level 2.1</a>
+                                <ul class="section-level-3">
+                                    <li class="toc-item">
+                                        <a href="/subpage1/page1.html#subpage-1-page-1-level-3">Subpage 1, Page 1, Level 3</a>
+                                        <ul class="section-level-3">
+                                            <li class="toc-item">
+                                                <a href="/subpage1/page1.html#subpage-1-page-1-level-4">Subpage 1, Page 1, Level 4</a>
+                                                <ul class="section-level-4">
+                                                    <li class="toc-item">
+                                                        <a href="/subpage1/page1.html#subpage-1-page-1-level-5">Subpage 1, Page 1, Level 5</a>
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                        </ul>
+                                    </li>
+                                </ul>
+                            </li>
+                            <li class="toc-item">
+                                <a href="/subpage1/page1.html#subpage-1-page-1-level-2-2">Subpage 1, Page 1, Level 2.2</a>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/subpage1/page2.html#subpage-1-page-2-level-1">Subpage 1, Page 2, Level 1</a>
+                        <ul class="section-level-2">
+                            <li class="toc-item">
+                                <a href="/subpage1/page2.html#subpage-1-page-2-level-2-1">Subpage 1, Page 2, Level 2.1</a>
+                                <ul class="section-level-3">
+                                    <li class="toc-item">
+                                        <a href="/subpage1/page2.html#subpage-1-page-2-level-3">Subpage 1, Page 2, Level 3</a>
+                                    </li>
+                                </ul>
+                            </li>
+                            <li class="toc-item">
+                                <a href="/subpage1/page2.html#subpage-1-page-2-level-2-2">Subpage 1, Page 2, Level 2.2</a>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+                <ul class="section-level-1">
+                    <li class="toc-item">
+                        <a href="/page1.html#page-1-level-2-1">Page 1, Level 2.1</a>
+                        <ul class="section-level-2">
+                            <li class="toc-item">
+                                <a href="/page1.html#page-1-level-3">Page 1, Level 3</a>
+                                <ul class="section-level-2">
+                                    <li class="toc-item">
+                                        <a href="/page1.html#page-1-level-4">Page 1, Level 4</a>
+                                        <ul class="section-level-3">
+                                            <li class="toc-item">
+                                                <a href="/page1.html#page-1-level-5">Page 1, Level 5</a>
+                                            </li>
+                                        </ul>
+                                    </li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/page1.html#page-1-level-2-2">Page 1, Level 2.2</a>
+                    </li>
+                </ul>
+            </li>
+            <li class="toc-item">
+                <a href="/subpage2/page1.html#subpage-2-page-1-level-1">Subpage 2, Page 1, Level 1</a>
+                <ul class="section-level-1">
+                    <li class="toc-item">
+                        <a href="/subpage2/page1.html#subpage-2-page-1-level-2-1">Subpage 2, Page 1, Level 2.1</a>
+                        <ul class="section-level-2">
+                            <li class="toc-item">
+                                <a href="/subpage2/page1.html#subpage-2-page-1-level-3">Subpage 2, Page 1, Level 3</a>
+                            </li>
+                        </ul>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/subpage2/page1.html#subpage-2-page-1-level-2-2">Subpage 2, Page 1, Level 2.2</a>
+                    </li>
+                </ul>
+            </li>
+        </ul>
+    </div>
+
+    <p>Glob</p>
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/subpages/page1.html#page-1">Page 1</a>
+            </li>
+            <li class="toc-item">
+                <a href="/subpages/page2.html#page-2">Page 2</a>
+            </li>
+        </ul>
+    </div>
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/toctree/toctree-no-duplicates/expected/index.html
+++ b/tests/Integration/tests/toctree/toctree-no-duplicates/expected/index.html
@@ -1,20 +1,22 @@
 <!-- content start -->
-    <div class="section" id="index">
-            <h1>index</h1>
+<div class="section" id="index">
+    <h1>index</h1>
 
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/overview.html#overview">Overview</a></li>
-
-    <li class="toc-item"><a href="/apple.html#apple">Apple</a></li>
-
-    <li class="toc-item"><a href="/banana.html#banana">Banana</a></li>
-
-    <li class="toc-item"><a href="/cherry.html#cherry">Cherry</a></li>
-
-    </ul>
-</div>
-
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/overview.html#overview">Overview</a>
+            </li>
+            <li class="toc-item">
+                <a href="/apple.html#apple">Apple</a>
+            </li>
+            <li class="toc-item">
+                <a href="/banana.html#banana">Banana</a>
+            </li>
+            <li class="toc-item">
+                <a href="/cherry.html#cherry">Cherry</a>
+            </li>
+        </ul>
     </div>
-
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/toctree/toctree-no-duplicates/expected/overview.html
+++ b/tests/Integration/tests/toctree/toctree-no-duplicates/expected/overview.html
@@ -1,21 +1,23 @@
 <!-- content start -->
-    <div class="section" id="overview">
-            <h1>Overview</h1>
+<div class="section" id="overview">
+    <h1>Overview</h1>
 
-            <p>Lorem Ipsum Dolor</p>
-            <div class="menu">
-    <ul class="menu-level">
-    <li class="toc-item current active"><a href="/overview.html#overview">Overview</a></li>
-
-    <li class="toc-item"><a href="/apple.html#apple">Apple</a></li>
-
-    <li class="toc-item"><a href="/banana.html#banana">Banana</a></li>
-
-    <li class="toc-item"><a href="/cherry.html#cherry">Cherry</a></li>
-
-    </ul>
-</div>
-
+    <p>Lorem Ipsum Dolor</p>
+    <div class="menu">
+        <ul class="menu-level">
+            <li class="toc-item current active">
+                <a href="/overview.html#overview">Overview</a>
+            </li>
+            <li class="toc-item">
+                <a href="/apple.html#apple">Apple</a>
+            </li>
+            <li class="toc-item">
+                <a href="/banana.html#banana">Banana</a>
+            </li>
+            <li class="toc-item">
+                <a href="/cherry.html#cherry">Cherry</a>
+            </li>
+        </ul>
     </div>
-
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/toctree/toctree-simple/expected/index.html
+++ b/tests/Integration/tests/toctree/toctree-simple/expected/index.html
@@ -1,21 +1,24 @@
 <!-- content start -->
-    <div class="section" id="index">
-            <h1>index</h1>
+<div class="section" id="index">
+    <h1>index</h1>
 
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a>        <ul class="section-level-1">
-            <li class="toc-item"><a href="/page1.html#chapter-1">Chapter 1</a></li>
-
-            <li class="toc-item"><a href="/page1.html#chapter-2">Chapter 2</a></li>
-
-                    </ul></li>
-
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
-
-    </ul>
-</div>
-
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/page1.html#page-1">Page 1</a>
+                <ul class="section-level-1">
+                    <li class="toc-item">
+                        <a href="/page1.html#chapter-1">Chapter 1</a>
+                    </li>
+                    <li class="toc-item">
+                        <a href="/page1.html#chapter-2">Chapter 2</a>
+                    </li>
+                </ul>
+            </li>
+            <li class="toc-item">
+                <a href="/page2.html#page-2">Page 2</a>
+            </li>
+        </ul>
     </div>
-
+</div>
 <!-- content end -->

--- a/tests/Integration/tests/toctree/toctree-titlesonly/expected/index.html
+++ b/tests/Integration/tests/toctree/toctree-titlesonly/expected/index.html
@@ -1,16 +1,16 @@
 <!-- content start -->
-    <div class="section" id="document-title">
-            <h1>Document Title</h1>
+<div class="section" id="document-title">
+    <h1>Document Title</h1>
 
-            <div class="toc">
-    <ul class="menu-level">
-    <li class="toc-item"><a href="/page1.html#page-1">Page 1</a></li>
-
-    <li class="toc-item"><a href="/page2.html#page-2">Page 2</a></li>
-
-    </ul>
-</div>
-
+    <div class="toc">
+        <ul class="menu-level">
+            <li class="toc-item">
+                <a href="/page1.html#page-1">Page 1</a>
+            </li>
+            <li class="toc-item">
+                <a href="/page2.html#page-2">Page 2</a>
+            </li>
+        </ul>
     </div>
-
+</div>
 <!-- content end -->


### PR DESCRIPTION
Fixes #922 

Some templates used `{% apply spaceless %}`. This filter does a [very naive preg_replace](https://github.com/twigphp/Twig/blob/b46e93c7257fb01b7c77768210997b1e00643b91/src/Extension/CoreExtension.php#L1132-L1135) to remove any space between HTML tags. This is a big issue, as it also removes whitespace between inline HTML tags (as shown by the testcase added in 5ede52dcde62b68db57c063429b80a1590ce719c).

We must no longer use spaceless in templates, as this creates issues like this. Instead, we must rely on Twig's whitespace control characters: `{{-`/`{%-`/`{#-` removing all whitespace before/after the Twig tag and  `{{~`/`{%~`/`{#~` removing all horizontal whitespace before/after the Twig tag.

I also introduced a Twig file loader that removes the last newline feed from files (8790e8e129b14fd3cdddbc16879df37a5774345a). In unix systems, all files must end with a new line feed. But we don't want all templates to end with a new line feed in the output. That seems to be the main reason spaceless was used in this project. By removing them during loading, we no longer need spaceless. If you want to enforce a new line in the resulting HTML, you can end the file with a Twig comment (as the new line between the last HTML and the Twig comment is not removed).

Furthermore, I improved whitespace control a bit to create nicer output HTML and had to update a LOT of tests (c1452ed7239d13536082bc56eb91f0ac1e7d3c1c). Merging this PR might also result in tests breaking in TYPO3 / Symfony Docs test suites, but this would have been the case also when only removing the use of spaceless.
(quick note: I updated most tests manually, except from the `tests-full` tests as these are very tedious. We might want to double check that all whitespace changes in this file are indeed not resulting in a display change)