### PR TITLE
Use a more precise autoload prefix

### DIFF
--- a/packages/guides-markdown/composer.json
+++ b/packages/guides-markdown/composer.json
@@ -9,7 +9,7 @@
     },
     "autoload": {
         "psr-4": {
-            "phpDocumentor\\Guides\\": "src/"
+            "phpDocumentor\\Guides\\Markdown\\": "src/Markdown/"
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
As `phpdocumentor/guides-markdown` provides only classes for the `Markdown` subnamespace, using a more precise autoload prefix for the PSR-4 configuration will allow the ClassLoader to avoid checking that package for other guides classes.
This won't make much difference when using an optimized autoloader with level 2 optimizations as the classmap will be used instead of checking the filesystem. But it will help a bit when using a non-optimized autoloader (which is common in dev environments as that provide a better DX when your codebase gets edited).

If this is considered good by maintainers, I will update the PR to apply that to other packages rather than just `guides-markdown` as others could also benefit from it.
Also, maintainers should decide whether they prefer using `src/Markdown/` as path in the config or flattening the `src` folder by removing the `Markdown` folder entirely (similar to what is done for `guides-cli`). Both options are valid and I'll happily apply the preferred one when updating this PR to cover all packages.