### PR TITLE
[FEATURE] Make index file configurable

### DIFF
--- a/packages/guides-cli/resources/schema/guides.xsd
+++ b/packages/guides-cli/resources/schema/guides.xsd
@@ -21,6 +21,7 @@
 
         <xsd:attribute name="input" type="xsd:string"/>
         <xsd:attribute name="input-file" type="xsd:string"/>
+        <xsd:attribute name="index-name" type="xsd:string"/>
         <xsd:attribute name="output" type="xsd:string"/>
         <xsd:attribute name="input-format" type="xsd:string"/>
         <xsd:attribute name="log-path" type="xsd:string"/>

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/MenuDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/MenuDirective.php
@@ -20,6 +20,8 @@ use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 use phpDocumentor\Guides\RestructuredText\Parser\DirectiveOption;
 use phpDocumentor\Guides\RestructuredText\Toc\ToctreeBuilder;
+use phpDocumentor\Guides\Settings\ProjectSettings;
+use phpDocumentor\Guides\Settings\SettingsManager;
 
 use function count;
 
@@ -28,12 +30,18 @@ use function count;
  * is for display only. It does not change the position of document in the document tree and can therefore be included
  * all pages as navigation.
  *
- * By default it displays a menu of the pages on level 1 up to level 2.
+ * By default, it displays a menu of the pages on level 1 up to level 2.
  */
 final class MenuDirective extends BaseDirective
 {
-    public function __construct(private readonly ToctreeBuilder $toctreeBuilder)
-    {
+    private SettingsManager $settingsManager;
+
+    public function __construct(
+        private readonly ToctreeBuilder $toctreeBuilder,
+        SettingsManager|null $settingsManager = null,
+    ) {
+        // if for backward compatibility reasons no settings manager was passed, use the defaults
+        $this->settingsManager = $settingsManager ?? new SettingsManager(new ProjectSettings());
     }
 
     public function getName(): string
@@ -49,7 +57,8 @@ final class MenuDirective extends BaseDirective
         $parserContext = $blockContext->getDocumentParserContext()->getParser()->getParserContext();
         $options = $directive->getOptions();
         $options['glob'] = new DirectiveOption('glob', true);
-        $options['globExclude'] ??= new DirectiveOption('globExclude', 'index,Index');
+        $indexName = $this->settingsManager->getProjectSettings()->getIndexName();
+        $options['globExclude'] ??= new DirectiveOption('globExclude', $indexName);
 
         $toctreeFiles = $this->toctreeBuilder->buildToctreeEntries(
             $parserContext,

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ToctreeDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ToctreeDirective.php
@@ -21,6 +21,8 @@ use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 use phpDocumentor\Guides\RestructuredText\Parser\DirectiveOption;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
 use phpDocumentor\Guides\RestructuredText\Toc\ToctreeBuilder;
+use phpDocumentor\Guides\Settings\ProjectSettings;
+use phpDocumentor\Guides\Settings\SettingsManager;
 
 /**
  * Sphinx based Toctree directive.
@@ -33,11 +35,16 @@ use phpDocumentor\Guides\RestructuredText\Toc\ToctreeBuilder;
  */
 final class ToctreeDirective extends BaseDirective
 {
+    private SettingsManager $settingsManager;
+
     /** @param Rule<InlineCompoundNode> $startingRule */
     public function __construct(
         private readonly ToctreeBuilder $toctreeBuilder,
         private readonly Rule $startingRule,
+        SettingsManager|null $settingsManager = null,
     ) {
+        // if for backward compatibility reasons no settings manager was passed, use the defaults
+        $this->settingsManager = $settingsManager ?? new SettingsManager(new ProjectSettings());
     }
 
     public function getName(): string
@@ -52,7 +59,8 @@ final class ToctreeDirective extends BaseDirective
     ): Node|null {
         $parserContext = $blockContext->getDocumentParserContext()->getParser()->getParserContext();
         $options = $directive->getOptions();
-        $options['globExclude'] ??= new DirectiveOption('globExclude', 'index,Index');
+        $indexName = $this->settingsManager->getProjectSettings()->getIndexName();
+        $options['globExclude'] ??= new DirectiveOption('globExclude', $indexName);
 
         $toctreeFiles = $this->toctreeBuilder->buildToctreeEntries(
             $parserContext,

--- a/packages/guides/src/DependencyInjection/GuidesExtension.php
+++ b/packages/guides/src/DependencyInjection/GuidesExtension.php
@@ -114,6 +114,7 @@ final class GuidesExtension extends Extension implements CompilerPassInterface, 
                 ->scalarNode('theme')->end()
                 ->scalarNode('input')->end()
                 ->scalarNode('input_file')->end()
+                ->scalarNode('index_name')->end()
                 ->scalarNode('output')->end()
                 ->scalarNode('input_format')->end()
                 ->arrayNode('output_format')
@@ -235,6 +236,10 @@ final class GuidesExtension extends Extension implements CompilerPassInterface, 
             if (!empty($pathInfo['extension'])) {
                 $projectSettings->setInputFormat($pathInfo['extension']);
             }
+        }
+
+        if (isset($config['index_name']) && $config['index_name'] !== '') {
+            $projectSettings->setIndexName((string) $config['index_name']);
         }
 
         if (isset($config['output'])) {

--- a/packages/guides/src/Settings/ProjectSettings.php
+++ b/packages/guides/src/Settings/ProjectSettings.php
@@ -24,6 +24,7 @@ final class ProjectSettings
     private string $theme = 'default';
     private string $input = 'docs';
     private string $inputFile = '';
+    private string $indexName = 'index,Index';
     private string $output = 'output';
     private string $inputFormat = 'rst';
     /** @var string[]  */
@@ -229,5 +230,17 @@ final class ProjectSettings
     public function setIgnoredDomains(array $ignoredDomains): void
     {
         $this->ignoredDomains = $ignoredDomains;
+    }
+
+    public function getIndexName(): string
+    {
+        return $this->indexName;
+    }
+
+    public function setIndexName(string $indexName): ProjectSettings
+    {
+        $this->indexName = $indexName;
+
+        return $this;
     }
 }

--- a/tests/Integration/tests/markdown/index-name-md/expected/anotherPage.html
+++ b/tests/Integration/tests/markdown/index-name-md/expected/anotherPage.html
@@ -1,0 +1,8 @@
+<!-- content start -->
+    <div class="section" id="another-page">
+            <h1>Another Page</h1>
+
+    <p>Lorem Ipsum Dolor.</p>
+
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/markdown/index-name-md/expected/readme.html
+++ b/tests/Integration/tests/markdown/index-name-md/expected/readme.html
@@ -1,0 +1,8 @@
+<!-- content start -->
+    <div class="section" id="sample-markdown-document">
+            <h1>Sample Markdown Document</h1>
+
+    <p>Lorem Ipsum</p>
+
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/markdown/index-name-md/expected/yetAnotherPage.html
+++ b/tests/Integration/tests/markdown/index-name-md/expected/yetAnotherPage.html
@@ -1,0 +1,8 @@
+<!-- content start -->
+    <div class="section" id="yet-another-page">
+            <h1>Yet Another Page</h1>
+
+    <p>Lorem Ipsum Dolor.</p>
+
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/markdown/index-name-md/input/anotherPage.md
+++ b/tests/Integration/tests/markdown/index-name-md/input/anotherPage.md
@@ -1,0 +1,3 @@
+# Another Page
+
+Lorem Ipsum Dolor.

--- a/tests/Integration/tests/markdown/index-name-md/input/guides.xml
+++ b/tests/Integration/tests/markdown/index-name-md/input/guides.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides xmlns="https://www.phpdoc.org/guides"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd"
+        input-format="md"
+        index-name="readme"
+>
+</guides>

--- a/tests/Integration/tests/markdown/index-name-md/input/readme.md
+++ b/tests/Integration/tests/markdown/index-name-md/input/readme.md
@@ -1,0 +1,3 @@
+# Sample Markdown Document
+
+Lorem Ipsum

--- a/tests/Integration/tests/markdown/index-name-md/input/yetAnotherPage.md
+++ b/tests/Integration/tests/markdown/index-name-md/input/yetAnotherPage.md
@@ -1,0 +1,3 @@
+# Yet Another Page
+
+Lorem Ipsum Dolor.


### PR DESCRIPTION
The index file will also be used in automatic menu building.

As oposed to setting "input-file" not only the one file mentioned will be rendererd but all files from the directory. However the name of the input file can be changed.

Some markdown projects like to change the name of the index file. For example powermail is using Readme.md as index file in every directory:

https://github.com/in2code-de/powermail/tree/master/Documentation

References #1108