### PR TITLE
[BUGFIX] inline break needs to convert to space

### DIFF
--- a/packages/guides-markdown/resources/config/guides-markdown.php
+++ b/packages/guides-markdown/resources/config/guides-markdown.php
@@ -11,6 +11,7 @@ use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\EmphasisParser;
 use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\InlineCodeParser;
 use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\InlineImageParser;
 use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\LinkParser;
+use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\NewLineParser;
 use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\PlainTextParser;
 use phpDocumentor\Guides\Markdown\Parsers\InlineParsers\StrongParser;
 use phpDocumentor\Guides\Markdown\Parsers\ListBlockParser;
@@ -72,6 +73,8 @@ return static function (ContainerConfigurator $container): void {
         ->tag('phpdoc.guides.markdown.parser.inlineParser')
         ->set(InlineImageParser::class)
         ->arg('$inlineParsers', tagged_iterator('phpdoc.guides.markdown.parser.inlineParser'))
+        ->tag('phpdoc.guides.markdown.parser.inlineParser')
+        ->set(NewLineParser::class)
         ->tag('phpdoc.guides.markdown.parser.inlineParser')
 
         ->set(MarkupLanguageParser::class)

--- a/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/NewLineParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/NewLineParser.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\Markdown\Parsers\InlineParsers;
+
+use League\CommonMark\Node\Inline\Newline;
+use League\CommonMark\Node\Node as CommonMarkNode;
+use League\CommonMark\Node\NodeWalker;
+use League\CommonMark\Node\NodeWalkerEvent;
+use phpDocumentor\Guides\MarkupLanguageParser;
+use phpDocumentor\Guides\Nodes\Inline\InlineNode;
+use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
+
+/** @extends AbstractInlineParser<PlainTextInlineNode> */
+class NewLineParser extends AbstractInlineParser
+{
+    public function __construct()
+    {
+    }
+
+    public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): InlineNode
+    {
+        return new PlainTextInlineNode(' ');
+    }
+
+    public function supports(NodeWalkerEvent $event): bool
+    {
+        return $event->isEntering() && $event->getNode() instanceof Newline;
+    }
+}

--- a/tests/Integration/tests/markdown/blockquote-md/expected/index.html
+++ b/tests/Integration/tests/markdown/blockquote-md/expected/index.html
@@ -2,7 +2,7 @@
     <div class="section" id="markdown-blockquotes">
             <h1>Markdown Blockquotes</h1>
             <blockquote>
-    <p>This is a blockquote.It can span multiple lines.</p>
+    <p>This is a blockquote. It can span multiple lines.</p>
 </blockquote>
             <div class="section" id="blockquotes-with-multiple-paragraphs">
             <h2>Blockquotes with Multiple Paragraphs</h2>

--- a/tests/Integration/tests/markdown/emphasis-md/expected/index.html
+++ b/tests/Integration/tests/markdown/emphasis-md/expected/index.html
@@ -2,7 +2,7 @@
     <div class="section" id="markdown-with-emphasis">
             <h1>Markdown with emphasis</h1>
 
-    <p><em>Italic</em> or <em>Italic</em><strong>Bold</strong> or <strong>Bold</strong></p>
+    <p><em>Italic</em> or <em>Italic</em> <strong>Bold</strong> or <strong>Bold</strong></p>
 
     </div>
 <!-- content end -->

--- a/tests/Integration/tests/markdown/html-inline-md/expected/index.html
+++ b/tests/Integration/tests/markdown/html-inline-md/expected/index.html
@@ -2,7 +2,7 @@
     <div class="section" id="markdown-with-html">
             <h1>Markdown with html</h1>
 
-    <p>In files of text, where words take flight,Markdown weaves its magic, bold and bright.Hashes and stars, a simple code,A poet&#039;s playground, where stories unfold. &lt;BR&gt;</p>
+    <p>In files of text, where words take flight, Markdown weaves its magic, bold and bright. Hashes and stars, a simple code, A poet&#039;s playground, where stories unfold. &lt;BR&gt;</p>
 
     </div>
 <!-- content end -->

