### PR TITLE
[BUGFIX] do not parse version config node

### DIFF
--- a/packages/guides/src/DependencyInjection/GuidesExtension.php
+++ b/packages/guides/src/DependencyInjection/GuidesExtension.php
@@ -42,6 +42,7 @@ use function is_array;
 use function is_int;
 use function is_string;
 use function pathinfo;
+use function trim;
 use function var_export;
 
 final class GuidesExtension extends Extension implements CompilerPassInterface, ConfigurationInterface, PrependExtensionInterface
@@ -68,12 +69,33 @@ final class GuidesExtension extends Extension implements CompilerPassInterface, 
                                         return var_export($value, true);
                                     }
 
+                                    if (is_string($value)) {
+                                        return trim($value, "'");
+                                    }
+
                                     return $value;
                                 },
                             )
                             ->end()
                         ->end()
-                        ->scalarNode('release')->end()
+                        ->scalarNode('release')
+                            ->beforeNormalization()
+                            ->always(
+                            // We need to revert the phpize call in XmlUtils. Version is always a string!
+                                static function ($value) {
+                                    if (!is_int($value) && !is_string($value)) {
+                                        return var_export($value, true);
+                                    }
+
+                                    if (is_string($value)) {
+                                        return trim($value, "'");
+                                    }
+
+                                    return $value;
+                                },
+                            )
+                            ->end()
+                        ->end()
                         ->scalarNode('copyright')->end()
                     ->end()
                 ->end()

--- a/tests/Integration/tests/configuration/config-project/expected/index.html
+++ b/tests/Integration/tests/configuration/config-project/expected/index.html
@@ -10,7 +10,7 @@
         <dd>Title</dd>
                                 <dt>version:</dt>
 
-        <dd>12.4</dd>
+        <dd>12.4.0</dd>
                                 <dt>release:</dt>
 
         <dd>12.4.9-dev</dd>

--- a/tests/Integration/tests/configuration/config-project/input/guides.xml
+++ b/tests/Integration/tests/configuration/config-project/input/guides.xml
@@ -5,7 +5,7 @@
 >
     <project
             title="Title"
-            version="12.4"
+            version="12.4.0"
             release="12.4.9-dev"
             copyright="since 1998 phpDocumentor Team and Contributors"
     />

--- a/tests/Integration/tests/meta/version-from-guides-xml/input/guides.xml
+++ b/tests/Integration/tests/meta/version-from-guides-xml/input/guides.xml
@@ -6,7 +6,7 @@
 >
     <project
             title="Render guides"
-            version="3.0"
+            version="'3.0'"
             release="3.0.0"
     />
 </guides>


### PR DESCRIPTION
symfony is trying to normalize the xml input using
some logic. However in our case we want to fetch the raw value for version. But this is not possible. therefor an escape system is added by adding `'`.

fixes #1057 