### PR TITLE
Allow some inlinenodes to have child nodes

### DIFF
--- a/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/AbstractInlineParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/AbstractInlineParser.php
@@ -17,13 +17,13 @@ use League\CommonMark\Node\Node as CommonMarkNode;
 use League\CommonMark\Node\NodeWalker;
 use phpDocumentor\Guides\Markdown\ParserInterface;
 use phpDocumentor\Guides\MarkupLanguageParser;
-use phpDocumentor\Guides\Nodes\Inline\InlineNode;
+use phpDocumentor\Guides\Nodes\Inline\InlineNodeInterface;
 
 /**
- * @template TValue as InlineNode
+ * @template TValue as InlineNodeInterface
  * @implements ParserInterface<TValue>
  */
 abstract class AbstractInlineParser implements ParserInterface
 {
-    abstract public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): InlineNode;
+    abstract public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): InlineNodeInterface;
 }

--- a/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/AbstractInlineTextDecoratorParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/AbstractInlineTextDecoratorParser.php
@@ -18,16 +18,16 @@ use League\CommonMark\Node\NodeWalker;
 use League\CommonMark\Node\NodeWalkerEvent;
 use phpDocumentor\Guides\MarkupLanguageParser;
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
+use phpDocumentor\Guides\Nodes\Inline\InlineNodeInterface;
 use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 use function count;
 use function sprintf;
-use function var_export;
 
 /**
- * @template TValue as InlineNode
+ * @template TValue as InlineNodeInterface
  * @extends AbstractInlineParser<TValue>
  */
 abstract class AbstractInlineTextDecoratorParser extends AbstractInlineParser
@@ -40,7 +40,7 @@ abstract class AbstractInlineTextDecoratorParser extends AbstractInlineParser
     }
 
     /** @return TValue */
-    public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): InlineNode
+    public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): InlineNodeInterface
     {
         $content = [];
 
@@ -66,12 +66,10 @@ abstract class AbstractInlineTextDecoratorParser extends AbstractInlineParser
 
             if ($this->supportsCommonMarkNode($commonMarkNode)) {
                 if (count($content) === 1 && $content[0] instanceof PlainTextInlineNode) {
-                    return $this->createInlineNode($commonMarkNode, $content[0]->getValue());
+                    return $this->createInlineNode($commonMarkNode, $content[0]->getValue(), $content);
                 }
 
-                $this->logger->warning(sprintf('%s CONTEXT: Content of emphasis could not be interpreted: %s', $this->getType(), var_export($content, true)));
-
-                return $this->createInlineNode($commonMarkNode, null);
+                return $this->createInlineNode($commonMarkNode, null, $content);
             }
 
             $this->logger->warning(sprintf('%s context does not allow a %s node', $this->getType(), $commonMarkNode::class));
@@ -83,7 +81,7 @@ abstract class AbstractInlineTextDecoratorParser extends AbstractInlineParser
     abstract protected function getType(): string;
 
     /** @return TValue */
-    abstract protected function createInlineNode(CommonMarkNode $commonMarkNode, string|null $content): InlineNode;
+    abstract protected function createInlineNode(CommonMarkNode $commonMarkNode, string|null $content): InlineNodeInterface;
 
     abstract protected function supportsCommonMarkNode(CommonMarkNode $commonMarkNode): bool;
 

--- a/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/EmphasisParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/EmphasisParser.php
@@ -17,6 +17,7 @@ use League\CommonMark\Extension\CommonMark\Node\Inline\Emphasis;
 use League\CommonMark\Node\Node as CommonMarkNode;
 use phpDocumentor\Guides\Nodes\Inline\EmphasisInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
+use phpDocumentor\Guides\Nodes\Inline\InlineNodeInterface;
 use Psr\Log\LoggerInterface;
 
 /** @extends AbstractInlineTextDecoratorParser<EmphasisInlineNode> */
@@ -35,9 +36,10 @@ final class EmphasisParser extends AbstractInlineTextDecoratorParser
         return 'Emphasis';
     }
 