--- a/tests/Integration/tests/markdown/paragraph-md/expected/index.html
+++ b/tests/Integration/tests/markdown/paragraph-md/expected/index.html
@@ -1,8 +1,8 @@
 <!-- content start -->
-<div class="section" id="typo3-extension-powermail">
-    <h1>TYPO3 Extension powermail</h1>
+    <div class="section" id="typo3-extension-powermail">
+            <h1>TYPO3 Extension powermail</h1>
 
     <p>Powermail is a well-known, editor-friendly, powerful and easy to use mailform extension for TYPO3 with a lots of features (spam prevention, marketing information, optin, ajax submit, diagram analysis, etc...)</p>
 
-</div>
+    </div>
 <!-- content end -->

--- a/tests/Integration/tests/markdown/paragraph-md/input/skip
+++ b/tests/Integration/tests/markdown/paragraph-md/input/skip
@@ -1,1 +1,0 @@
-Single line breaks within a paragraph in MarkDown are removed. GitHub treates them as a whitespace.

--- a/tests/Integration/tests/markdown/readme-md/expected/index.html
+++ b/tests/Integration/tests/markdown/readme-md/expected/index.html
@@ -2,7 +2,7 @@
     <div class="section" id="child-s-swing-usage-guide">
             <h1>Child&#039;s Swing Usage Guide</h1>
 
-    <p>Welcome to the world of fun and laughter with our child&#039;s swing! Follow thesimple steps below to ensure a safe and enjoyable experience for your littleone.</p>
+    <p>Welcome to the world of fun and laughter with our child&#039;s swing! Follow the simple steps below to ensure a safe and enjoyable experience for your little one.</p>
 
             <div class="section" id="table-of-contents">
             <h2>Table of Contents</h2>
@@ -37,13 +37,13 @@
 
 <ol>
     <li>
-    <p><strong>Choose a Sturdy Location:</strong> Select a location with a sturdy beam or swingset structure capable of supporting the weight of the swing and the child.</p>
+    <p><strong>Choose a Sturdy Location:</strong> Select a location with a sturdy beam or swing set structure capable of supporting the weight of the swing and the child.</p>
 </li>
     <li>
-    <p><strong>Securely Attach the Swing:</strong> Use strong and reliable <a href="https://example.com/ropes">ropes</a>or chains to securely attach the swing to the chosen location. Double-checkthe knots or hardware to ensure they are tight and safe.</p>
+    <p><strong>Securely Attach the Swing:</strong> Use strong and reliable <a href="https://example.com/ropes">ropes</a> or chains to securely attach the swing to the chosen location. Double-check the knots or hardware to ensure they are tight and safe.</p>
 </li>
     <li>
-    <p><strong>Adjust the Height:</strong> Adjust the height of the swing to a level that iscomfortable for your child. Ensure that it is not too high or too low.</p>
+    <p><strong>Adjust the Height:</strong> Adjust the height of the swing to a level that is comfortable for your child. Ensure that it is not too high or too low.</p>
 </li>
 </ol>
 
@@ -54,13 +54,13 @@
 
 <ol>
     <li>
-    <p><strong>Place the Child in the Swing:</strong> Gently place your child in the swing seat,ensuring they are properly seated and secure.</p>
+    <p><strong>Place the Child in the Swing:</strong> Gently place your child in the swing seat, ensuring they are properly seated and secure.</p>
 </li>
     <li>
-    <p><strong>Hold onto the Swing:</strong> Provide support and hold onto the swing until yourchild is comfortably seated and ready to swing.</p>
+    <p><strong>Hold onto the Swing:</strong> Provide support and hold onto the swing until your child is comfortably seated and ready to swing.</p>
 </li>
     <li>
