### PR TITLE
Fix invalid url parsing

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Parser/InlineLexer.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/InlineLexer.php
@@ -74,7 +74,7 @@ final class InlineLexer extends AbstractLexer
             '|',
             '\\*\\*',
             '\\*',
-            '\b(?<!:)[a-z0-9\\.\-+]{2,}:\\/\\/[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*[-a-zA-Z0-9()@%_\\+~#&\\/=]', // standalone hyperlinks
+            '\b(?<!:)[a-z0-9\\.\-+]{2,}:\\/\\/[-a-zA-Z0-9@:%_\\+.~#?&\\/=]*[-a-zA-Z0-9@%_\\+~#&\\/=]', // standalone hyperlinks
         ];
     }
 


### PR DESCRIPTION
I did not found any specification where an URL can contain parenthesis in the url, nor we do have a test that fails on this case. If we need it anyway we can introduce it later on. But for now this fixes a bug where the fetch of a url is way to gredy.