-    protected function createInlineNode(CommonMarkNode $commonMarkNode, string|null $content): InlineNode
+    /** @param InlineNodeInterface[] $children */
+    protected function createInlineNode(CommonMarkNode $commonMarkNode, string|null $content, array $children = []): InlineNodeInterface
     {
-        return new EmphasisInlineNode($content ?? '');
+        return new EmphasisInlineNode($content ?? '', $children);
     }
 
     protected function supportsCommonMarkNode(CommonMarkNode $commonMarkNode): bool

--- a/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/InlineCodeParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/InlineCodeParser.php
@@ -18,6 +18,7 @@ use League\CommonMark\Node\Node as CommonMarkNode;
 use League\CommonMark\Node\NodeWalker;
 use League\CommonMark\Node\NodeWalkerEvent;
 use phpDocumentor\Guides\MarkupLanguageParser;
+use phpDocumentor\Guides\Nodes\Inline\InlineNodeInterface;
 use phpDocumentor\Guides\Nodes\Inline\LiteralInlineNode;
 
 use function assert;
@@ -25,7 +26,7 @@ use function assert;
 /** @extends AbstractInlineParser<LiteralInlineNode> */
 final class InlineCodeParser extends AbstractInlineParser
 {
-    public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): LiteralInlineNode
+    public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): InlineNodeInterface
     {
         assert($current instanceof Code);
 

--- a/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/InlineImageParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/InlineImageParser.php
@@ -17,6 +17,7 @@ use League\CommonMark\Extension\CommonMark\Node\Inline\Image;
 use League\CommonMark\Node\Node as CommonMarkNode;
 use phpDocumentor\Guides\Nodes\Inline\ImageInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
+use phpDocumentor\Guides\Nodes\Inline\InlineNodeInterface;
 use Psr\Log\LoggerInterface;
 
 use function assert;
@@ -38,7 +39,7 @@ final class InlineImageParser extends AbstractInlineTextDecoratorParser
         return 'Image';
     }
 
-    protected function createInlineNode(CommonMarkNode $commonMarkNode, string|null $content): InlineNode
+    protected function createInlineNode(CommonMarkNode $commonMarkNode, string|null $content): InlineNodeInterface
     {
         assert($commonMarkNode instanceof Image);
 

--- a/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/LinkParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/LinkParser.php
@@ -17,6 +17,7 @@ use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
 use League\CommonMark\Node\Node as CommonMarkNode;
 use phpDocumentor\Guides\Nodes\Inline\HyperLinkNode;
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
+use phpDocumentor\Guides\Nodes\Inline\InlineNodeInterface;
 use Psr\Log\LoggerInterface;
 
 use function assert;
@@ -42,7 +43,8 @@ final class LinkParser extends AbstractInlineTextDecoratorParser
         return 'Link';
     }
 
-    protected function createInlineNode(CommonMarkNode $commonMarkNode, string|null $content): InlineNode
+    /** @param InlineNodeInterface[] $children */
+    protected function createInlineNode(CommonMarkNode $commonMarkNode, string|null $content, array $children = []): InlineNodeInterface
     {
         assert($commonMarkNode instanceof Link);
 
@@ -52,7 +54,7 @@ final class LinkParser extends AbstractInlineTextDecoratorParser
             $url = substr($url, 0, -3);
         }
 
-        return new HyperLinkNode($content, $url);
+        return new HyperLinkNode($content, $url, $children);
     }
 
     protected function supportsCommonMarkNode(CommonMarkNode $commonMarkNode): bool

--- a/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/NewLineParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/NewLineParser.php
@@ -18,7 +18,7 @@ use League\CommonMark\Node\Node as CommonMarkNode;
 use League\CommonMark\Node\NodeWalker;
 use League\CommonMark\Node\NodeWalkerEvent;
 use phpDocumentor\Guides\MarkupLanguageParser;
-use phpDocumentor\Guides\Nodes\Inline\InlineNode;
+use phpDocumentor\Guides\Nodes\Inline\InlineNodeInterface;
 use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 
 /** @extends AbstractInlineParser<PlainTextInlineNode> */
@@ -28,7 +28,7 @@ class NewLineParser extends AbstractInlineParser
     {
     }
 