-    <p><strong>Start Swinging:</strong> Give a gentle push to start the swinging motion. Observeyour child&#039;s comfort level and adjust the swinging speed accordingly.</p>
+    <p><strong>Start Swinging:</strong> Give a gentle push to start the swinging motion. Observe your child&#039;s comfort level and adjust the swinging speed accordingly.</p>
 <pre><code class="language-">procedure startSwinging(swing, child)
     while child.isComfortable()
         swing.giveGentlePush()
@@ -71,12 +71,12 @@ end procedure
 </code></pre>
 </li>
     <li>
-    <p><strong>Supervise Always:</strong> Always supervise your child while they are using theswing. Ensure they are using it safely and within the recommended age and weightlimits.</p>
+    <p><strong>Supervise Always:</strong> Always supervise your child while they are using the swing. Ensure they are using it safely and within the recommended age and weight limits.</p>
 </li>
 </ol>
 
             <blockquote>
-    <p>&quot;Swinging is not just a physical activity; it&#039;s a journey into the world ofimagination and joy.&quot;</p>
+    <p>&quot;Swinging is not just a physical activity; it&#039;s a journey into the world of imagination and joy.&quot;</p>
 </blockquote>
             <div class="section" id="additional-tips">
             <h3>Additional Tips:</h3>
@@ -99,16 +99,16 @@ end procedure
 
 <ol>
     <li>
-    <p><strong>Check Hardware Regularly:</strong> Periodically inspect the ropes or chains, aswell as any hardware used to attach the swing. Replace any damaged or worn-outparts immediately.</p>
+    <p><strong>Check Hardware Regularly:</strong> Periodically inspect the ropes or chains, as well as any hardware used to attach the swing. Replace any damaged or worn-out parts immediately.</p>
 </li>
     <li>
-    <p><strong>Set Age and Weight Limits:</strong> Follow the manufacturer&#039;s recommended age andweight limits for the swing. Do not exceed these limits to ensure safety.</p>
+    <p><strong>Set Age and Weight Limits:</strong> Follow the manufacturer&#039;s recommended age and weight limits for the swing. Do not exceed these limits to ensure safety.</p>
 </li>
     <li>
-    <p><strong>Use Proper Attire:</strong> Encourage your child to wear appropriate clothing,including closed-toe shoes, to prevent any injuries.</p>
+    <p><strong>Use Proper Attire:</strong> Encourage your child to wear appropriate clothing, including closed-toe shoes, to prevent any injuries.</p>
 </li>
     <li>
-    <p><strong>No Rough Play:</strong> Instruct your child not to engage in rough play or attemptto stand up in the swing.</p>
+    <p><strong>No Rough Play:</strong> Instruct your child not to engage in rough play or attempt to stand up in the swing.</p>
 </li>
 </ol>
 
@@ -119,13 +119,13 @@ end procedure
 
 <ol>
     <li>
-    <p><strong>Clean the Swing:</strong> Wipe down the swing seat regularly to keep it clean andfree from dirt or debris.</p>
+    <p><strong>Clean the Swing:</strong> Wipe down the swing seat regularly to keep it clean and free from dirt or debris.</p>
 </li>
     <li>
-    <p><strong>Inspect for Wear:</strong> Check the swing&#039;s components for signs of wear ordamage. Replace any worn-out parts promptly.</p>
+    <p><strong>Inspect for Wear:</strong> Check the swing&#039;s components for signs of wear or damage. Replace any worn-out parts promptly.</p>
 </li>
     <li>
-    <p><strong>Tighten Loose Hardware:</strong> Ensure that all nuts and bolts are securelytightened to maintain stability.</p>
+    <p><strong>Tighten Loose Hardware:</strong> Ensure that all nuts and bolts are securely tightened to maintain stability.</p>
 </li>
 </ol>
 
@@ -136,15 +136,15 @@ end procedure
 
 <ul>
     <li class="dash">
