### PR TITLE
[BUGFIX] Ignore orphans in toctrees with globbing

### DIFF
--- a/packages/guides/src/Compiler/NodeTransformers/DocumentEntryRegistrationTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/DocumentEntryRegistrationTransformer.php
@@ -66,6 +66,7 @@ final class DocumentEntryRegistrationTransformer implements NodeTransformer
             $node->getTitle() ?? TitleNode::emptyNode(),
             $node->isRoot(),
             $additionalData,
+            $node->isOrphan(),
         );
         $compilerContext->getProjectNode()->addDocumentEntry($entry);
 

--- a/packages/guides/src/Compiler/NodeTransformers/MenuNodeTransformers/GlobMenuEntryNodeTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/MenuNodeTransformers/GlobMenuEntryNodeTransformer.php
@@ -49,6 +49,10 @@ final class GlobMenuEntryNodeTransformer extends AbstractMenuEntryNodeTransforme
         $globExclude = explode(',', $currentMenu->getOption('globExclude') . '');
         $menuEntries = [];
         foreach ($documentEntries as $documentEntry) {
+            if ($documentEntry->isOrphan()) {
+                continue;
+            }
+
             if (
                 !self::matches($documentEntry->getFile(), $entryNode, $currentPath, $globExclude)
             ) {

--- a/packages/guides/src/Nodes/DocumentTree/DocumentEntryNode.php
+++ b/packages/guides/src/Nodes/DocumentTree/DocumentEntryNode.php
@@ -34,6 +34,7 @@ final class DocumentEntryNode extends EntryNode
         private readonly TitleNode $titleNode,
         private readonly bool $isRoot = false,
         private array $additionalData = [],
+        private bool $orphan = false,
     ) {
     }
 
@@ -107,6 +108,11 @@ final class DocumentEntryNode extends EntryNode
     public function getAdditionalData(string $key): Node|null
     {
         return $this->additionalData[$key] ?? null;
+    }
+
+    public function isOrphan(): bool
+    {
+        return $this->orphan;
     }
 
     public function addAdditionalData(string $key, Node $value): void

--- a/tests/Integration/tests-full/automatic_menu/automatic-default-menu/input/doNotInclude.rst
+++ b/tests/Integration/tests-full/automatic_menu/automatic-default-menu/input/doNotInclude.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+Do not Include in menu
+======================
+
+This is an orphan an must be ignored by glob patterns

--- a/tests/Integration/tests/toctree/toctree-glob-level-1/input/doNotInclude.rst
+++ b/tests/Integration/tests/toctree/toctree-glob-level-1/input/doNotInclude.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+Do not Include in menu
+======================
+
+This is an orphan an must be ignored by glob patterns


### PR DESCRIPTION
Orphans are by default not meant to be in menus. Therefore they must be excluded during globbing and can only be added to a menu if they are explicitely added.