-    public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): InlineNode
+    public function parse(MarkupLanguageParser $parser, NodeWalker $walker, CommonMarkNode $current): InlineNodeInterface
     {
         return new PlainTextInlineNode(' ');
     }

--- a/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/StrongParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/StrongParser.php
@@ -16,6 +16,7 @@ namespace phpDocumentor\Guides\Markdown\Parsers\InlineParsers;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Strong;
 use League\CommonMark\Node\Node as CommonMarkNode;
 use phpDocumentor\Guides\Nodes\Inline\InlineNode;
+use phpDocumentor\Guides\Nodes\Inline\InlineNodeInterface;
 use phpDocumentor\Guides\Nodes\Inline\StrongInlineNode;
 use Psr\Log\LoggerInterface;
 
@@ -35,9 +36,10 @@ final class StrongParser extends AbstractInlineTextDecoratorParser
         return 'StrongDecorator';
     }
 
-    protected function createInlineNode(CommonMarkNode $commonMarkNode, string|null $content): InlineNode
+    /** @param InlineNodeInterface[] $children */
+    protected function createInlineNode(CommonMarkNode $commonMarkNode, string|null $content, array $children = []): InlineNodeInterface
     {
-        return new StrongInlineNode($content ?? '');
+        return new StrongInlineNode($content ?? '', $children);
     }
 
     protected function supportsCommonMarkNode(CommonMarkNode $commonMarkNode): bool

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/DefaultTextRoleRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/DefaultTextRoleRule.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
-use phpDocumentor\Guides\Nodes\Inline\InlineNode;
+use phpDocumentor\Guides\Nodes\Inline\InlineNodeInterface;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
@@ -27,7 +27,7 @@ final class DefaultTextRoleRule extends AbstractInlineRule
         return $lexer->token?->type === InlineLexer::BACKTICK;
     }
 
-    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNode|null
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNodeInterface|null
     {
         $text = '';
 

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/EmphasisRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/EmphasisRule.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
 use phpDocumentor\Guides\Nodes\Inline\EmphasisInlineNode;
-use phpDocumentor\Guides\Nodes\Inline\InlineNode;
+use phpDocumentor\Guides\Nodes\Inline\InlineNodeInterface;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
@@ -28,7 +28,7 @@ final class EmphasisRule extends AbstractInlineRule
         return $lexer->token?->type === InlineLexer::EMPHASIS_DELIMITER;
     }
 