-    <p><strong>Swing Doesn&#039;t Move Smoothly:</strong> Check for any knots or tangles in the ropesor chains. Untangle and ensure a smooth swinging motion.</p>
+    <p><strong>Swing Doesn&#039;t Move Smoothly:</strong> Check for any knots or tangles in the ropes or chains. Untangle and ensure a smooth swinging motion.</p>
 </li>
     <li class="dash">
-    <p><strong>Unusual Sounds:</strong> If you hear any creaking or unusual sounds, inspect thehardware for any loose or damaged parts.</p>
+    <p><strong>Unusual Sounds:</strong> If you hear any creaking or unusual sounds, inspect the hardware for any loose or damaged parts.</p>
 
     <p>If you hear screaming or crying, untangle the child.</p>
 </li>
     <li class="dash">
-    <p><strong>Uneven Swinging:</strong> Adjust the height of the swing to achieve a balanced andeven swinging motion.</p>
+    <p><strong>Uneven Swinging:</strong> Adjust the height of the swing to achieve a balanced and even swinging motion.</p>
 </li>
 </ul>
 

--- a/tests/Integration/tests/markdown/url-embedded-md/expected/index.html
+++ b/tests/Integration/tests/markdown/url-embedded-md/expected/index.html
@@ -1,11 +1,11 @@
 <!-- content start -->
-<div class="section" id="sample-markdown-document">
-    <h1>Sample Markdown Document</h1>
+    <div class="section" id="sample-markdown-document">
+            <h1>Sample Markdown Document</h1>
 
     <p>See <a href="https://www.example.com">https://www.example.com</a> for additional information.</p>
 
 
     <p>See also <a href="https://www.example.com/more">https://www.example.com/more</a>.</p>
 
-</div>
+    </div>
 <!-- content end -->

--- a/tests/Integration/tests/navigation/breadcrumb/expected/page1.html
+++ b/tests/Integration/tests/navigation/breadcrumb/expected/page1.html
@@ -1,136 +1,136 @@
 <!-- content start -->
-<div class="section" id="page-1">
-    <h1>Page 1</h1>
-    <nav aria-label="breadcrumb">
-        <a href="/index.html"
-           class="breadcrumb level-0">Document Title</a> &gt;
-        <span class="breadcrumb active level-1">Page 1</span>
-    </nav>
+    <div class="section" id="page-1">
+            <h1>Page 1</h1>
+            <nav aria-label="breadcrumb">
+    <a href="/index.html"
+               class="breadcrumb level-0">Document Title</a> &gt;
+                    <span class="breadcrumb active level-1">Page 1</span>
+        </nav>
 
     <p>Lorem Ipsum Dolor.</p>
 
-    <div class="menu">
-        <ul class="menu-level">
-            <li class="toc-item current active">
-                <a href="/page1.html#page-1">Page 1</a>
+            <div class="menu">
+    <ul class="menu-level">
+    <li class="toc-item current active">
+    <a href="/page1.html#page-1">Page 1</a>
 
-                <ul class="section-level-1">
-                    <li class="toc-item">
-                        <a href="/page1.html#page-1-level-2">Page 1 Level 2</a>
-
-                        <ul class="section-level-2">
-                            <li class="toc-item">
-                                <a href="/page1.html#page-1-level-3">Page 1 Level 3</a>
-
-                                <ul class="section-level-2">
-                                    <li class="toc-item">
-                                        <a href="/page1.html#page-1-level-4">Page 1 Level 4</a>
-
-
-                                    </li>
-                                </ul>
-                            </li>
-                        </ul>
-                    </li>
-                </ul>
-            </li>
+        <ul class="section-level-1">
             <li class="toc-item">
-                <a href="/page2.html#page-2">Page 2</a>
+    <a href="/page1.html#page-1-level-2">Page 1 Level 2</a>
 
