### PR TITLE
Fix regression on missing resource put

### DIFF
--- a/packages/filesystem/src/FileSystem.php
+++ b/packages/filesystem/src/FileSystem.php
@@ -46,6 +46,9 @@ interface FileSystem
 
     public function put(string $path, string $contents): bool;
 
+    /** @param resource $resource */
+    public function putStream(string $path, $resource): void;
+
     /** @return StorageAttributes[] */
     public function listContents(string $directory = '', bool $recursive = false): array;
 

--- a/packages/filesystem/src/FlySystemAdapter.php
+++ b/packages/filesystem/src/FlySystemAdapter.php
@@ -75,6 +75,12 @@ class FlySystemAdapter implements FileSystem
         return $this->filesystem->put($path, $contents);
     }
 
+    /** @param resource $resource */
+    public function putStream(string $path, $resource): void
+    {
+        $this->filesystem->putStream($path, $resource);
+    }
+
     /** @return StorageAttributes[] */
     public function listContents(string $directory = '', bool $recursive = false): array
     {

--- a/packages/filesystem/src/FlysystemV1/FlysystemV1.php
+++ b/packages/filesystem/src/FlysystemV1/FlysystemV1.php
@@ -52,6 +52,12 @@ class FlysystemV1 implements Filesystem
         return $this->filesystem->put($path, $contents);
     }
 
+    /** @param resource $resource */
+    public function putStream(string $path, $resource): void
+    {
+        $this->filesystem->putStream($path, $resource);
+    }
+
     /** @return StorageAttributes[] */
     public function listContents(string $directory = '', bool $recursive = false): array
     {

--- a/packages/filesystem/src/FlysystemV3/FlysystemV3.php
+++ b/packages/filesystem/src/FlysystemV3/FlysystemV3.php
@@ -52,6 +52,12 @@ final class FlysystemV3 implements FileSystem
         return true;
     }
 
+    /** @param resource $resource */
+    public function putStream(string $path, $resource): void
+    {
+        $this->filesystem->writeStream($path, $resource);
+    }
+
     /** @return FileAttributes[] */
     public function listContents(string $directory = '', bool $recursive = false): array
     {


### PR DESCRIPTION
Some external libraries did rely on the usage of putResource. This method wasn't part of the new filesystem interface and was therefore breaking those implementations.