### PR TITLE
[FIX] make heading level dynamic

### DIFF
--- a/packages/guides/src/Nodes/DocumentNode.php
+++ b/packages/guides/src/Nodes/DocumentNode.php
@@ -121,7 +121,7 @@ final class DocumentNode extends CompoundNode
     public function getTitle(): TitleNode|null
     {
         foreach ($this->value as $node) {
-            if ($node instanceof SectionNode && $node->getTitle()->getLevel() === 1) {
+            if ($node instanceof SectionNode) {
                 return $node->getTitle();
             }
 

--- a/tests/Integration/tests/markdown/sections-no-level-1-md/expected/index.html
+++ b/tests/Integration/tests/markdown/sections-no-level-1-md/expected/index.html
@@ -1,0 +1,45 @@
+<!-- content start -->
+
+<div class="section" id="introduction">
+            <h2>Introduction</h2>
+
+    <p>This is a sample Markdown document demonstrating sections and subsections.</p>
+
+    </div>
+            <div class="section" id="section-1">
+            <h2>Section 1</h2>
+
+    <p>This is the first section of the document.</p>
+
+            <div class="section" id="subsection-1-1">
+            <h3>Subsection 1.1</h3>
+
+    <p>This is a subsection under Section 1.</p>
+
+    </div>
+            <div class="section" id="subsection-1-2">
+            <h3>Subsection 1.2</h3>
+
+    <p>Another subsection under Section 1.</p>
+
+    </div>
+    </div>
+            <div class="section" id="section-2">
+            <h2>Section 2</h2>
+
+    <p>Moving on to the second section of the document.</p>
+
+            <div class="section" id="subsection-2-1">
+            <h3>Subsection 2.1</h3>
+
+    <p>A subsection under Section 2.</p>
+
+    </div>
+    </div>
+            <div class="section" id="conclusion">
+            <h2>Conclusion</h2>
+
+    <p>In conclusion, this is a simple example of a Markdown document with various sections and subsections.</p>
+
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/markdown/sections-no-level-1-md/input/guides.xml
+++ b/tests/Integration/tests/markdown/sections-no-level-1-md/input/guides.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides xmlns="https://www.phpdoc.org/guides"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd"
+        input-format="md"
+>
+</guides>

--- a/tests/Integration/tests/markdown/sections-no-level-1-md/input/index.md
+++ b/tests/Integration/tests/markdown/sections-no-level-1-md/input/index.md
@@ -1,0 +1,27 @@
+## Introduction
+
+This is a sample Markdown document demonstrating sections and subsections.
+
+## Section 1
+
+This is the first section of the document.
+
+### Subsection 1.1
+
+This is a subsection under Section 1.
+
+### Subsection 1.2
+
+Another subsection under Section 1.
+
+## Section 2
+
+Moving on to the second section of the document.
+
+### Subsection 2.1
+
+A subsection under Section 2.
+
+## Conclusion
+
+In conclusion, this is a simple example of a Markdown document with various sections and subsections.


### PR DESCRIPTION
The heading level of markdown documents is not strictly 1 based. Some documents are starting with a random heading. Before those documents were rendered empty. This change fixes that behavior, headings to not longer start at level 1.