-                <ul class="section-level-1">
-                    <li class="toc-item">
-                        <a href="/page2.html#page-2-level-2">Page 2 Level 2</a>
-
-                        <ul class="section-level-2">
-                            <li class="toc-item">
-                                <a href="/page2.html#page-2-level-3">Page 2 Level 3</a>
-
-                                <ul class="section-level-2">
-                                    <li class="toc-item">
-                                        <a href="/page2.html#page-2-level-4">Page 2 Level 4</a>
-
-
-                                    </li>
-                                </ul>
-                            </li>
-                        </ul>
-                    </li>
-                </ul>
-            </li>
+        <ul class="section-level-2">
             <li class="toc-item">
-                <a href="/level-1-1/index.html#level-1-1">Level 1-1</a>
-                <ul class="menu-level-1">
-                    <li class="toc-item">
-                        <a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a>
+    <a href="/page1.html#page-1-level-3">Page 1 Level 3</a>
 
-
-                    </li>
-                    <li class="toc-item">
-                        <a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a>
-
-
-                    </li>
-                    <li class="toc-item">
-                        <a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>
-                        <ul class="menu-level-2">
-                            <li class="toc-item">
-                                <a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a>
-
-
-                            </li>
-                            <li class="toc-item">
-                                <a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a>
-
-
-                            </li>
-                        </ul>
-
-                    </li>
-                    <li class="toc-item">
-                        <a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>
-                        <ul class="menu-level-2">
-                            <li class="toc-item">
-                                <a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a>
-
-
-                            </li>
-                            <li class="toc-item">
-                                <a href="/level-1-1/level-2-2/subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a>
-
-
-                            </li>
-                        </ul>
-
-                    </li>
-                </ul>
-
-            </li>
+        <ul class="section-level-2">
             <li class="toc-item">
-                <a href="/level-1-2/index.html#level-1-2">Level 1-2</a>
-                <ul class="menu-level-1">
-                    <li class="toc-item">
-                        <a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a>
+    <a href="/page1.html#page-1-level-4">Page 1 Level 4</a>
 
 
-                    </li>
-                    <li class="toc-item">
-                        <a href="/level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a>
+</li>
+                    </ul>
+</li>
+                    </ul>
+</li>
+                    </ul>
+</li>
+    <li class="toc-item">
+    <a href="/page2.html#page-2">Page 2</a>
+
+        <ul class="section-level-1">
+            <li class="toc-item">
+    <a href="/page2.html#page-2-level-2">Page 2 Level 2</a>
+
+        <ul class="section-level-2">
+            <li class="toc-item">
+    <a href="/page2.html#page-2-level-3">Page 2 Level 3</a>
+
+        <ul class="section-level-2">
+            <li class="toc-item">
+    <a href="/page2.html#page-2-level-4">Page 2 Level 4</a>
 
 
-                    </li>
-                </ul>
+</li>
+                    </ul>
+</li>
+                    </ul>
+</li>
+                    </ul>
+</li>
+    <li class="toc-item">
+    <a href="/level-1-1/index.html#level-1-1">Level 1-1</a>
+        <ul class="menu-level-1">
+            <li class="toc-item">
+    <a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a>
 
