### PR TITLE
[TASK] Add getter for Documents to RenderContext

### DIFF
--- a/packages/guides/src/RenderContext.php
+++ b/packages/guides/src/RenderContext.php
@@ -82,6 +82,17 @@ class RenderContext
         )->withIterator($this->getIterator());
     }
 
+    public function getDocument(): DocumentNode
+    {
+        return $this->document;
+    }
+
+    /** @return DocumentNode[] */
+    public function getAllDocuments(): array
+    {
+        return $this->allDocuments;
+    }
+
     public function withIterator(Renderer\DocumentListIterator $iterator): self
     {
         $that = clone $this;


### PR DESCRIPTION
Currently to get the current document you have to do

$document = $renderContext->getDocumentNodeForEntry($renderContext->getCurrentDocumentEntry());

even though the document is saved in a variable