### PR TITLE
[BUGFIX] do not trim per line

### DIFF
--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/GridTableRuleTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/GridTableRuleTest.php
@@ -205,7 +205,7 @@ RST;
 +===================================+===============+
 | description                       | string        |
 +-----------------------------------+               |
-| author                            |               |
+| author                            | test          |
 +-----------------------------------+---------------+
 | keywords                          | string        |
 +-----------------------------------+---------------+
@@ -217,7 +217,7 @@ RST;
 
         $row1 = new TableRow();
         $row1->addColumn(self::createColumnNode('description'));
-        $rowSpan = self::createColumnNode('string');
+        $rowSpan = self::createColumnNode("string\n\ntest");
         $rowSpan->incrementRowSpan();
         $row1->addColumn($rowSpan);
 

--- a/packages/guides/src/Nodes/Table/TableColumn.php
+++ b/packages/guides/src/Nodes/Table/TableColumn.php
@@ -54,7 +54,7 @@ final class TableColumn extends CompoundNode
 
     public function addContent(string $content): void
     {
-        $this->content = trim($this->content . $content);
+        $this->content .= $content;
     }
 
     public function incrementRowSpan(): void

--- a/packages/guides/src/Nodes/Table/TableRow.php
+++ b/packages/guides/src/Nodes/Table/TableRow.php
@@ -23,8 +23,10 @@ use function sprintf;
 
 final class TableRow
 {
-    /** @var TableColumn[] */
-    private array $columns = [];
+    /** @param TableColumn[] $columns */
+    public function __construct(private array $columns = [])
+    {
+    }
 
     public function addColumn(TableColumn $tableColumn): void
     {

--- a/tests/Integration/tests/tables/grid-table-with-list/expected/index.html
+++ b/tests/Integration/tests/tables/grid-table-with-list/expected/index.html
@@ -6,17 +6,21 @@
                 <tbody>
     <tr>
             <td><strong>Paragraphs</strong></td>
-        <td><p>Paragraph 1</p>
-<p>Paragraph 2</p></td>
+        <td>
+            <p>Paragraph 1</p>
+            <p>Paragraph 2</p>
+        </td>
     </tr>
     <tr>
             <td><strong>Lists</strong></td>
-            <td><p>See the list</p>
+            <td>
+                <p>See the list</p>
                 <ul>
                     <li>Item 1</li>
                     <li>Item 2</li>
                 </ul>
-<p>A paragraph</p></td>
+<p>A paragraph</p>
+            </td>
     </tr>
 </tbody>
 </table>


### PR DESCRIPTION
Table cells may contain multiple lines as we did trim the cell content before the table parsing was completed we did mis empty lines. As empty lines where missing we did break the parsing process of a table cell.

fixes #955 