-            </li>
-        </ul>
-    </div>
-    <div class="section" id="page-1-level-2">
-        <h2>Page 1 Level 2</h2>
-        <div class="section" id="page-1-level-3">
+
+</li>
+            <li class="toc-item">
+    <a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a>
+
+
+</li>
+            <li class="toc-item">
+    <a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>
+        <ul class="menu-level-2">
+            <li class="toc-item">
+    <a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a>
+
+
+</li>
+            <li class="toc-item">
+    <a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a>
+
+
+</li>
+                    </ul>
+
+</li>
+            <li class="toc-item">
+    <a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>
+        <ul class="menu-level-2">
+            <li class="toc-item">
+    <a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a>
+
+
+</li>
+            <li class="toc-item">
+    <a href="/level-1-1/level-2-2/subpage2.html#subpage-2-level-2-2">Subpage 2, Level 2-2</a>
+
+
+</li>
+                    </ul>
+
+</li>
+                    </ul>
+
+</li>
+    <li class="toc-item">
+    <a href="/level-1-2/index.html#level-1-2">Level 1-2</a>
+        <ul class="menu-level-1">
+            <li class="toc-item">
+    <a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a>
+
+
+</li>
+            <li class="toc-item">
+    <a href="/level-1-2/subpage2.html#subpage-2-level-1-2">Subpage 2, Level 1-2</a>
+
+
+</li>
+                    </ul>
+
+</li>
+    </ul>
+</div>
+            <div class="section" id="page-1-level-2">
+            <h2>Page 1 Level 2</h2>
+            <div class="section" id="page-1-level-3">
             <h3>Page 1 Level 3</h3>
             <div class="section" id="page-1-level-4">
-                <h4>Page 1 Level 4</h4>
-            </div>
-        </div>
+            <h4>Page 1 Level 4</h4>
     </div>
-</div>
+    </div>
+    </div>
+    </div>
 <!-- content end -->

--- a/tests/Integration/tests/tables/grid-table-with-list/expected/index.html
+++ b/tests/Integration/tests/tables/grid-table-with-list/expected/index.html
@@ -1,4 +1,3 @@
-
 <!-- content start -->
     <div class="section" id="table">
             <h1>table</h1>
@@ -6,21 +5,25 @@
                 <tbody>
     <tr>
             <td><strong>Paragraphs</strong></td>
-        <td>
-            <p>Paragraph 1</p>
-            <p>Paragraph 2</p>
-        </td>
+            <td>
+    <p>Paragraph 1</p>
+
+    <p>Paragraph 2</p>
+</td>
     </tr>
     <tr>
             <td><strong>Lists</strong></td>
             <td>
-                <p>See the list</p>
-                <ul>
-                    <li>Item 1</li>
-                    <li>Item 2</li>
-                </ul>
-<p>A paragraph</p>
-            </td>
+    <p>See the list</p>
+
+
+<ul>
+    <li>Item 1</li>
+    <li>Item 2</li>
+</ul>
+
+    <p>A paragraph</p>
+</td>
     </tr>
 </tbody>
 </table>

--- a/tests/Integration/tests/toctree/toctree-glob-deep-level-3/expected/index.html
+++ b/tests/Integration/tests/toctree/toctree-glob-deep-level-3/expected/index.html
@@ -1,118 +1,118 @@
 <!-- content start -->
-<div class="section" id="document-title">
-    <h1>Document Title</h1>
+    <div class="section" id="document-title">
+            <h1>Document Title</h1>
 
     <p>Lorem Ipsum Dolor.</p>
 
-    <div class="toc">
-        <ul class="menu-level">
+            <div class="toc">
+    <ul class="menu-level">
+    <li class="toc-item">
+    <a href="/level-1-1/index.html#level-1-1">Level 1-1</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="/level-1-1/level-2-2/subpage2.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="/level-1-2/index.html#level-1-2">Level 1-2</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="/level-1-2/subpage2.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="/page1.html#page-1">Page 1</a>
+
+        <ul class="section-level-1">
             <li class="toc-item">
-                <a href="/level-1-1/index.html#level-1-1">Level 1-1</a>
+    <a href="/page1.html#page-1-level-2">Page 1 Level 2</a>
 
-
-            </li>
+        <ul class="section-level-2">
             <li class="toc-item">
-                <a href="/level-1-1/level-2-1/index.html#level-2-1">Level 2-1</a>
+    <a href="/page1.html#page-1-level-3">Page 1 Level 3</a>
 
-
-            </li>
+        <ul class="section-level-2">
             <li class="toc-item">