-    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNode|null
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNodeInterface|null
     {
         $text = '';
 

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/InlineRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/InlineRule.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
-use phpDocumentor\Guides\Nodes\Inline\InlineNode;
+use phpDocumentor\Guides\Nodes\Inline\InlineNodeInterface;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
@@ -21,7 +21,7 @@ interface InlineRule
 {
     public function applies(InlineLexer $lexer): bool;
 
-    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNode|null;
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNodeInterface|null;
 
     public function getPriority(): int;
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/InternalReferenceRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/InternalReferenceRule.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
-use phpDocumentor\Guides\Nodes\Inline\InlineNode;
+use phpDocumentor\Guides\Nodes\Inline\InlineNodeInterface;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
@@ -24,7 +24,7 @@ final class InternalReferenceRule extends ReferenceRule
         return $lexer->token?->type === InlineLexer::UNDERSCORE;
     }
 
-    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNode|null
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNodeInterface|null
     {
         $text = '';
         $initialPosition = $lexer->token?->position;

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/NamedPhraseRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/NamedPhraseRule.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
-use phpDocumentor\Guides\Nodes\Inline\InlineNode;
+use phpDocumentor\Guides\Nodes\Inline\InlineNodeInterface;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 use phpDocumentor\Guides\RestructuredText\Parser\References\EmbeddedReferenceParser;
@@ -37,7 +37,7 @@ final class NamedPhraseRule extends ReferenceRule
         return $lexer->token?->type === InlineLexer::BACKTICK;
     }
 
-    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNode|null
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNodeInterface|null
     {
         $value = '';
         $initialPosition = $lexer->token?->position;

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/NamedReferenceRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/NamedReferenceRule.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
-use phpDocumentor\Guides\Nodes\Inline\InlineNode;
+use phpDocumentor\Guides\Nodes\Inline\InlineNodeInterface;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
@@ -35,7 +35,7 @@ final class NamedReferenceRule extends ReferenceRule
         return $lexer->token?->type === InlineLexer::NAMED_REFERENCE;
     }
 
-    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNode|null
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNodeInterface|null
     {
         $value = rtrim($lexer->token?->value ?? '', '_');
         $node = $this->createReference($blockContext, $value);

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/StrongRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/StrongRule.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
-use phpDocumentor\Guides\Nodes\Inline\InlineNode;
+use phpDocumentor\Guides\Nodes\Inline\InlineNodeInterface;
 use phpDocumentor\Guides\Nodes\Inline\StrongInlineNode;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
@@ -28,7 +28,7 @@ final class StrongRule extends AbstractInlineRule
         return $lexer->token?->type === InlineLexer::STRONG_DELIMITER;
     }
 
-    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNode|null
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNodeInterface|null
     {
         $text = '';
 

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/TextRoleRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/TextRoleRule.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\InlineRules;
 
-use phpDocumentor\Guides\Nodes\Inline\InlineNode;
+use phpDocumentor\Guides\Nodes\Inline\InlineNodeInterface;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\InlineLexer;
 
@@ -29,7 +29,7 @@ final class TextRoleRule extends AbstractInlineRule
         return $lexer->token?->type === InlineLexer::COLON;
     }
 
-    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNode|null
+    public function apply(BlockContext $blockContext, InlineLexer $lexer): InlineNodeInterface|null
     {
         $domain = null;
         $role = null;

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/LineBlockRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/LineBlockRule.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Parser\Productions;
 
 use phpDocumentor\Guides\Nodes\CompoundNode;
-use phpDocumentor\Guides\Nodes\Inline\InlineNode;
+use phpDocumentor\Guides\Nodes\Inline\InlineNodeInterface;
 use phpDocumentor\Guides\Nodes\Inline\NewlineInlineNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Nodes\ContainerNode;
@@ -71,7 +71,7 @@ final class LineBlockRule implements Rule
         return $buffer;
     }
 
-    /** @return CompoundNode<InlineNode> */
+    /** @return CompoundNode<InlineNodeInterface> */
     private function createLine(BlockContext $blockContext, Buffer $buffer): CompoundNode
     {
         $line = $this->inlineMarkupRule->apply(new BlockContext(

--- a/packages/guides-restructured-text/src/RestructuredText/TextRoles/TextRole.php
+++ b/packages/guides-restructured-text/src/RestructuredText/TextRoles/TextRole.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\TextRoles;
 
-use phpDocumentor\Guides\Nodes\Inline\InlineNode;
+use phpDocumentor\Guides\Nodes\Inline\InlineNodeInterface;
 use phpDocumentor\Guides\RestructuredText\Parser\DocumentParserContext;
 
 interface TextRole
@@ -32,5 +32,5 @@ interface TextRole
         string $role,
         string $content,
         string $rawContent,
-    ): InlineNode;
+    ): InlineNodeInterface;
 }

--- a/packages/guides-theme-rst/resources/template/rst/template.php
+++ b/packages/guides-theme-rst/resources/template/rst/template.php
@@ -76,7 +76,6 @@ return [
     AnnotationListNode::class => 'body/annotation-list.rst.twig',
     // Inline
     ImageInlineNode::class => 'inline/image.rst.twig',
-    InlineCompoundNode::class => 'inline/inline-node.rst.twig',
     AbbreviationInlineNode::class => 'inline/textroles/abbreviation.rst.twig',
     CitationInlineNode::class => 'inline/citation.rst.twig',
     DocReferenceNode::class => 'inline/doc.rst.twig',
@@ -91,6 +90,7 @@ return [
     StrongInlineNode::class => 'inline/strong.rst.twig',
     VariableInlineNode::class => 'inline/variable.rst.twig',
     GenericTextRoleInlineNode::class => 'inline/textroles/generic.rst.twig',
+    InlineCompoundNode::class => 'inline/inline-node.rst.twig',
     // Output as Metatags
     AuthorNode::class => 'structure/header/author.rst.twig',
     CopyrightNode::class => 'structure/header/copyright.rst.twig',

--- a/packages/guides/resources/template/html/inline/emphasis.html.twig
+++ b/packages/guides/resources/template/html/inline/emphasis.html.twig
@@ -1,1 +1,5 @@
-<em>{{- node.value -}}</em>
+<em>
+    {%- for child in node.children -%}
+        {{- renderNode(child) -}}
+    {%- endfor -%}
+</em>

--- a/packages/guides/resources/template/html/inline/link.html.twig
+++ b/packages/guides/resources/template/html/inline/link.html.twig
@@ -3,8 +3,12 @@
         {%- for key, value in attributes %} {{- key -}}="{{- value -}}"{% endfor -%}
         {%- if node.classes %} class="{{ node.classesString }}"{% endif -%}
     >
-    {{- node.value -}}
+    {%- for child in node.children -%}
+        {{- renderNode(child) -}}
+    {%- endfor -%}
     </a>
 {%- else -%}
-    {{- node.value -}}
+    {%- for child in node.children -%}
+        {{- renderNode(child) -}}
+    {%- endfor -%}
 {%- endif -%}

--- a/packages/guides/resources/template/html/inline/strong.html.twig
+++ b/packages/guides/resources/template/html/inline/strong.html.twig
@@ -1,1 +1,5 @@
-<strong>{{- node.value -}}</strong>
+<strong>
+{%- for child in node.children -%}
+    {{- renderNode(child) -}}
+{%- endfor -%}
+</strong>

--- a/packages/guides/resources/template/html/template.php
+++ b/packages/guides/resources/template/html/template.php
@@ -83,7 +83,6 @@ return [
     EmbeddedFrame::class => 'body/embedded-frame.html.twig',
     // Inline
     ImageInlineNode::class => 'inline/image.html.twig',
-    InlineCompoundNode::class => 'inline/inline-node.html.twig',
     AbbreviationInlineNode::class => 'inline/textroles/abbreviation.html.twig',
     CitationInlineNode::class => 'inline/citation.html.twig',
     DocReferenceNode::class => 'inline/doc.html.twig',
@@ -98,6 +97,8 @@ return [
     StrongInlineNode::class => 'inline/strong.html.twig',
     VariableInlineNode::class => 'inline/variable.html.twig',
     GenericTextRoleInlineNode::class => 'inline/textroles/generic.html.twig',
+    InlineCompoundNode::class => 'inline/inline-node.html.twig',
+
     // Output as Metatags
     AuthorNode::class => 'structure/header/author.html.twig',
     CopyrightNode::class => 'structure/header/copyright.html.twig',

--- a/packages/guides/src/Nodes/Inline/AbstractLinkInlineNode.php
+++ b/packages/guides/src/Nodes/Inline/AbstractLinkInlineNode.php
@@ -13,13 +13,32 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\Nodes\Inline;
 
-abstract class AbstractLinkInlineNode extends InlineNode implements LinkInlineNode
+use Doctrine\Deprecations\Deprecation;
+use phpDocumentor\Guides\Nodes\InlineCompoundNode;
+
+abstract class AbstractLinkInlineNode extends InlineCompoundNode implements LinkInlineNode
 {
+    use BCInlineNodeBehavior;
+
     private string $url = '';
 
-    public function __construct(string $type, private readonly string $targetReference, string $value = '')
-    {
-        parent::__construct($type, $value);
+    /** @param InlineNodeInterface[] $children */
+    public function __construct(
+        private readonly string $type,
+        private readonly string $targetReference,
+        string $value = '',
+        array $children = [],
+    ) {
+        if (empty($children)) {
+            Deprecation::trigger(
+                'phpdocumentor/guides',
+                'https://github.com/phpDocumentor/guides/issues/1161',
+                'Please provide the children as an array of InlineNodeInterface instances instead of a string.',
+            );
+            $children = [new PlainTextInlineNode($value)];
+        }
+
+        parent::__construct($children);
     }
 
     public function getTargetReference(): string
@@ -45,5 +64,10 @@ abstract class AbstractLinkInlineNode extends InlineNode implements LinkInlineNo
             'targetReference' => $this->getTargetReference(),
             'value' => $this->getValue(),
         ];
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
     }
 }

--- a/packages/guides/src/Nodes/Inline/BCInlineNodeBehavior.php
+++ b/packages/guides/src/Nodes/Inline/BCInlineNodeBehavior.php
@@ -14,19 +14,28 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\Nodes\Inline;
 
 use Doctrine\Deprecations\Deprecation;
-use phpDocumentor\Guides\Nodes\InlineCompoundNode;
 
-final class StrongInlineNode extends InlineCompoundNode
+use function is_string;
+
+trait BCInlineNodeBehavior
 {
-    use BCInlineNodeBehavior;
-
-    public const TYPE = 'strong';
-
-    /** @param InlineNodeInterface[] $children */
-    public function __construct(string $value, array $children = [])
+    public function getValue(): string
     {
-        if (empty($children)) {
-            $children = [new PlainTextInlineNode($value)];
+        Deprecation::trigger(
+            'phpdocumentor/guides',
+            'https://github.com/phpDocumentor/guides/issues/1161',
+            'Use getChildren to access the value of this node.',
+        );
+
+        return $this->toString();
+    }
+
+    /** @param InlineNodeInterface[]|string $value */
+    public function setValue(mixed $value): void
+    {
+        if (is_string($value)) {
+            $value = [new PlainTextInlineNode($value)];
+
             Deprecation::trigger(
                 'phpdocumentor/guides',
                 'https://github.com/phpDocumentor/guides/issues/1161',
@@ -34,11 +43,8 @@ final class StrongInlineNode extends InlineCompoundNode
             );
         }
 
-        parent::__construct($children);
+        parent::setValue($value);
     }
 
-    public function getType(): string
-    {
-        return self::TYPE;
-    }
+    abstract public function toString(): string;
 }

--- a/packages/guides/src/Nodes/Inline/EmphasisInlineNode.php
+++ b/packages/guides/src/Nodes/Inline/EmphasisInlineNode.php
@@ -13,12 +13,32 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\Nodes\Inline;
 
-final class EmphasisInlineNode extends InlineNode
+use Doctrine\Deprecations\Deprecation;
+use phpDocumentor\Guides\Nodes\InlineCompoundNode;
+
+final class EmphasisInlineNode extends InlineCompoundNode
 {
+    use BCInlineNodeBehavior;
+
     public const TYPE = 'emphasis';
 
-    public function __construct(string $value)
+    /** @param InlineNodeInterface[] $children */
+    public function __construct(string $value, array $children = [])
     {
-        parent::__construct(self::TYPE, $value);
+        if (empty($children)) {
+            $children = [new PlainTextInlineNode($value)];
+            Deprecation::trigger(
+                'phpdocumentor/guides',
+                'https://github.com/phpDocumentor/guides/issues/1161',
+                'Please provide the children as an array of InlineNodeInterface instances instead of a string.',
+            );
+        }
+
+        parent::__construct($children);
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
     }
 }

--- a/packages/guides/src/Nodes/Inline/HyperLinkNode.php
+++ b/packages/guides/src/Nodes/Inline/HyperLinkNode.php
@@ -18,8 +18,9 @@ namespace phpDocumentor\Guides\Nodes\Inline;
  */
 final class HyperLinkNode extends AbstractLinkInlineNode
 {
-    public function __construct(string $value, string $targetReference)
+    /** @param InlineNodeInterface[] $children */
+    public function __construct(string $value, string $targetReference, array $children = [])
     {
-        parent::__construct('link', $targetReference, $value);
+        parent::__construct('link', $targetReference, $value, $children);
     }
 }

--- a/packages/guides/src/Nodes/Inline/InlineNode.php
+++ b/packages/guides/src/Nodes/Inline/InlineNode.php
@@ -16,7 +16,7 @@ namespace phpDocumentor\Guides\Nodes\Inline;
 use phpDocumentor\Guides\Nodes\AbstractNode;
 
 /** @extends AbstractNode<String> */
-abstract class InlineNode extends AbstractNode
+abstract class InlineNode extends AbstractNode implements InlineNodeInterface
 {
     public function __construct(private readonly string $type, string $value = '')
     {

--- a/packages/guides/src/Nodes/Inline/InlineNodeInterface.php
+++ b/packages/guides/src/Nodes/Inline/InlineNodeInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\Nodes\Inline;
+
+use phpDocumentor\Guides\Nodes\Node;
+
+interface InlineNodeInterface extends Node
+{
+    public function getType(): string;
+
+    public function toString(): string;
+}

--- a/packages/guides/src/Nodes/InlineCompoundNode.php
+++ b/packages/guides/src/Nodes/InlineCompoundNode.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\Nodes;
 
-use phpDocumentor\Guides\Nodes\Inline\InlineNode;
+use phpDocumentor\Guides\Nodes\Inline\InlineNodeInterface;
 use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 
-/** @extends CompoundNode<InlineNode> */
-final class InlineCompoundNode extends CompoundNode
+/** @extends CompoundNode<InlineNodeInterface> */
+class InlineCompoundNode extends CompoundNode implements InlineNodeInterface
 {
     public function toString(): string
     {
@@ -32,5 +32,10 @@ final class InlineCompoundNode extends CompoundNode
     public static function getPlainTextInlineNode(string $content): self
     {
         return new InlineCompoundNode([new PlainTextInlineNode($content)]);
+    }
+
+    public function getType(): string
+    {
+        return 'compound';
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -91,6 +91,11 @@ parameters:
 			path: packages/guides-graphs/src/Graphs/Renderer/PlantumlRenderer.php
 
 		-
+			message: "#^Method phpDocumentor\\\\Guides\\\\Markdown\\\\Parsers\\\\InlineParsers\\\\AbstractInlineTextDecoratorParser\\<TValue of phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\InlineNodeInterface\\>\\:\\:createInlineNode\\(\\) invoked with 3 parameters, 2 required\\.$#"
+			count: 2
+			path: packages/guides-markdown/src/Markdown/Parsers/InlineParsers/AbstractInlineTextDecoratorParser.php
+
+		-
 			message: "#^Cannot call method scalarNode\\(\\) on Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\|null\\.$#"
 			count: 1
 			path: packages/guides-restructured-text/src/RestructuredText/DependencyInjection/ReStructuredTextExtension.php
@@ -144,6 +149,36 @@ parameters:
 			message: "#^Cannot call method scalarNode\\(\\) on Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\|null\\.$#"
 			count: 1
 			path: packages/guides/src/DependencyInjection/GuidesExtension.php
+
+		-
+			message: "#^Parameter \\#1 \\$value \\(array\\<phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\InlineNodeInterface\\>\\|string\\) of method phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\AbstractLinkInlineNode\\:\\:setValue\\(\\) should be contravariant with parameter \\$value \\(mixed\\) of method phpDocumentor\\\\Guides\\\\Nodes\\\\Node\\:\\:setValue\\(\\)$#"
+			count: 3
+			path: packages/guides/src/Nodes/Inline/AbstractLinkInlineNode.php
+
+		-
+			message: "#^Return type \\(string\\) of method phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\AbstractLinkInlineNode\\:\\:getValue\\(\\) should be compatible with return type \\(array\\<phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\InlineNodeInterface\\>\\) of method phpDocumentor\\\\Guides\\\\Nodes\\\\AbstractNode\\<array\\<phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\InlineNodeInterface\\>\\>\\:\\:getValue\\(\\)$#"
+			count: 1
+			path: packages/guides/src/Nodes/Inline/AbstractLinkInlineNode.php
+
+		-
+			message: "#^Parameter \\#1 \\$value \\(array\\<phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\InlineNodeInterface\\>\\|string\\) of method phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\EmphasisInlineNode\\:\\:setValue\\(\\) should be contravariant with parameter \\$value \\(mixed\\) of method phpDocumentor\\\\Guides\\\\Nodes\\\\Node\\:\\:setValue\\(\\)$#"
+			count: 2
+			path: packages/guides/src/Nodes/Inline/EmphasisInlineNode.php
+
+		-
+			message: "#^Return type \\(string\\) of method phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\EmphasisInlineNode\\:\\:getValue\\(\\) should be compatible with return type \\(array\\<phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\InlineNodeInterface\\>\\) of method phpDocumentor\\\\Guides\\\\Nodes\\\\AbstractNode\\<array\\<phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\InlineNodeInterface\\>\\>\\:\\:getValue\\(\\)$#"
+			count: 1
+			path: packages/guides/src/Nodes/Inline/EmphasisInlineNode.php
+
+		-
+			message: "#^Parameter \\#1 \\$value \\(array\\<phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\InlineNodeInterface\\>\\|string\\) of method phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\StrongInlineNode\\:\\:setValue\\(\\) should be contravariant with parameter \\$value \\(mixed\\) of method phpDocumentor\\\\Guides\\\\Nodes\\\\Node\\:\\:setValue\\(\\)$#"
+			count: 2
+			path: packages/guides/src/Nodes/Inline/StrongInlineNode.php
+
+		-
+			message: "#^Return type \\(string\\) of method phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\StrongInlineNode\\:\\:getValue\\(\\) should be compatible with return type \\(array\\<phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\InlineNodeInterface\\>\\) of method phpDocumentor\\\\Guides\\\\Nodes\\\\AbstractNode\\<array\\<phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\InlineNodeInterface\\>\\>\\:\\:getValue\\(\\)$#"
+			count: 1
+			path: packages/guides/src/Nodes/Inline/StrongInlineNode.php
 
 		-
 			message: "#^Property phpDocumentor\\\\Guides\\\\Renderer\\\\DocumentListIterator\\:\\:\\$currentDocument \\(WeakReference\\<phpDocumentor\\\\Guides\\\\Nodes\\\\DocumentNode\\>\\|null\\) does not accept WeakReference\\<TIn of object\\>\\.$#"

--- a/psalm.xml
+++ b/psalm.xml
@@ -19,6 +19,8 @@
 
     <issueHandlers>
         <LessSpecificReturnType errorLevel="info"/>
+        <LessSpecificImplementedReturnType errorLevel="info"/>
+        <MoreSpecificImplementedParamType errorLevel="info"/>
         <MissingConstructor errorLevel="info" />
         <PropertyNotSetInConstructor errorLevel="info" />
         <DeprecatedMethod errorLevel="info">

--- a/tests/Integration/tests/markdown/emphasis-md/expected/index.html
+++ b/tests/Integration/tests/markdown/emphasis-md/expected/index.html
@@ -2,7 +2,7 @@
     <div class="section" id="markdown-with-emphasis">
             <h1>Markdown with emphasis</h1>
 
-    <p><em>Italic</em> or <em>Italic</em> <strong>Bold</strong> or <strong>Bold</strong></p>
-
+    <p><em>Italic</em> or <em>Italic</em>, <strong>Bold</strong> or <strong>Bold</strong>, <strong>Bold and <em>Italic</em></strong>, <em>Italic and <strong>Bold</strong></em></p>
+    <p><a href="https://phpdoc.org"><em>test</em></a></p>
     </div>
 <!-- content end -->

--- a/tests/Integration/tests/markdown/emphasis-md/input/index.md
+++ b/tests/Integration/tests/markdown/emphasis-md/input/index.md
@@ -1,4 +1,8 @@
 # Markdown with emphasis
 
-*Italic* or _Italic_
-**Bold** or __Bold__
+*Italic* or _Italic_,
+**Bold** or __Bold__,
+**Bold and _Italic_**,
+_Italic and **Bold**_
+
+[_test_](https://phpdoc.org)


### PR DESCRIPTION
Markdown supports more nesting on nodes than RST does. To support this we needed to add support for compound nodes. We tried to be backward compatible for people building their own template. This layer will be removed in v2 and therfor we do trigger deprecations. See #1161

Fixes: #1160