-                <a href="/level-1-1/level-2-1/subpage1.html#subpage-1-level-2-1">Subpage 1, Level 2-1</a>
+    <a href="/page1.html#page-1-level-4">Page 1 Level 4</a>
 
 
-            </li>
+</li>
+                    </ul>
+</li>
+                    </ul>
+</li>
+                    </ul>
+</li>
+    <li class="toc-item">
+    <a href="/page2.html#page-2">Page 2</a>
+
+        <ul class="section-level-1">
             <li class="toc-item">
-                <a href="/level-1-1/level-2-1/subpage2.html#subpage-2-level-2-1">Subpage 2, Level 2-1</a>
+    <a href="/page2.html#page-2-level-2">Page 2 Level 2</a>
 
-
-            </li>
+        <ul class="section-level-2">
             <li class="toc-item">
-                <a href="/level-1-1/level-2-2/index.html#level-2-2">Level 2-2</a>
+    <a href="/page2.html#page-2-level-3">Page 2 Level 3</a>
 
-
-            </li>
+        <ul class="section-level-2">
             <li class="toc-item">
-                <a href="/level-1-1/level-2-2/subpage1.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a>
+    <a href="/page2.html#page-2-level-4">Page 2 Level 4</a>
 
 
-            </li>
-            <li class="toc-item">
-                <a href="/level-1-1/level-2-2/subpage2.html#subpage-1-level-2-2">Subpage 1, Level 2-2</a>
-
-
-            </li>
-            <li class="toc-item">
-                <a href="/level-1-1/subpage1.html#subpage-1-level-1-1">Subpage 1, Level 1-1</a>
-
-
-            </li>
-            <li class="toc-item">
-                <a href="/level-1-1/subpage2.html#subpage-2-level-1-1">Subpage 2, Level 1-1</a>
-
-
-            </li>
-            <li class="toc-item">
-                <a href="/level-1-2/index.html#level-1-2">Level 1-2</a>
-
-
-            </li>
-            <li class="toc-item">
-                <a href="/level-1-2/subpage1.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a>
-
-
-            </li>
-            <li class="toc-item">
-                <a href="/level-1-2/subpage2.html#subpage-1-level-1-2">Subpage 1, Level 1-2</a>
-
-
-            </li>
-            <li class="toc-item">
-                <a href="/page1.html#page-1">Page 1</a>
-
-                <ul class="section-level-1">
-                    <li class="toc-item">
-                        <a href="/page1.html#page-1-level-2">Page 1 Level 2</a>
-
-                        <ul class="section-level-2">
-                            <li class="toc-item">
-                                <a href="/page1.html#page-1-level-3">Page 1 Level 3</a>
-
-                                <ul class="section-level-2">
-                                    <li class="toc-item">
-                                        <a href="/page1.html#page-1-level-4">Page 1 Level 4</a>
-
-
-                                    </li>
-                                </ul>
-                            </li>
-                        </ul>
-                    </li>
-                </ul>
-            </li>
-            <li class="toc-item">
-                <a href="/page2.html#page-2">Page 2</a>
-
-                <ul class="section-level-1">
-                    <li class="toc-item">
-                        <a href="/page2.html#page-2-level-2">Page 2 Level 2</a>
-
-                        <ul class="section-level-2">
-                            <li class="toc-item">
-                                <a href="/page2.html#page-2-level-3">Page 2 Level 3</a>
-
-                                <ul class="section-level-2">
-                                    <li class="toc-item">
-                                        <a href="/page2.html#page-2-level-4">Page 2 Level 4</a>
-
-
-                                    </li>
-                                </ul>
-                            </li>
-                        </ul>
-                    </li>
-                </ul>
-            </li>
-        </ul>
-    </div>
+</li>
+                    </ul>
+</li>
+                    </ul>
+</li>
+                    </ul>
+</li>
+    </ul>
 </div>
+    </div>
 <!-- content end -->


### PR DESCRIPTION
An inline break needs to be converted to a space as markdown doesn't care about linebreaks in a paragraph.

fixes #1091