### PR TITLE
First iteration on option attributes

### DIFF
--- a/docs/developers/directive.rst
+++ b/docs/developers/directive.rst
@@ -49,3 +49,60 @@ All you need to do is create a node and add the content.
     :caption: your-extension/Directive/ExampleDirective.php
     :lineos:
 
+Reading directive options
+=========================
+
+A directive can declare the options it accepts using the repeatable
+:php:class:`\phpDocumentor\Guides\RestructuredText\Directives\Attributes\Option` attribute on the directive class.
+Each option has a ``name``, a ``type`` (one of the
+:php:class:`\phpDocumentor\Guides\RestructuredText\Directives\OptionType` enum cases and ``String`` by default) and
+an optional ``default`` value that is returned when the option is not present on the directive:
+
+.. code-block:: php
+    :caption: your-extension/Directive/ExampleDirective.php
+
+    use phpDocumentor\Guides\RestructuredText\Directives\Attributes\Option;
+    use phpDocumentor\Guides\RestructuredText\Directives\OptionType;
+
+    #[Option(name: 'title', description: 'The title of the node')]
+    #[Option(name: 'count', type: OptionType::Integer, default: 3, description: 'How many entries to render')]
+    #[Option(name: 'enabled', type: OptionType::Boolean, default: true)]
+    final class ExampleDirective extends SubDirective
+    {
+        // ...
+    }
+
+Inside the directive you fetch a single option with
+:php:method:`\phpDocumentor\Guides\RestructuredText\Directives\BaseDirective::readOption()`:
+
+.. code-block:: php
+
+    $title = $this->readOption($directive, 'title');   // string|null
+    $count = $this->readOption($directive, 'count');   // int
+    $enabled = $this->readOption($directive, 'enabled'); // bool
+
+``readOption()`` returns a value typed according to the matching ``#[Option]`` attribute:
+
+- an ``OptionType::String`` option returns ``string``, ``OptionType::Integer`` returns ``int``,
+  ``OptionType::Boolean`` returns ``bool`` and ``OptionType::Array`` returns ``array``;
+- when the option declares a ``default``, the default's type is added to the return type, so an
+  option without a ``default`` returns ``<type>|null``;
+- when no matching ``#[Option]`` attribute can be found for the given name, the return type is ``mixed``.
+
+Static analysis
+---------------
+
+The return type of ``readOption()`` is inferred by a PHPStan
+``DynamicMethodReturnTypeExtension`` shipped with the ``phpdocumentor/guides-restructured-text`` package. To
+enable it, require the package and include its rule set in your ``phpstan.neon``:
+
+.. code-block:: yaml
+    :caption: phpstan.neon
+
+    includes:
+        - vendor/phpdocumentor/guides-restructured-text/rules.neon
+
+With the rule enabled, PHPStan reports type mismatches when a directive uses an option in a way that
+is incompatible with its declared ``#[Option]`` type (for example passing a possibly-``null`` ``string|null``
+title to a method that requires a ``string``).
+

--- a/docs/developers/directive/subdirective.php
+++ b/docs/developers/directive/subdirective.php
@@ -2,28 +2,23 @@
 
 namespace YourExtension\Directives;
 
-use phpDocumentor\Guides\RestructuredText\Nodes\Node;
-use phpDocumentor\Guides\RestructuredText\Nodes\SubDirectiveNode;
-use phpDocumentor\Guides\RestructuredText\Parser\SubDirectiveParser;
-use phpDocumentor\Guides\RestructuredText\Parser\SubDirectiveParserFactory;
+use phpDocumentor\Guides\RestructuredText\Directives\Attributes\Directive;
+use phpDocumentor\Guides\RestructuredText\Directives\Attributes\Option;
+use phpDocumentor\Guides\RestructuredText\Directives\OptionType;
+use phpDocumentor\Guides\RestructuredText\Directives\SubDirective;
+use phpDocumentor\Guides\Nodes\Node;
 
+#[Directive(name: 'example')]
+#[Option(name: 'option1', type: OptionType::Boolean, description: 'An example option', default: false)]
 class ExampleSubDirective extends SubDirective
 {
-    public function getName(): string
+    public function createNode(\phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode $directiveNode): Node
     {
-        return 'example';
-    }
-
-    final protected function processSub(
-        BlockContext $blockContext,
-        CollectionNode $collectionNode,
-        Directive $directive,
-    ): Node|null {
         return new ExampleNode(
-            $this->name,
-            $directive->getDataNode(),
+            $this->readOption($directiveNode, 'option1'),
+            $directiveNode->getDataNode(),
             $this->text,
-            $collectionNode->getChildren(),
+            $directiveNode->getChildren(),
         );
     }
 }

--- a/packages/guides-restructured-text/resources/config/guides-restructured-text.php
+++ b/packages/guides-restructured-text/resources/config/guides-restructured-text.php
@@ -381,6 +381,10 @@ return static function (ContainerConfigurator $container): void {
         ->set(GlobSearcher::class)
         ->set(ToctreeBuilder::class)
         ->set(InlineMarkupRule::class)
+
+        ->set(\phpDocumentor\Guides\RestructuredText\Compiler\Passes\DirectiveProcessPass::class)
+        ->arg('$directives', tagged_iterator('phpdoc.guides.directive'))
+        ->tag('phpdoc.guides.compiler.nodeTransformers')
         ->set(DefaultCodeNodeOptionMapper::class)
         ->alias(CodeNodeOptionMapper::class, DefaultCodeNodeOptionMapper::class);
 };

--- a/packages/guides-restructured-text/resources/config/guides-restructured-text.php
+++ b/packages/guides-restructured-text/resources/config/guides-restructured-text.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use phpDocumentor\Guides\ReferenceResolvers\DocumentNameResolverInterface;
+use phpDocumentor\Guides\RestructuredText\Compiler\Passes\DirectiveProcessPass;
 use phpDocumentor\Guides\RestructuredText\Directives\AdmonitionDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\AttentionDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\BaseDirective;
@@ -280,6 +281,7 @@ return static function (ContainerConfigurator $container): void {
         ->tag('phpdoc.guides.parser.rst.body_element', ['priority' => ParagraphRule::PRIORITY + 1])
         ->set(DirectiveRule::class)
         ->arg('$directives', tagged_iterator('phpdoc.guides.directive'))
+        ->arg('$startingRule', service(DirectiveContentRule::class))
         ->tag('phpdoc.guides.parser.rst.body_element', ['priority' => DirectiveRule::PRIORITY])
         ->set(CommentRule::class)
         ->tag('phpdoc.guides.parser.rst.body_element', ['priority' => CommentRule::PRIORITY])
@@ -382,7 +384,7 @@ return static function (ContainerConfigurator $container): void {
         ->set(ToctreeBuilder::class)
         ->set(InlineMarkupRule::class)
 
-        ->set(\phpDocumentor\Guides\RestructuredText\Compiler\Passes\DirectiveProcessPass::class)
+        ->set(DirectiveProcessPass::class)
         ->arg('$directives', tagged_iterator('phpdoc.guides.directive'))
         ->tag('phpdoc.guides.compiler.nodeTransformers')
         ->set(DefaultCodeNodeOptionMapper::class)

--- a/packages/guides-restructured-text/rules.neon
+++ b/packages/guides-restructured-text/rules.neon
@@ -1,0 +1,5 @@
+services:
+	-
+		class: phpDocumentor\Guides\PHPStan\Rules\ReadOptionReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension

--- a/packages/guides-restructured-text/src/PHPStan/Rules/ReadOptionReturnTypeExtension.php
+++ b/packages/guides-restructured-text/src/PHPStan/Rules/ReadOptionReturnTypeExtension.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\PHPStan\Rules;
+
+use phpDocumentor\Guides\RestructuredText\Directives\Attributes\Option;
+use phpDocumentor\Guides\RestructuredText\Directives\BaseDirective;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\BooleanType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+use function count;
+
+final class ReadOptionReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return BaseDirective::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'readOption';
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope,
+    ): Type|null {
+        $args = $methodCall->getArgs();
+        if (count($args) < 2) {
+            return null;
+        }
+
+        $optionNameType = $scope->getType($args[1]->value);
+        $constantStrings = $optionNameType->getConstantStrings();
+        if (count($constantStrings) !== 1) {
+            return new MixedType();
+        }
+
+        $callerType = $scope->getType($methodCall->var);
+        $classReflections = $callerType->getObjectClassReflections();
+        if (count($classReflections) === 0) {
+            return new MixedType();
+        }
+
+        return $this->resolveReturnType($classReflections[0], $constantStrings[0]->getValue());
+    }
+
+    public function resolveReturnType(ClassReflection $classReflection, string $optionName): Type
+    {
+        foreach ($classReflection->getAttributes() as $attribute) {
+            if ($attribute->getName() !== Option::class) {
+                continue;
+            }
+
+            $argumentTypes = $attribute->getArgumentTypes();
+
+            $nameType = $argumentTypes['name'] ?? null;
+            if ($nameType === null || count($nameType->getConstantStrings()) !== 1) {
+                continue;
+            }
+
+            if ($nameType->getConstantStrings()[0]->getValue() !== $optionName) {
+                continue;
+            }
+
+            return TypeCombinator::union(
+                $this->resolveBaseType($argumentTypes['type'] ?? null),
+                $this->resolveDefaultType($argumentTypes['default'] ?? null),
+            );
+        }
+
+        return new MixedType();
+    }
+
+    private function resolveBaseType(Type|null $typeArgument): Type
+    {
+        $enumCase = $typeArgument?->getEnumCaseObject();
+        if ($enumCase !== null) {
+            return match ($enumCase->getEnumCaseName()) {
+                'Integer' => new IntegerType(),
+                'Boolean' => new BooleanType(),
+                'Array' => new ArrayType(new MixedType(), new MixedType()),
+                default => new StringType(),
+            };
+        }
+
+        return new StringType();
+    }
+
+    private function resolveDefaultType(Type|null $defaultArgument): Type
+    {
+        if ($defaultArgument === null) {
+            return new NullType();
+        }
+
+        if (
+            $defaultArgument->isNull()->yes()
+            || $defaultArgument->isBoolean()->yes()
+            || $defaultArgument->isFloat()->yes()
+            || $defaultArgument->isInteger()->yes()
+            || $defaultArgument->isString()->yes()
+        ) {
+            return $defaultArgument;
+        }
+
+        return new MixedType();
+    }
+}

--- a/packages/guides-restructured-text/src/RestructuredText/Compiler/Passes/DirectiveProcessPass.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Compiler/Passes/DirectiveProcessPass.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\RestructuredText\Compiler\Passes;
+
+use phpDocumentor\Guides\Compiler\CompilerContext;
+use phpDocumentor\Guides\Compiler\NodeTransformer;
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Directives\BaseDirective as DirectiveHandler;
+use phpDocumentor\Guides\RestructuredText\Directives\GeneralDirective;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
+use phpDocumentor\Guides\RestructuredText\Parser\Directive;
+use Psr\Log\LoggerInterface;
+
+class DirectiveProcessPass implements NodeTransformer
+{
+    /** @var array<string, DirectiveHandler> */
+    private array $directives;
+
+    /** @param iterable<DirectiveHandler> $directives */
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly GeneralDirective $generalDirective,
+        iterable $directives = [],
+    ) {
+        foreach ($directives as $directive) {
+            $this->registerDirective($directive);
+        }
+    }
+
+    private function registerDirective(DirectiveHandler $directive): void
+    {
+        $this->directives[strtolower($directive->getName())] = $directive;
+        foreach ($directive->getAliases() as $alias) {
+            $this->directives[strtolower($alias)] = $directive;
+        }
+    }
+
+    public function enterNode(Node $node, CompilerContext $compilerContext): Node
+    {
+        return $node;
+    }
+
+    public function leaveNode(Node $node, CompilerContext $compilerContext): Node|null
+    {
+        return $this->getDirectiveHandler($node->getDirective())->createNode($node->getDirective());
+    }
+
+    private function getDirectiveHandler(Directive $directive): DirectiveHandler
+    {
+        return $this->directives[strtolower($directive->getName())] ?? $this->generalDirective;
+    }
+
+    public function supports(Node $node): bool
+    {
+        return $node instanceof DirectiveNode;
+    }
+
+    public function getPriority(): int
+    {
+        return PHP_INT_MAX;
+    }
+}

--- a/packages/guides-restructured-text/src/RestructuredText/Compiler/Passes/DirectiveProcessPass.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Compiler/Passes/DirectiveProcessPass.php
@@ -15,6 +15,7 @@ namespace phpDocumentor\Guides\RestructuredText\Compiler\Passes;
 
 use phpDocumentor\Guides\Compiler\CompilerContext;
 use phpDocumentor\Guides\Compiler\NodeTransformer;
+use phpDocumentor\Guides\Compiler\ReverseNodeTransformer;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Directives\BaseDirective as DirectiveHandler;
 use phpDocumentor\Guides\RestructuredText\Directives\GeneralDirective;
@@ -27,7 +28,7 @@ use function strtolower;
 use const PHP_INT_MAX;
 
 /** @implements NodeTransformer<DirectiveNode> */
-final class DirectiveProcessPass implements NodeTransformer
+final class DirectiveProcessPass implements ReverseNodeTransformer
 {
     /** @var array<string, DirectiveHandler> */
     private array $directives;

--- a/packages/guides-restructured-text/src/RestructuredText/Compiler/Passes/DirectiveProcessPass.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Compiler/Passes/DirectiveProcessPass.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
 namespace phpDocumentor\Guides\RestructuredText\Compiler\Passes;
 
 use phpDocumentor\Guides\Compiler\CompilerContext;
@@ -13,7 +22,12 @@ use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 use Psr\Log\LoggerInterface;
 
-class DirectiveProcessPass implements NodeTransformer
+use function strtolower;
+
+use const PHP_INT_MAX;
+
+/** @implements NodeTransformer<DirectiveNode> */
+final class DirectiveProcessPass implements NodeTransformer
 {
     /** @var array<string, DirectiveHandler> */
     private array $directives;
@@ -44,7 +58,14 @@ class DirectiveProcessPass implements NodeTransformer
 
     public function leaveNode(Node $node, CompilerContext $compilerContext): Node|null
     {
-        return $this->getDirectiveHandler($node->getDirective())->createNode($node->getDirective());
+        $newNode = $this->getDirectiveHandler($node->getDirective())->createNode($node);
+        if ($newNode === null) {
+            return null;
+        }
+
+        $newNode->setClasses($node->getClasses());
+
+        return $newNode;
     }
 
     private function getDirectiveHandler(Directive $directive): DirectiveHandler

--- a/packages/guides-restructured-text/src/RestructuredText/Compiler/Passes/DirectiveProcessPass.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Compiler/Passes/DirectiveProcessPass.php
@@ -81,6 +81,6 @@ final class DirectiveProcessPass implements ReverseNodeTransformer
 
     public function getPriority(): int
     {
-        return PHP_INT_MAX;
+        return 100;
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Compiler/Passes/DirectiveProcessPass.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Compiler/Passes/DirectiveProcessPass.php
@@ -14,19 +14,17 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Compiler\Passes;
 
 use phpDocumentor\Guides\Compiler\CompilerContext;
-use phpDocumentor\Guides\Compiler\NodeTransformer;
 use phpDocumentor\Guides\Compiler\ReverseNodeTransformer;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Directives\BaseDirective as DirectiveHandler;
 use phpDocumentor\Guides\RestructuredText\Directives\GeneralDirective;
 use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
-use Psr\Log\LoggerInterface;
 
 use function array_merge;
 use function strtolower;
 
-/** @implements NodeTransformer<DirectiveNode> */
+/** @implements ReverseNodeTransformer<DirectiveNode> */
 final class DirectiveProcessPass implements ReverseNodeTransformer
 {
     /** @var array<string, DirectiveHandler> */
@@ -34,7 +32,6 @@ final class DirectiveProcessPass implements ReverseNodeTransformer
 
     /** @param iterable<DirectiveHandler> $directives */
     public function __construct(
-        private readonly LoggerInterface $logger,
         private readonly GeneralDirective $generalDirective,
         iterable $directives = [],
     ) {
@@ -58,6 +55,10 @@ final class DirectiveProcessPass implements ReverseNodeTransformer
 
     public function leaveNode(Node $node, CompilerContext $compilerContext): Node|null
     {
+        if ($node instanceof DirectiveNode === false) {
+            return $node;
+        }
+
         $newNode = $this->getDirectiveHandler($node->getDirective())->createNode($node);
         if ($newNode === null) {
             return null;

--- a/packages/guides-restructured-text/src/RestructuredText/Compiler/Passes/DirectiveProcessPass.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Compiler/Passes/DirectiveProcessPass.php
@@ -23,9 +23,8 @@ use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 use Psr\Log\LoggerInterface;
 
+use function array_merge;
 use function strtolower;
-
-use const PHP_INT_MAX;
 
 /** @implements NodeTransformer<DirectiveNode> */
 final class DirectiveProcessPass implements ReverseNodeTransformer
@@ -64,7 +63,7 @@ final class DirectiveProcessPass implements ReverseNodeTransformer
             return null;
         }
 
-        $newNode->setClasses($node->getClasses());
+        $newNode->setClasses(array_merge($newNode->getClasses(), $node->getClasses()));
 
         return $newNode;
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/AbstractAdmonitionDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/AbstractAdmonitionDirective.php
@@ -17,6 +17,7 @@ use phpDocumentor\Guides\Nodes\AdmonitionNode;
 use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\ParagraphNode;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
@@ -53,8 +54,18 @@ abstract class AbstractAdmonitionDirective extends SubDirective
         );
     }
 
-    final public function getName(): string
+    public function createNode(DirectiveNode $directiveNode): Node|null
     {
-        return $this->name;
+        $children = $directiveNode->getChildren();
+        if ($directiveNode->getDirective()->getDataNode() !== null) {
+            array_unshift($children, new ParagraphNode([$directiveNode->getDirective()->getDataNode()]));
+        }
+
+        return new AdmonitionNode(
+            $directiveNode->getDirective()->getName(),
+            null,
+            $this->text,
+            $children,
+        );
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/AbstractAdmonitionDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/AbstractAdmonitionDirective.php
@@ -51,11 +51,16 @@ abstract class AbstractAdmonitionDirective extends SubDirective
 
     public function createNode(DirectiveNode $directiveNode): Node|null
     {
+        $children = $directiveNode->getChildren();
+        if ($directiveNode->getDirective()->getDataNode() !== null) {
+            array_unshift($children, new ParagraphNode([$directiveNode->getDirective()->getDataNode()]));
+        }
+
         return new AdmonitionNode(
             $directiveNode->getDirective()->getName(),
-            $directiveNode->getDirective()->getDataNode(),
+            null,
             $this->text,
-            $directiveNode->getChildren(),
+            $children,
         );
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/AbstractAdmonitionDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/AbstractAdmonitionDirective.php
@@ -26,8 +26,12 @@ use function array_unshift;
 
 abstract class AbstractAdmonitionDirective extends SubDirective
 {
-    public function __construct(protected Rule $startingRule, private readonly string $name, private readonly string $text)
-    {
+    public function __construct(
+        protected Rule $startingRule,
+        /** @phpstan-ignore-next-line  */
+        private readonly string $name,
+        private readonly string $text,
+    ) {
         parent::__construct($startingRule);
     }
 

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/AbstractAdmonitionDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/AbstractAdmonitionDirective.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
-use Doctrine\Deprecations\Deprecation;
 use phpDocumentor\Guides\Nodes\AdmonitionNode;
 use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\Node;
@@ -56,11 +55,15 @@ abstract class AbstractAdmonitionDirective extends SubDirective
             array_unshift($children, new ParagraphNode([$directiveNode->getDirective()->getDataNode()]));
         }
 
-        return new AdmonitionNode(
+        $node = new AdmonitionNode(
             $directiveNode->getDirective()->getName(),
             null,
             $this->text,
             $children,
         );
+
+        $node->setClasses([$directiveNode->getDirective()->getOptionString('class')]);
+
+        return $node;
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/AbstractAdmonitionDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/AbstractAdmonitionDirective.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
+use Doctrine\Deprecations\Deprecation;
 use phpDocumentor\Guides\Nodes\AdmonitionNode;
 use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\Node;
@@ -39,33 +40,22 @@ abstract class AbstractAdmonitionDirective extends SubDirective
         BlockContext $blockContext,
         CollectionNode $collectionNode,
         Directive $directive,
-    ): Node {
-        $children = $collectionNode->getChildren();
-
-        if ($directive->getDataNode() !== null) {
-            array_unshift($children, new ParagraphNode([$directive->getDataNode()]));
-        }
-
-        return new AdmonitionNode(
-            $this->name,
-            null,
-            $this->text,
-            $children,
+    ): Node|null {
+        return $this->createNode(
+            new DirectiveNode(
+                $directive,
+                $collectionNode->getChildren(),
+            ),
         );
     }
 
     public function createNode(DirectiveNode $directiveNode): Node|null
     {
-        $children = $directiveNode->getChildren();
-        if ($directiveNode->getDirective()->getDataNode() !== null) {
-            array_unshift($children, new ParagraphNode([$directiveNode->getDirective()->getDataNode()]));
-        }
-
         return new AdmonitionNode(
             $directiveNode->getDirective()->getName(),
-            null,
+            $directiveNode->getDirective()->getDataNode(),
             $this->text,
-            $children,
+            $directiveNode->getChildren(),
         );
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/AbstractVersionChangeDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/AbstractVersionChangeDirective.php
@@ -77,7 +77,7 @@ abstract class AbstractVersionChangeDirective extends SubDirective
         }
     }
 
-    public function createNode(DirectiveNode $directiveNode): Node|null
+    public function createNode(DirectiveNode $directiveNode): Node
     {
         return new VersionChangeNode(
             $this->type,

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/AbstractVersionChangeDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/AbstractVersionChangeDirective.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
-use Doctrine\Deprecations\Deprecation;
-use LogicException;
 use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
@@ -23,19 +21,12 @@ use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
 
-use function sprintf;
-
 /** @see https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-versionadded */
 abstract class AbstractVersionChangeDirective extends SubDirective
 {
-    /**
-     * @param string $name the directive's name, as matched in the .rst source; may differ from $type so
-     *                      that renaming a directive does not also change the CSS class of its rendered output
-     * @param string $type the type passed to VersionChangeNode, also used as the rendered CSS class
-     */
+    /** @param string $type the type passed to VersionChangeNode, also used as the rendered CSS class */
     public function __construct(
         protected Rule $startingRule,
-        private readonly string $name,
         private readonly string $type,
         private readonly string $label,
     ) {
@@ -57,24 +48,6 @@ abstract class AbstractVersionChangeDirective extends SubDirective
                 $collectionNode->getChildren(),
             ),
         );
-    }
-
-    public function getName(): string
-    {
-        try {
-            return parent::getName();
-        } catch (LogicException) {
-            Deprecation::trigger(
-                'phpdocumentor/guides-restructured-text',
-                'TODO: link',
-                sprintf(
-                    'Directives without attributes are deprecated, consult the documentation for more information on how to update your directives. Directive: %s',
-                    $this->type,
-                ),
-            );
-
-            return $this->type;
-        }
     }
 
     public function createNode(DirectiveNode $directiveNode): Node

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/AbstractVersionChangeDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/AbstractVersionChangeDirective.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 use Doctrine\Deprecations\Deprecation;
+use LogicException;
 use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
@@ -21,6 +22,8 @@ use phpDocumentor\Guides\RestructuredText\Nodes\VersionChangeNode;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
+
+use function sprintf;
 
 /** @see https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-versionadded */
 abstract class AbstractVersionChangeDirective extends SubDirective
@@ -60,7 +63,7 @@ abstract class AbstractVersionChangeDirective extends SubDirective
     {
         try {
             return parent::getName();
-        } catch (\LogicException) {
+        } catch (LogicException) {
             Deprecation::trigger(
                 'phpdocumentor/guides-restructured-text',
                 'TODO: link',

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/AbstractVersionChangeDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/AbstractVersionChangeDirective.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
+use Doctrine\Deprecations\Deprecation;
 use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Nodes\VersionChangeNode;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
@@ -46,16 +48,39 @@ abstract class AbstractVersionChangeDirective extends SubDirective
         CollectionNode $collectionNode,
         Directive $directive,
     ): Node {
-        return new VersionChangeNode(
-            $this->type,
-            $this->label,
-            $directive->getData(),
-            $collectionNode->getChildren(),
+        return $this->createNode(
+            new DirectiveNode(
+                $directive,
+                $collectionNode->getChildren(),
+            ),
         );
     }
 
-    final public function getName(): string
+    public function getName(): string
     {
-        return $this->name;
+        try {
+            return parent::getName();
+        } catch (\LogicException) {
+            Deprecation::trigger(
+                'phpdocumentor/guides-restructured-text',
+                'TODO: link',
+                sprintf(
+                    'Directives without attributes are deprecated, consult the documentation for more information on how to update your directives. Directive: %s',
+                    $this->type,
+                ),
+            );
+
+            return $this->type;
+        }
+    }
+
+    public function createNode(DirectiveNode $directiveNode): Node|null
+    {
+        return new VersionChangeNode(
+            $this->type,
+            $this->label,
+            $directiveNode->getDirective()->getData(),
+            $directiveNode->getChildren(),
+        );
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/AdmonitionDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/AdmonitionDirective.php
@@ -16,6 +16,7 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 use phpDocumentor\Guides\Nodes\AdmonitionNode;
 use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
@@ -46,22 +47,32 @@ final class AdmonitionDirective extends SubDirective
         CollectionNode $collectionNode,
         Directive $directive,
     ): Node|null {
+        return $this->createNode(
+            new DirectiveNode(
+                $directive,
+                $collectionNode->getChildren(),
+            ),
+        );
+    }
+
+    public function createNode(DirectiveNode $directiveNode): Node|null
+    {
         // The title argument is required per the RST spec.
         // Skip rendering if no title is provided.
-        if ($directive->getData() === '') {
+        if ($directiveNode->getDirective()->getData() === '') {
             return null;
         }
 
         $name = trim(
-            preg_replace('/[^0-9a-zA-Z]+/', '-', strtolower($directive->getData())) ?? '',
+            preg_replace('/[^0-9a-zA-Z]+/', '-', strtolower($directiveNode->getDirective()->getData())) ?? '',
             '-',
         );
 
         return new AdmonitionNode(
             $name,
-            $directive->getDataNode(),
-            $directive->getData(),
-            $collectionNode->getChildren(),
+            $directiveNode->getDirective()->getDataNode(),
+            $directiveNode->getDirective()->getData(),
+            $directiveNode->getChildren(),
             true,
         );
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/AdmonitionDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/AdmonitionDirective.php
@@ -34,13 +34,9 @@ use function trim;
  *
  * @see https://docutils.sourceforge.io/docs/ref/rst/directives.html#generic-admonition
  */
+#[Attributes\Directive(name: 'admonition')]
 final class AdmonitionDirective extends SubDirective
 {
-    public function getName(): string
-    {
-        return 'admonition';
-    }
-
     /** {@inheritDoc}
      *
      * @param Directive $directive

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/AttentionDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/AttentionDirective.php
@@ -26,6 +26,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
  *      This is an attention admonition.
  * ```
  */
+#[Attributes\Directive(name: 'attention')]
 final class AttentionDirective extends AbstractAdmonitionDirective
 {
     public function __construct(protected Rule $startingRule)

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/Attributes/Directive.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/Attributes/Directive.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\RestructuredText\Directives\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class Directive
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly array $aliases = [],
+    ) {
+
+    }
+}

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/Attributes/Directive.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/Attributes/Directive.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
 namespace phpDocumentor\Guides\RestructuredText\Directives\Attributes;
 
 use Attribute;
@@ -9,10 +18,10 @@ use Attribute;
 #[Attribute(Attribute::TARGET_CLASS)]
 final class Directive
 {
+    /** @param string[] $aliases */
     public function __construct(
         public readonly string $name,
         public readonly array $aliases = [],
     ) {
-
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/Attributes/Option.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/Attributes/Option.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\RestructuredText\Directives\Attributes;
+
+use Attribute;
+use phpDocumentor\Guides\RestructuredText\Directives\OptionType;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+final class Option
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly OptionType $type = OptionType::String,
+        public readonly mixed $default = null,
+        public readonly string $description = '',
+        public readonly string|null $example = null,
+    ) {
+    }
+}
+

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/Attributes/Option.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/Attributes/Option.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
 namespace phpDocumentor\Guides\RestructuredText\Directives\Attributes;
 
 use Attribute;
@@ -19,4 +28,3 @@ final class Option
     ) {
     }
 }
-

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/Attributes/Option.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/Attributes/Option.php
@@ -22,7 +22,7 @@ final class Option
     public function __construct(
         public readonly string $name,
         public readonly OptionType $type = OptionType::String,
-        public readonly mixed $default = null,
+        public readonly bool|string|int|float|null $default = null,
         public readonly string $description = '',
         public readonly string|null $example = null,
     ) {

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/BaseDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/BaseDirective.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
+use Doctrine\Deprecations\Deprecation;
 use LogicException;
 use phpDocumentor\Guides\Nodes\GenericNode;
 use phpDocumentor\Guides\Nodes\Node;
@@ -110,7 +111,18 @@ abstract class BaseDirective
         $reflection = new ReflectionClass($this);
         $attributes = $reflection->getAttributes(Attributes\Directive::class);
 
-        return count($attributes) === 1;
+        if (count($attributes) !== 1) {
+            Deprecation::trigger(
+                'phpdocumentor/guide-restructured-text',
+                'https://github.com/phpDocumentor/guides/issues/1373',
+                'Directive class "%s" must have a Directive attribute. This directive needs to be upgraded.',
+                $this->getName(),
+            );
+
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/BaseDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/BaseDirective.php
@@ -38,10 +38,29 @@ abstract class BaseDirective
     /** @var array<string, Option|null> Cache of Option attributes indexed by option name */
     private array $optionAttributeCache;
 
+    private string $name;
+
+    private array $aliases;
+
     /**
      * Get the directive name
      */
-    abstract public function getName(): string;
+    public function getName(): string
+    {
+        if (isset($this->name)) {
+            return $this->name;
+        }
+
+        $reflection = new \ReflectionClass($this);
+        $attributes = $reflection->getAttributes(Attributes\Directive::class);
+
+        if (count($attributes) === 0) {
+            throw new \LogicException('Directive class must have a Directive attribute');
+        }
+
+        $this->name = $attributes[0]->newInstance()->name;
+        return $this->name;
+    }
 
     /**
      * Allow a directive to be registered under multiple names.
@@ -52,7 +71,35 @@ abstract class BaseDirective
      */
     public function getAliases(): array
     {
-        return [];
+        if (isset($this->aliases)) {
+            return $this->aliases;
+        }
+
+        $reflection = new \ReflectionClass($this);
+        $attributes = $reflection->getAttributes(Attributes\Directive::class);
+        $this->aliases = [];
+        if (count($attributes) !== 0) {
+            $this->aliases = $attributes[0]->newInstance()->aliases;
+        }
+
+        return $this->aliases;
+    }
+
+    /**
+     * Returns whether this directive has been upgraded to a new version.
+     *
+     * In the new version of directives, the processing is done during the compile phase.
+     * This method only exists to allow for backward compatibility with directives that
+     * were written before the upgrade.
+     *
+     * @internal
+     */
+    final public function isUpgraded(): bool
+    {
+        $reflection = new \ReflectionClass($this);
+        $attributes = $reflection->getAttributes(Attributes\Directive::class);
+
+        return count($attributes) === 1;
     }
 
     /**
@@ -85,6 +132,11 @@ abstract class BaseDirective
         Directive $directive,
     ): Node {
         return new GenericNode($directive->getVariable(), $directive->getData());
+    }
+
+    public function createNode(Directive $directive): Node|null
+    {
+        return null;
     }
 
     /**

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/BaseDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/BaseDirective.php
@@ -13,12 +13,21 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
+use LogicException;
 use phpDocumentor\Guides\Nodes\GenericNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Directives\Attributes\Option;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 use phpDocumentor\Guides\RestructuredText\Parser\DirectiveOption;
+use ReflectionClass;
+
+use function array_map;
+use function count;
+use function filter_var;
+
+use const FILTER_VALIDATE_BOOL;
 
 /**
  * A directive is like a function you can call or apply to a block
@@ -35,11 +44,12 @@ use phpDocumentor\Guides\RestructuredText\Parser\DirectiveOption;
  */
 abstract class BaseDirective
 {
-    /** @var array<string, Option|null> Cache of Option attributes indexed by option name */
+    /** @var array<string, Option> Cache of Option attributes indexed by option name */
     private array $optionAttributeCache;
 
     private string $name;
 
+    /** @var string[] */
     private array $aliases;
 
     /**
@@ -51,14 +61,15 @@ abstract class BaseDirective
             return $this->name;
         }
 
-        $reflection = new \ReflectionClass($this);
+        $reflection = new ReflectionClass($this);
         $attributes = $reflection->getAttributes(Attributes\Directive::class);
 
         if (count($attributes) === 0) {
-            throw new \LogicException('Directive class must have a Directive attribute');
+            throw new LogicException('Directive class must have a Directive attribute');
         }
 
         $this->name = $attributes[0]->newInstance()->name;
+
         return $this->name;
     }
 
@@ -75,7 +86,7 @@ abstract class BaseDirective
             return $this->aliases;
         }
 
-        $reflection = new \ReflectionClass($this);
+        $reflection = new ReflectionClass($this);
         $attributes = $reflection->getAttributes(Attributes\Directive::class);
         $this->aliases = [];
         if (count($attributes) !== 0) {
@@ -96,7 +107,7 @@ abstract class BaseDirective
      */
     final public function isUpgraded(): bool
     {
-        $reflection = new \ReflectionClass($this);
+        $reflection = new ReflectionClass($this);
         $attributes = $reflection->getAttributes(Attributes\Directive::class);
 
         return count($attributes) === 1;
@@ -134,7 +145,7 @@ abstract class BaseDirective
         return new GenericNode($directive->getVariable(), $directive->getData());
     }
 
-    public function createNode(Directive $directive): Node|null
+    public function createNode(DirectiveNode $directiveNode): Node|null
     {
         return null;
     }
@@ -173,13 +184,14 @@ abstract class BaseDirective
         return $this->getOptionValue($directive, $optionAttribute);
     }
 
+    /** @return array<string, mixed> */
     final protected function readAllOptions(Directive $directive): array
     {
         $this->initialize();
 
         return array_map(
             fn (Option $option) => $this->getOptionValue($directive, $option),
-            $this->optionAttributeCache
+            $this->optionAttributeCache,
         );
     }
 
@@ -201,10 +213,8 @@ abstract class BaseDirective
             OptionType::Boolean => $value === null || filter_var($value, FILTER_VALIDATE_BOOL),
             OptionType::String => (string) $value,
             OptionType::Array => (array) $value,
-            default => $value,
         };
     }
-
 
     /**
      * Finds the Option attribute for the given option name on the current class.
@@ -213,7 +223,7 @@ abstract class BaseDirective
      *
      * @return Option|null The Option attribute if found, null otherwise
      */
-    private function findOptionAttribute(string $optionName): ?Option
+    private function findOptionAttribute(string $optionName): Option|null
     {
         $this->initialize();
 
@@ -226,7 +236,7 @@ abstract class BaseDirective
             return;
         }
 
-        $reflection = new \ReflectionClass($this);
+        $reflection = new ReflectionClass($this);
         $attributes = $reflection->getAttributes(Option::class);
         $this->optionAttributeCache = [];
         foreach ($attributes as $attribute) {
@@ -235,5 +245,3 @@ abstract class BaseDirective
         }
     }
 }
-
-

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/BaseDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/BaseDirective.php
@@ -184,7 +184,7 @@ abstract class BaseDirective
         return $this->getOptionValue($directive, $optionAttribute);
     }
 
-    /** @return array<string, bool|float|int|string|null> */
+    /** @return array<string, scalar|scalar[]|null> */
     final protected function readAllOptions(Directive $directive): array
     {
         $this->initialize();
@@ -195,7 +195,8 @@ abstract class BaseDirective
         );
     }
 
-    private function getOptionValue(Directive $directive, Option|null $option): mixed
+    /** @return scalar|scalar[]|null */
+    private function getOptionValue(Directive $directive, Option|null $option): bool|float|int|string|array|null
     {
         if ($option === null) {
             return null;

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/BaseDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/BaseDirective.php
@@ -15,6 +15,7 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 use phpDocumentor\Guides\Nodes\GenericNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Directives\Attributes\Option;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 use phpDocumentor\Guides\RestructuredText\Parser\DirectiveOption;
@@ -34,6 +35,9 @@ use phpDocumentor\Guides\RestructuredText\Parser\DirectiveOption;
  */
 abstract class BaseDirective
 {
+    /** @var array<string, Option|null> Cache of Option attributes indexed by option name */
+    private array $optionAttributeCache;
+
     /**
      * Get the directive name
      */
@@ -97,4 +101,87 @@ abstract class BaseDirective
 
         return $result;
     }
+
+    /**
+     * Gets an option value from a directive based on attribute configuration.
+     *
+     * Looks up the option in the directive and returns its value converted to the
+     * appropriate type based on the Option attribute defined on this directive class.
+     * If the option is not present in the directive, returns the default value from the attribute.
+     *
+     * @param Directive $directive The directive containing the options
+     * @param string $optionName The name of the option to retrieve
+     *
+     * @return mixed The option value converted to the appropriate type, or the default value
+     */
+    final protected function readOption(Directive $directive, string $optionName): mixed
+    {
+        $optionAttribute = $this->findOptionAttribute($optionName);
+
+        return $this->getOptionValue($directive, $optionAttribute);
+    }
+
+    final protected function readAllOptions(Directive $directive): array
+    {
+        $this->initialize();
+
+        return array_map(
+            fn (Option $option) => $this->getOptionValue($directive, $option),
+            $this->optionAttributeCache
+        );
+    }
+
+    private function getOptionValue(Directive $directive, Option|null $option): mixed
+    {
+        if ($option === null) {
+            return null;
+        }
+
+        if (!$directive->hasOption($option->name)) {
+            return $option->default;
+        }
+
+        $directiveOption = $directive->getOption($option->name);
+        $value = $directiveOption->getValue();
+
+        return match ($option->type) {
+            OptionType::Integer => (int) $value,
+            OptionType::Boolean => $value === null || filter_var($value, FILTER_VALIDATE_BOOL),
+            OptionType::String => (string) $value,
+            OptionType::Array => (array) $value,
+            default => $value,
+        };
+    }
+
+
+    /**
+     * Finds the Option attribute for the given option name on the current class.
+     *
+     * @param string $optionName The option name to look for
+     *
+     * @return Option|null The Option attribute if found, null otherwise
+     */
+    private function findOptionAttribute(string $optionName): ?Option
+    {
+        $this->initialize();
+
+        return $this->optionAttributeCache[$optionName] ?? null;
+    }
+
+    private function initialize(): void
+    {
+        if (isset($this->optionAttributeCache)) {
+            return;
+        }
+
+        $reflection = new \ReflectionClass($this);
+        $attributes = $reflection->getAttributes(Option::class);
+        $this->optionAttributeCache = [];
+        foreach ($attributes as $attribute) {
+            $option = $attribute->newInstance();
+            $this->optionAttributeCache[$option->name] = $option;
+        }
+    }
 }
+
+

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/BaseDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/BaseDirective.php
@@ -184,7 +184,7 @@ abstract class BaseDirective
         return $this->getOptionValue($directive, $optionAttribute);
     }
 
-    /** @return array<string, mixed> */
+    /** @return array<string, bool|float|int|string|null> */
     final protected function readAllOptions(Directive $directive): array
     {
         $this->initialize();

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/BreadcrumbDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/BreadcrumbDirective.php
@@ -15,6 +15,7 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 use phpDocumentor\Guides\Nodes\BreadCrumbNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
@@ -30,17 +31,11 @@ use phpDocumentor\Guides\RestructuredText\Parser\Directive;
  * ..  breadcrumb::
  * ```
  */
+#[Attributes\Directive(name: 'breadcrumb')]
 final class BreadcrumbDirective extends BaseDirective
 {
-    public function getName(): string
+    public function createNode(DirectiveNode $directiveNode): Node|null
     {
-        return 'breadcrumb';
-    }
-
-    public function processNode(
-        BlockContext $blockContext,
-        Directive $directive,
-    ): Node {
         return new BreadCrumbNode();
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/BreadcrumbDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/BreadcrumbDirective.php
@@ -32,7 +32,7 @@ use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 #[Attributes\Directive(name: 'breadcrumb')]
 final class BreadcrumbDirective extends BaseDirective
 {
-    public function createNode(DirectiveNode $directiveNode): Node|null
+    public function createNode(DirectiveNode $directiveNode): Node
     {
         return new BreadCrumbNode();
     }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/BreadcrumbDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/BreadcrumbDirective.php
@@ -16,8 +16,6 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 use phpDocumentor\Guides\Nodes\BreadCrumbNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
-use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
-use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
 /**
  * The "breadcrumb" directive displays a breadcrumb of the current. It does not exist in Sphinx or the

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/CautionDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/CautionDirective.php
@@ -26,6 +26,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
  *      This is a caution admonition.
  * ```
  */
+#[Attributes\Directive(name: 'caution')]
 final class CautionDirective extends AbstractAdmonitionDirective
 {
     public function __construct(protected Rule $startingRule)

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ConfvalDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ConfvalDirective.php
@@ -16,6 +16,7 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\ReferenceResolvers\AnchorNormalizer;
+use phpDocumentor\Guides\RestructuredText\Directives\Attributes\Option;
 use phpDocumentor\Guides\RestructuredText\Nodes\ConfvalNode;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
@@ -32,6 +33,11 @@ use function trim;
  *
  * https://sphinx-toolbox.readthedocs.io/en/stable/extensions/confval.html
  */
+#[Option(name: 'name', description: 'Id of the configuration value, used for linking to it.')]
+#[Option(name: 'type', description: 'Type of the configuration value, e.g. "string", "int", etc.')]
+#[Option(name: 'required', type: OptionType::Boolean, default: false, description: 'Whether the configuration value is required or not.')]
+#[Option(name: 'default', description: 'Default value of the configuration value, if any.')]
+#[Option(name: 'noindex', type: OptionType::Boolean, default: false, description: 'Whether the configuration value should not be indexed.')]
 final class ConfvalDirective extends SubDirective
 {
     public const NAME = 'confval';
@@ -80,16 +86,16 @@ final class ConfvalDirective extends SubDirective
         }
 
         if ($directive->hasOption('type')) {
-            $type = $this->inlineParser->parse($directive->getOptionString('type'), $blockContext);
+            $type = $this->inlineParser->parse($this->readOption($directive, 'type'), $blockContext);
         }
 
-        $required = $directive->getOptionBool('required');
+        $required = $this->readOption($directive, 'required');
 
         if ($directive->hasOption('default')) {
-            $default = $this->inlineParser->parse($directive->getOptionString('default'), $blockContext);
+            $default = $this->inlineParser->parse($this->readOption($directive, 'default'), $blockContext);
         }
 
-        $noindex = $directive->getOptionBool('noindex');
+        $noindex = $this->readOption($directive, 'noindex');
 
         foreach ($directive->getOptions() as $option) {
             if (in_array($option->getName(), ['type', 'required', 'default', 'noindex', 'name'], true)) {

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ConfvalDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ConfvalDirective.php
@@ -86,13 +86,13 @@ final class ConfvalDirective extends SubDirective
         }
 
         if ($directive->hasOption('type')) {
-            $type = $this->inlineParser->parse($this->readOption($directive, 'type'), $blockContext);
+            $type = $this->inlineParser->parse($this->readOption($directive, 'type') ?? '', $blockContext);
         }
 
         $required = $this->readOption($directive, 'required');
 
         if ($directive->hasOption('default')) {
-            $default = $this->inlineParser->parse($this->readOption($directive, 'default'), $blockContext);
+            $default = $this->inlineParser->parse($this->readOption($directive, 'default') ?? '', $blockContext);
         }
 
         $noindex = $this->readOption($directive, 'noindex');

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ContentsDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ContentsDirective.php
@@ -17,6 +17,7 @@ use phpDocumentor\Guides\Nodes\Menu\ContentMenuNode;
 use phpDocumentor\Guides\Nodes\Menu\SectionMenuEntryNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\ReferenceResolvers\DocumentNameResolverInterface;
+use phpDocumentor\Guides\RestructuredText\Directives\Attributes\Option;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
@@ -25,6 +26,8 @@ use phpDocumentor\Guides\RestructuredText\Parser\Directive;
  *
  * Displays a table of content of the current page
  */
+#[Option(name: 'local', type: OptionType::Boolean, description: 'If set, the table of contents will only include sections that are local to the current document.', default: false)]
+#[Option(name: 'depth', description: 'The maximum depth of the table of contents.')]
 final class ContentsDirective extends BaseDirective
 {
     public function __construct(
@@ -51,6 +54,6 @@ final class ContentsDirective extends BaseDirective
         return (new ContentMenuNode([new SectionMenuEntryNode($absoluteUrl)]))
             ->withOptions($this->optionsToArray($options))
             ->withCaption($directive->getDataNode())
-            ->withLocal($directive->hasOption('local'));
+            ->withLocal($this->readOption($directive, 'local'));
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ContentsDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ContentsDirective.php
@@ -54,6 +54,6 @@ final class ContentsDirective extends BaseDirective
         return (new ContentMenuNode([new SectionMenuEntryNode($absoluteUrl)]))
             ->withOptions($this->optionsToArray($options))
             ->withCaption($directive->getDataNode())
-            ->withLocal($this->readOption($directive, 'local'));
+            ->withLocal($directive->getOptionBool('local'));
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/CsvTableDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/CsvTableDirective.php
@@ -20,6 +20,7 @@ use phpDocumentor\Guides\Nodes\ParagraphNode;
 use phpDocumentor\Guides\Nodes\Table\TableColumn;
 use phpDocumentor\Guides\Nodes\Table\TableRow;
 use phpDocumentor\Guides\Nodes\TableNode;
+use phpDocumentor\Guides\RestructuredText\Directives\Attributes\Option;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\RuleContainer;

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/CsvTableDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/CsvTableDirective.php
@@ -20,7 +20,6 @@ use phpDocumentor\Guides\Nodes\ParagraphNode;
 use phpDocumentor\Guides\Nodes\Table\TableColumn;
 use phpDocumentor\Guides\Nodes\Table\TableRow;
 use phpDocumentor\Guides\Nodes\TableNode;
-use phpDocumentor\Guides\RestructuredText\Directives\Attributes\Option;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\RuleContainer;

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/DangerDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/DangerDirective.php
@@ -26,6 +26,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
  *      This is a danger admonition.
  * ```
  */
+#[Attributes\Directive(name: 'danger')]
 class DangerDirective extends AbstractAdmonitionDirective
 {
     public function __construct(protected Rule $startingRule)

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/DeprecatedDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/DeprecatedDirective.php
@@ -28,16 +28,11 @@ use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
  *
  * The legacy name `deprecated` is supported as an alias.
  */
+#[Attributes\Directive(name: 'version-deprecated', aliases: ['deprecated'])]
 final class DeprecatedDirective extends AbstractVersionChangeDirective
 {
     public function __construct(protected Rule $startingRule)
     {
         parent::__construct($startingRule, 'version-deprecated', 'deprecated', 'Deprecated since version %s');
-    }
-
-    /** {@inheritDoc} */
-    public function getAliases(): array
-    {
-        return ['deprecated'];
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/DeprecatedDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/DeprecatedDirective.php
@@ -33,6 +33,6 @@ final class DeprecatedDirective extends AbstractVersionChangeDirective
 {
     public function __construct(protected Rule $startingRule)
     {
-        parent::__construct($startingRule, 'version-deprecated', 'deprecated', 'Deprecated since version %s');
+        parent::__construct($startingRule, 'deprecated', 'Deprecated since version %s');
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/DocumentBlockDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/DocumentBlockDirective.php
@@ -16,9 +16,11 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\DocumentBlockNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Directives\Attributes\Option;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
+#[Option(name: 'identifier', description: 'The identifier of the document block')]
 final class DocumentBlockDirective extends SubDirective
 {
     public function getName(): string
@@ -39,7 +41,7 @@ final class DocumentBlockDirective extends SubDirective
 
         return new DocumentBlockNode(
             $collectionNode->getChildren(),
-            $identifier,
+            $this->readOption($directive, 'identifier'),
         );
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/DocumentBlockDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/DocumentBlockDirective.php
@@ -39,7 +39,7 @@ final class DocumentBlockDirective extends SubDirective
     ): Node {
         return new DocumentBlockNode(
             $collectionNode->getChildren(),
-            $this->readOption($directive, 'identifier'),
+            $this->readOption($directive, 'identifier') ?? '',
         );
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/DocumentBlockDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/DocumentBlockDirective.php
@@ -37,8 +37,6 @@ final class DocumentBlockDirective extends SubDirective
         CollectionNode $collectionNode,
         Directive $directive,
     ): Node {
-        $identifier = ((string) $directive->getOption('identifier')->getValue());
-
         return new DocumentBlockNode(
             $collectionNode->getChildren(),
             $this->readOption($directive, 'identifier'),

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/DocumentBlockDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/DocumentBlockDirective.php
@@ -20,7 +20,7 @@ use phpDocumentor\Guides\RestructuredText\Directives\Attributes\Option;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
-#[Option(name: 'identifier', description: 'The identifier of the document block')]
+#[Option(name: 'identifier', type: OptionType::String, description: 'The identifier of the document block')]
 final class DocumentBlockDirective extends SubDirective
 {
     public function getName(): string

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ErrorDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ErrorDirective.php
@@ -26,6 +26,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
  *      This is an error admonition.
  * ```
  */
+#[Attributes\Directive(name: 'error')]
 final class ErrorDirective extends AbstractAdmonitionDirective
 {
     public function __construct(protected Rule $startingRule)

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/FigureDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/FigureDirective.php
@@ -18,6 +18,7 @@ use phpDocumentor\Guides\Nodes\FigureNode;
 use phpDocumentor\Guides\Nodes\ImageNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\ReferenceResolvers\DocumentNameResolverInterface;
+use phpDocumentor\Guides\RestructuredText\Directives\Attributes\Option;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
@@ -33,6 +34,14 @@ use function dirname;
  *
  *      Here is an awesome caption
  */
+#[Option(name: 'width', description: 'Width of the image in pixels')]
+#[Option(name: 'height', description: 'Height of the image in pixels')]
+#[Option(name: 'alt', description: 'Alternative text for the image')]
+#[Option(name: 'scale', description: 'Scale of the image, e.g. 0.5 for half size')]
+#[Option(name: 'target', description: 'Target for the image, e.g. a link to the image')]
+#[Option(name: 'class', description: 'CSS class to apply to the image')]
+#[Option(name: 'name', description: 'Name of the image, used for references')]
+#[Option(name: 'align', description: 'Alignment of the image, e.g. left, right, center')]
 final class FigureDirective extends SubDirective
 {
     public function __construct(

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/GeneralDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/GeneralDirective.php
@@ -31,7 +31,7 @@ use function str_contains;
  */
 final class GeneralDirective extends SubDirective
 {
-    /** @param Rule<Node> $startingRule */
+    /** @param Rule<CollectionNode> $startingRule */
     public function __construct(
         Rule $startingRule,
         private readonly SettingsManager $settingsManager,

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/GeneralDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/GeneralDirective.php
@@ -31,7 +31,7 @@ use function str_contains;
  */
 final class GeneralDirective extends SubDirective
 {
-    /** @param Rule<CollectionNode> $startingRule */
+    /** @param Rule<Node> $startingRule */
     public function __construct(
         Rule $startingRule,
         private readonly SettingsManager $settingsManager,

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/HintDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/HintDirective.php
@@ -26,6 +26,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
  *      This is a hint admonition.
  * ```
  */
+#[Attributes\Directive(name: 'hint')]
 final class HintDirective extends AbstractAdmonitionDirective
 {
     public function __construct(protected Rule $startingRule)

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ImageDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ImageDirective.php
@@ -20,6 +20,7 @@ use phpDocumentor\Guides\Nodes\Inline\LinkInlineNode;
 use phpDocumentor\Guides\Nodes\Inline\ReferenceNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\ReferenceResolvers\DocumentNameResolverInterface;
+use phpDocumentor\Guides\RestructuredText\Directives\Attributes\Option;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
@@ -37,6 +38,14 @@ use const FILTER_VALIDATE_URL;
  *      :width: 100
  *      :title: An image
  */
+#[Option(name: 'width', description: 'Width of the image in pixels')]
+#[Option(name: 'height', description: 'Height of the image in pixels')]
+#[Option(name: 'alt', description: 'Alternative text for the image')]
+#[Option(name: 'scale', description: 'Scale of the image, e.g. 0.5 for half size')]
+#[Option(name: 'target', description: 'Target for the image, e.g. a link to the image')]
+#[Option(name: 'class', description: 'CSS class to apply to the image')]
+#[Option(name: 'name', description: 'Name of the image, used for references')]
+#[Option(name: 'align', description: 'Alignment of the image, e.g. left, right, center')]
 final class ImageDirective extends BaseDirective
 {
     /** @see https://regex101.com/r/9dUrzu/3 */
@@ -67,8 +76,11 @@ final class ImageDirective extends BaseDirective
             ),
         );
         if ($directive->hasOption('target')) {
-            $targetReference = (string) $directive->getOption('target')->getValue();
-            $node->setTarget($this->resolveLinkTarget($targetReference));
+            $node->setTarget(
+                $this->resolveLinkTarget(
+                    $this->readOption($directive, 'target')
+                ),
+            );
         }
 
         return $node;

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ImageDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ImageDirective.php
@@ -78,7 +78,7 @@ final class ImageDirective extends BaseDirective
         if ($directive->hasOption('target')) {
             $node->setTarget(
                 $this->resolveLinkTarget(
-                    $this->readOption($directive, 'target')
+                    $this->readOption($directive, 'target'),
                 ),
             );
         }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ImageDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ImageDirective.php
@@ -78,7 +78,7 @@ final class ImageDirective extends BaseDirective
         if ($directive->hasOption('target')) {
             $node->setTarget(
                 $this->resolveLinkTarget(
-                    $this->readOption($directive, 'target'),
+                    $directive->getOptionString('target'),
                 ),
             );
         }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ImportantDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ImportantDirective.php
@@ -26,6 +26,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
  *      This is a important admonition.
  * ```
  */
+#[Attributes\Directive(name: 'important')]
 final class ImportantDirective extends AbstractAdmonitionDirective
 {
     public function __construct(protected Rule $startingRule)

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/IncludeDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/IncludeDirective.php
@@ -17,6 +17,7 @@ use phpDocumentor\Guides\Nodes\CodeNode;
 use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\LiteralBlockNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Directives\Attributes\Option;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\DocumentRule;
@@ -27,6 +28,8 @@ use function explode;
 use function sprintf;
 use function str_replace;
 
+#[Option(name: 'literal', description: 'If set, the contents will be rendered as a literal block.')]
+#[Option(name: 'code', description: 'If set, the contents will be rendered as a code block with the specified language.')]
 final class IncludeDirective extends BaseDirective
 {
     public function __construct(private readonly DocumentRule $startingRule)

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/NoteDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/NoteDirective.php
@@ -26,6 +26,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
  *      This is a note admonition.
  * ```
  */
+#[Attributes\Directive(name: 'note')]
 final class NoteDirective extends AbstractAdmonitionDirective
 {
     public function __construct(protected Rule $startingRule)

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/OptionType.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/OptionType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\RestructuredText\Directives;
+
+enum OptionType
+{
+    case String;
+    case Integer;
+    case Boolean;
+    case Array;
+}

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/OptionType.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/OptionType.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 enum OptionType

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/SeeAlsoDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/SeeAlsoDirective.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
+use phpDocumentor\Guides\RestructuredText\Directives\Attributes\Directive;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
 
 /**
@@ -26,6 +27,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
  *      This is a seealso admonition.
  * ```
  */
+#[Directive(name: 'seealso')]
 final class SeeAlsoDirective extends AbstractAdmonitionDirective
 {
     public function __construct(protected Rule $startingRule)

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/TipDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/TipDirective.php
@@ -26,6 +26,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
  *      This is a tip admonition.
  * ```
  */
+#[Attributes\Directive(name: 'tip')]
 final class TipDirective extends AbstractAdmonitionDirective
 {
     public function __construct(protected Rule $startingRule)

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/VersionAddedDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/VersionAddedDirective.php
@@ -33,6 +33,6 @@ final class VersionAddedDirective extends AbstractVersionChangeDirective
 {
     public function __construct(protected Rule $startingRule)
     {
-        parent::__construct($startingRule, 'version-added', 'versionadded', 'New in version %s');
+        parent::__construct($startingRule, 'versionadded', 'New in version %s');
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/VersionAddedDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/VersionAddedDirective.php
@@ -28,16 +28,11 @@ use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
  *
  * The legacy name `versionadded` is supported as an alias.
  */
+#[Attributes\Directive(name: 'version-added', aliases: ['versionadded'])]
 final class VersionAddedDirective extends AbstractVersionChangeDirective
 {
     public function __construct(protected Rule $startingRule)
     {
         parent::__construct($startingRule, 'version-added', 'versionadded', 'New in version %s');
-    }
-
-    /** {@inheritDoc} */
-    public function getAliases(): array
-    {
-        return ['versionadded'];
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/VersionChangedDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/VersionChangedDirective.php
@@ -33,6 +33,6 @@ final class VersionChangedDirective extends AbstractVersionChangeDirective
 {
     public function __construct(protected Rule $startingRule)
     {
-        parent::__construct($startingRule, 'version-changed', 'versionchanged', 'Changed in version %s');
+        parent::__construct($startingRule, 'versionchanged', 'Changed in version %s');
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/VersionChangedDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/VersionChangedDirective.php
@@ -28,16 +28,11 @@ use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
  *
  * The legacy name `versionchanged` is supported as an alias.
  */
+#[Attributes\Directive(name: 'version-changed', aliases: ['versionchanged'])]
 final class VersionChangedDirective extends AbstractVersionChangeDirective
 {
     public function __construct(protected Rule $startingRule)
     {
         parent::__construct($startingRule, 'version-changed', 'versionchanged', 'Changed in version %s');
-    }
-
-    /** {@inheritDoc} */
-    public function getAliases(): array
-    {
-        return ['versionchanged'];
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/WarningDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/WarningDirective.php
@@ -26,6 +26,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
  *      This is a warning admonition.
  * ```
  */
+#[Attributes\Directive(name: 'warning')]
 final class WarningDirective extends AbstractAdmonitionDirective
 {
     public function __construct(protected Rule $startingRule)

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/YoutubeDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/YoutubeDirective.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 use phpDocumentor\Guides\Nodes\EmbeddedFrame;
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Directives\Attributes;
 use phpDocumentor\Guides\RestructuredText\Directives\Attributes\Option;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
@@ -37,6 +39,7 @@ use function array_filter;
  * - string allow The allow attribute of the iframe, default is 'encrypted-media; picture-in-picture; web-share'
  * - bool allowfullscreen Whether the video should be allowed to go fullscreen, default is true
  */
+#[Attributes\Directive(name: 'youtube')]
 #[Option('width', type: OptionType::Integer, default: 560, description: 'Width of the video')]
 #[Option('title', type: OptionType::String, description: 'Title of the video')]
 #[Option('height', type: OptionType::Integer, default: 315, description: 'Height of the video')]
@@ -53,6 +56,11 @@ final class YoutubeDirective extends BaseDirective
         BlockContext $blockContext,
         Directive $directive,
     ): EmbeddedFrame {
+        return $this->createNode($directive);
+    }
+
+    public function createNode(Directive $directive): EmbeddedFrame
+    {
         $node = new EmbeddedFrame(
             'https://www.youtube-nocookie.com/embed/' . $directive->getData(),
         );

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/YoutubeDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/YoutubeDirective.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 use phpDocumentor\Guides\Nodes\EmbeddedFrame;
+use phpDocumentor\Guides\RestructuredText\Directives\Attributes\Option;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
@@ -36,6 +37,11 @@ use function array_filter;
  * - string allow The allow attribute of the iframe, default is 'encrypted-media; picture-in-picture; web-share'
  * - bool allowfullscreen Whether the video should be allowed to go fullscreen, default is true
  */
+#[Option('width', type: OptionType::Integer, default: 560, description: 'Width of the video')]
+#[Option('title', type: OptionType::String, description: 'Title of the video')]
+#[Option('height', type: OptionType::Integer, default: 315, description: 'Height of the video')]
+#[Option('allow', type: OptionType::String, default: 'encrypted-media; picture-in-picture; web-share', description: 'Allow attribute of the iframe')]
+#[Option('allowfullscreen', type: OptionType::Boolean, default: true, description: 'Whether the video should be allowed to go fullscreen')]
 final class YoutubeDirective extends BaseDirective
 {
     public function getName(): string
@@ -51,16 +57,6 @@ final class YoutubeDirective extends BaseDirective
             'https://www.youtube-nocookie.com/embed/' . $directive->getData(),
         );
 
-        return $node->withOptions(
-            array_filter(
-                [
-                    'width' => $directive->getOption('width')->getValue() ?? 560,
-                    'title' => $directive->getOption('title')->getValue(),
-                    'height' => $directive->getOption('height')->getValue() ?? 315,
-                    'allow' => $directive->getOption('allow')->getValue() ?? 'encrypted-media; picture-in-picture; web-share',
-                    'allowfullscreen' => (bool) ($directive->getOption('allowfullscreen')->getValue() ?? true),
-                ],
-            ),
-        );
+        return $node->withOptions($this->readAllOptions($directive));
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/YoutubeDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/YoutubeDirective.php
@@ -14,13 +14,10 @@ declare(strict_types=1);
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 use phpDocumentor\Guides\Nodes\EmbeddedFrame;
-use phpDocumentor\Guides\Nodes\Node;
-use phpDocumentor\Guides\RestructuredText\Directives\Attributes;
 use phpDocumentor\Guides\RestructuredText\Directives\Attributes\Option;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
-
-use function array_filter;
 
 /**
  * This directive is used to embed a youtube video in the document.
@@ -47,24 +44,19 @@ use function array_filter;
 #[Option('allowfullscreen', type: OptionType::Boolean, default: true, description: 'Whether the video should be allowed to go fullscreen')]
 final class YoutubeDirective extends BaseDirective
 {
-    public function getName(): string
-    {
-        return 'youtube';
-    }
-
     public function process(
         BlockContext $blockContext,
         Directive $directive,
     ): EmbeddedFrame {
-        return $this->createNode($directive);
+        return $this->createNode(new DirectiveNode($directive));
     }
 
-    public function createNode(Directive $directive): EmbeddedFrame
+    public function createNode(DirectiveNode $directiveNode): EmbeddedFrame
     {
         $node = new EmbeddedFrame(
-            'https://www.youtube-nocookie.com/embed/' . $directive->getData(),
+            'https://www.youtube-nocookie.com/embed/' . $directiveNode->getDirective()->getData(),
         );
 
-        return $node->withOptions($this->readAllOptions($directive));
+        return $node->withOptions($this->readAllOptions($directiveNode->getDirective()));
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Nodes/DirectiveNode.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Nodes/DirectiveNode.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\RestructuredText\Nodes;
+
+use phpDocumentor\Guides\Nodes\AbstractNode;
+use phpDocumentor\Guides\RestructuredText\Parser\Directive;
+
+/** @extends AbstractNode<Directive> */
+final class DirectiveNode extends AbstractNode
+{
+    public function __construct(private Directive $directive)
+    {
+
+    }
+
+    public function getDirective(): Directive
+    {
+        return $this->directive;
+    }
+}

--- a/packages/guides-restructured-text/src/RestructuredText/Nodes/DirectiveNode.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Nodes/DirectiveNode.php
@@ -20,9 +20,9 @@ use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 /** @extends CompoundNode<Node> */
 final class DirectiveNode extends CompoundNode
 {
-    public function __construct(private readonly Directive $directive)
+    public function __construct(private readonly Directive $directive, array $children = [])
     {
-        parent::__construct();
+        parent::__construct($children);
     }
 
     public function getDirective(): Directive

--- a/packages/guides-restructured-text/src/RestructuredText/Nodes/DirectiveNode.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Nodes/DirectiveNode.php
@@ -2,17 +2,27 @@
 
 declare(strict_types=1);
 
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
 namespace phpDocumentor\Guides\RestructuredText\Nodes;
 
-use phpDocumentor\Guides\Nodes\AbstractNode;
+use phpDocumentor\Guides\Nodes\CompoundNode;
+use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
-/** @extends AbstractNode<Directive> */
-final class DirectiveNode extends AbstractNode
+/** @extends CompoundNode<Node> */
+final class DirectiveNode extends CompoundNode
 {
-    public function __construct(private Directive $directive)
+    public function __construct(private readonly Directive $directive)
     {
-
+        parent::__construct();
     }
 
     public function getDirective(): Directive

--- a/packages/guides-restructured-text/src/RestructuredText/Nodes/DirectiveNode.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Nodes/DirectiveNode.php
@@ -20,6 +20,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 /** @extends CompoundNode<Node> */
 final class DirectiveNode extends CompoundNode
 {
+    /** @param Node[] $children */
     public function __construct(private readonly Directive $directive, array $children = [])
     {
         parent::__construct($children);

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Directive.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Directive.php
@@ -42,7 +42,7 @@ final class Directive
 
     public function getName(): string
     {
-        return $this->name;
+        return strtolower($this->name);
     }
 
     public function getData(): string
@@ -60,7 +60,7 @@ final class Directive
     {
         $this->options[$value->getName()] = $value;
     }
-    
+
     public function hasOption(string $name): bool
     {
         return isset($this->options[$name]);

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Directive.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Directive.php
@@ -15,6 +15,8 @@ namespace phpDocumentor\Guides\RestructuredText\Parser;
 
 use phpDocumentor\Guides\Nodes\InlineCompoundNode;
 
+use function strtolower;
+
 /**
  * Represents the data contained in an arbitrary directive
  *

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/InlineLexer.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/InlineLexer.php
@@ -170,4 +170,15 @@ final class InlineLexer extends AbstractLexer
 
         return self::WORD;
     }
+
+    /**
+     * Moves to the next token in the input string.
+     *
+     * @phpstan-impure
+     * @phpstan-assert-if-true !null $this->lookahead
+     */
+    public function moveNext(): bool
+    {
+        return parent::moveNext();
+    }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveContentRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveContentRule.php
@@ -18,7 +18,7 @@ use phpDocumentor\Guides\Nodes\CompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 
-/** @implements Rule<CollectionNode> */
+/** @implements Rule<Node> */
 final class DirectiveContentRule implements Rule
 {
     public function __construct(private readonly RuleContainer $bodyElements)
@@ -32,7 +32,7 @@ final class DirectiveContentRule implements Rule
 
     public function apply(BlockContext $blockContext, CompoundNode|null $on = null): Node
     {
-        $node = new CollectionNode([]);
+        $node = $on ?? new CollectionNode([]);
         $documentIterator = $blockContext->getDocumentIterator();
         // We explicitly do not use foreach, but rather the cursors of the DocumentIterator
         // this is done because we are transitioning to a method where a Substate can take the current
@@ -40,7 +40,7 @@ final class DirectiveContentRule implements Rule
         while ($documentIterator->valid()) {
             $this->bodyElements->apply($blockContext, $node);
         }
-        
+
         return $node;
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveContentRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveContentRule.php
@@ -18,7 +18,7 @@ use phpDocumentor\Guides\Nodes\CompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 
-/** @implements Rule<Node> */
+/** @implements Rule<CollectionNode> */
 final class DirectiveContentRule implements Rule
 {
     public function __construct(private readonly RuleContainer $bodyElements)

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
@@ -18,6 +18,7 @@ use phpDocumentor\Guides\Nodes\CompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Directives\BaseDirective as DirectiveHandler;
 use phpDocumentor\Guides\RestructuredText\Directives\GeneralDirective;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Buffer;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
@@ -84,10 +85,15 @@ final class DirectiveRule implements Rule
         }
 
         $this->parseDirectiveContent($directive, $blockContext);
+        $this->interpretDirectiveOptions($documentIterator, $directive);
 
         $directiveHandler = $this->getDirectiveHandler($directive);
+        if ($directiveHandler->isUpgraded()) {
+            //What do we do with the content of the directive?
+            // Child nodes need to be parsed. and the content needs to be collected as a string.
+            return new DirectiveNode($directive);
+        }
 
-        $this->interpretDirectiveOptions($documentIterator, $directive);
         $buffer = $this->collectDirectiveContents($documentIterator);
 
         // Processing the Directive, the handler is responsible for adding the right Nodes to the document.

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
@@ -49,12 +49,16 @@ final class DirectiveRule implements Rule
     /** @var array<string, DirectiveHandler> */
     private array $directives;
 
-    /** @param iterable<DirectiveHandler> $directives */
+    /**
+     * @param iterable<DirectiveHandler> $directives
+     * @param Rule<Node>|null $startingRule
+     */
     public function __construct(
         private readonly InlineMarkupRule $inlineMarkupRule,
         private readonly LoggerInterface $logger,
         private readonly GeneralDirective $generalDirective,
         iterable $directives = [],
+        private readonly Rule|null $startingRule = null,
     ) {
         foreach ($directives as $directive) {
             $this->registerDirective($directive);
@@ -88,13 +92,14 @@ final class DirectiveRule implements Rule
         $this->interpretDirectiveOptions($documentIterator, $directive);
 
         $directiveHandler = $this->getDirectiveHandler($directive);
-        if ($directiveHandler->isUpgraded()) {
-            //What do we do with the content of the directive?
-            // Child nodes need to be parsed. and the content needs to be collected as a string.
-            return new DirectiveNode($directive);
-        }
-
         $buffer = $this->collectDirectiveContents($documentIterator);
+
+        if ($this->startingRule !== null && $directiveHandler->isUpgraded()) {
+            return $this->startingRule->apply(
+                new BlockContext($blockContext->getDocumentParserContext(), $buffer->getLinesString(), true, $documentIterator->key()),
+                new DirectiveNode($directive),
+            );
+        }
 
         // Processing the Directive, the handler is responsible for adding the right Nodes to the document.
         try {

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
@@ -95,10 +95,22 @@ final class DirectiveRule implements Rule
         $buffer = $this->collectDirectiveContents($documentIterator);
 
         if ($this->startingRule !== null && $directiveHandler->isUpgraded()) {
-            return $this->startingRule->apply(
+            $node = $this->startingRule->apply(
                 new BlockContext($blockContext->getDocumentParserContext(), $buffer->getLinesString(), true, $documentIterator->key()),
                 new DirectiveNode($directive),
             );
+
+            if ($node === null) {
+                return null;
+            }
+
+            if ($directive->getVariable() === '') {
+                return $node;
+            }
+
+            $blockContext->getDocumentParserContext()->getDocument()->addVariable($directive->getVariable(), $node);
+
+            return null;
         }
 
         // Processing the Directive, the handler is responsible for adding the right Nodes to the document.

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/AnnotationRoleRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/AnnotationRoleRule.php
@@ -42,33 +42,30 @@ final class AnnotationRoleRule extends AbstractInlineRule
             switch ($token->type) {
                 case InlineLexer::ANNOTATION_END:
                     // `]`  found, look for `_`
-                    if (!$lexer->moveNext() && $lexer->token === null) {
+                    if ($lexer->isNextToken(InlineLexer::UNDERSCORE) === false) {
                         break 2;
                     }
 
-                    $token = $lexer->token;
-                    if ($token->type === InlineLexer::UNDERSCORE) {
-                        if (AnnotationUtility::isFootnoteKey($annotationName)) {
-                            $number = AnnotationUtility::getFootnoteNumber($annotationName);
-                            $name = AnnotationUtility::getFootnoteName($annotationName);
-                            $node = new FootnoteInlineNode(
-                                $annotationName,
-                                $name ?? '',
-                                $number ?? 0,
-                            );
-                        } else {
-                            $node = new CitationInlineNode(
-                                $annotationName,
-                                $annotationName,
-                            );
-                        }
-
-                        $lexer->moveNext();
-
-                        return $node;
+                    $lexer->moveNext();
+                    if (AnnotationUtility::isFootnoteKey($annotationName)) {
+                        $number = AnnotationUtility::getFootnoteNumber($annotationName);
+                        $name = AnnotationUtility::getFootnoteName($annotationName);
+                        $node = new FootnoteInlineNode(
+                            $annotationName,
+                            $name ?? '',
+                            $number ?? 0,
+                        );
+                    } else {
+                        $node = new CitationInlineNode(
+                            $annotationName,
+                            $annotationName,
+                        );
                     }
 
-                    break 2;
+                    $lexer->moveNext();
+
+                    return $node;
+
                 case InlineLexer::WHITESPACE:
                     // Annotation keys may not contain whitespace
                     break 2;

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/DefaultTextRoleRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/DefaultTextRoleRule.php
@@ -52,7 +52,7 @@ final class DefaultTextRoleRule extends AbstractInlineRule
                 case InlineLexer::BACKSLASH:
                     $lexer->moveNext();
 
-                    $text .= $lexer->token->value;
+                    $text .= $lexer->token?->value;
 
                     break;
                 default:

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/EmphasisRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/EmphasisRule.php
@@ -50,7 +50,7 @@ final class EmphasisRule extends AbstractInlineRule
 
                 case InlineLexer::BACKSLASH:
                     $lexer->moveNext();
-                    $text .= $lexer->token->value;
+                    $text .= $lexer->token?->value;
 
                     break;
                 default:

--- a/packages/guides-restructured-text/tests/unit/PHPStan/ReadOptionFixtureDirective.php
+++ b/packages/guides-restructured-text/tests/unit/PHPStan/ReadOptionFixtureDirective.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\RestructuredText\PHPStan;
+
+use phpDocumentor\Guides\RestructuredText\Directives\Attributes\Option;
+use phpDocumentor\Guides\RestructuredText\Directives\BaseDirective;
+use phpDocumentor\Guides\RestructuredText\Directives\OptionType;
+
+#[Option(name: 'name', type: OptionType::String, description: 'A string option without a default')]
+#[Option(name: 'title', type: OptionType::String, default: 'Default title', description: 'A string option with a default')]
+#[Option(name: 'count', type: OptionType::Integer, default: 4, description: 'An integer option with a default')]
+#[Option(name: 'enabled', type: OptionType::Boolean, default: false, description: 'A boolean option with a default')]
+#[Option(name: 'tags', type: OptionType::Array, description: 'An array option without a default')]
+#[Option(name: 'float', type: OptionType::String, default: 1.5, description: 'A string option with a float default')]
+final class ReadOptionFixtureDirective extends BaseDirective
+{
+    public function getName(): string
+    {
+        return 'fixture';
+    }
+}

--- a/packages/guides-restructured-text/tests/unit/PHPStan/ReadOptionReturnTypeExtensionTest.php
+++ b/packages/guides-restructured-text/tests/unit/PHPStan/ReadOptionReturnTypeExtensionTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\RestructuredText\PHPStan;
+
+use phpDocumentor\Guides\PHPStan\Rules\ReadOptionReturnTypeExtension;
+use phpDocumentor\Guides\RestructuredText\Directives\BaseDirective;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Testing\PHPStanTestCaseTrait;
+use PHPStan\Type\VerbosityLevel;
+use PHPUnit\Framework\TestCase;
+
+final class ReadOptionReturnTypeExtensionTest extends TestCase
+{
+    use PHPStanTestCaseTrait;
+
+    private ReadOptionReturnTypeExtension $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new ReadOptionReturnTypeExtension();
+    }
+
+    /** @return string[][] */
+    public static function optionTypeProvider(): array
+    {
+        return [
+            'string without default' => ['name', 'string|null'],
+            'string with default' => ['title', 'string'],
+            'integer with default' => ['count', 'int'],
+            'boolean with default' => ['enabled', 'bool'],
+            'array without default' => ['tags', 'array|null'],
+            'string with float default' => ['float', '1.5|string'],
+        ];
+    }
+
+    /** @dataProvider optionTypeProvider */
+    public function testResolvesDeclaredOptionTypes(string $optionName, string $expectedType): void
+    {
+        $type = $this->subject->resolveReturnType($this->fixtureReflection(), $optionName);
+
+        self::assertSame($expectedType, $type->describe(VerbosityLevel::precise()));
+    }
+
+    public function testUnknownOptionResolvesToMixed(): void
+    {
+        $type = $this->subject->resolveReturnType($this->fixtureReflection(), 'unknown');
+
+        self::assertSame('mixed', $type->describe(VerbosityLevel::precise()));
+    }
+
+    public function testClassWithoutOptionsResolvesToMixed(): void
+    {
+        $reflection = $this->reflectionProvider()->getClass(BaseDirective::class);
+
+        $type = $this->subject->resolveReturnType($reflection, 'name');
+
+        self::assertSame('mixed', $type->describe(VerbosityLevel::precise()));
+    }
+
+    public function testExtensionAppliesToBaseDirective(): void
+    {
+        self::assertSame(BaseDirective::class, $this->subject->getClass());
+    }
+
+    private function fixtureReflection(): ClassReflection
+    {
+        return $this->reflectionProvider()->getClass(ReadOptionFixtureDirective::class);
+    }
+
+    private function reflectionProvider(): ReflectionProvider
+    {
+        return self::getContainer()->getByType(ReflectionProvider::class);
+    }
+}

--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/DirectiveRuleTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/DirectiveRuleTest.php
@@ -37,7 +37,10 @@ final class DirectiveRuleTest extends RuleTestCase
         $this->rule = new DirectiveRule(
             $this->givenInlineMarkupRule(),
             new Logger('test'),
-            new GeneralDirective(new DirectiveContentRule(new RuleContainer()), self::createMock(SettingsManager::class)),
+            new GeneralDirective(
+                new DirectiveContentRule(new RuleContainer()),
+                self::createStub(SettingsManager::class),
+            ),
             [$this->directiveHandler],
         );
     }

--- a/packages/guides/src/Compiler/DocumentNodeTraverser.php
+++ b/packages/guides/src/Compiler/DocumentNodeTraverser.php
@@ -50,6 +50,12 @@ final class DocumentNodeTraverser
         TreeNode $shadowNode,
         CompilerContext $compilerContext,
     ): void {
+        if ($transformer instanceof ReverseNodeTransformer) {
+            foreach ($shadowNode->getChildren() as $shadowChild) {
+                $this->traverseForTransformer($transformer, $shadowChild, $compilerContext->withShadowTree($shadowChild));
+            }
+        }
+
         $node = $shadowNode->getNode();
         $supports = $transformer->supports($node);
 
@@ -60,8 +66,10 @@ final class DocumentNodeTraverser
             }
         }
 
-        foreach ($shadowNode->getChildren() as $shadowChild) {
-            $this->traverseForTransformer($transformer, $shadowChild, $compilerContext->withShadowTree($shadowChild));
+        if ($transformer instanceof ReverseNodeTransformer === false) {
+            foreach ($shadowNode->getChildren() as $shadowChild) {
+                $this->traverseForTransformer($transformer, $shadowChild, $compilerContext->withShadowTree($shadowChild));
+            }
         }
 
         if (!$supports) {

--- a/packages/guides/src/Compiler/NodeTransformers/VariableInlineNodeTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/VariableInlineNodeTransformer.php
@@ -48,14 +48,14 @@ final class VariableInlineNodeTransformer implements NodeTransformer
         $nodeReplacement ??= $compilerContext->getProjectNode()->getVariable($node->getValue(), null);
 
         if ($nodeReplacement instanceof Node) {
-            $node->setChild($nodeReplacement);
-        } else {
-            $this->logger->warning(
-                'No replacement was found for variable |' . $node->getValue() . '|',
-                $compilerContext->getLoggerInformation(),
-            );
-            $node->setChild(new PlainTextInlineNode('|' . $node->getValue() . '|'));
+            return $nodeReplacement;
         }
+
+        $this->logger->warning(
+            'No replacement was found for variable |' . $node->getValue() . '|',
+            $compilerContext->getLoggerInformation(),
+        );
+        $node->setChild(new PlainTextInlineNode('|' . $node->getValue() . '|'));
 
         return $node;
     }

--- a/packages/guides/src/Compiler/ReverseNodeTransformer.php
+++ b/packages/guides/src/Compiler/ReverseNodeTransformer.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Guides\Compiler;
+
+/**
+ * Reverse NodeTransformers are applied with child nodes first, then the parent node.
+ *
+ * This is useful for NodeTransformers that need to know the state of the child nodes before transforming the parent node.
+ */
+interface ReverseNodeTransformer extends NodeTransformer
+{
+
+}

--- a/packages/guides/src/Compiler/ReverseNodeTransformer.php
+++ b/packages/guides/src/Compiler/ReverseNodeTransformer.php
@@ -13,10 +13,15 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\Compiler;
 
+use phpDocumentor\Guides\Nodes\Node;
+
 /**
  * Reverse NodeTransformers are applied with child nodes first, then the parent node.
  *
  * This is useful for NodeTransformers that need to know the state of the child nodes before transforming the parent node.
+ *
+ * @template TNode of Node
+ * @extends NodeTransformer<Node>
  */
 interface ReverseNodeTransformer extends NodeTransformer
 {

--- a/packages/guides/src/Compiler/ReverseNodeTransformer.php
+++ b/packages/guides/src/Compiler/ReverseNodeTransformer.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
 namespace phpDocumentor\Guides\Compiler;
 
 /**
@@ -11,5 +20,4 @@ namespace phpDocumentor\Guides\Compiler;
  */
 interface ReverseNodeTransformer extends NodeTransformer
 {
-
 }

--- a/packages/guides/src/Nodes/AbstractNode.php
+++ b/packages/guides/src/Nodes/AbstractNode.php
@@ -77,7 +77,7 @@ abstract class AbstractNode implements Node
             // strip trailing hyphens
             $value = (string) preg_replace('/-$/', '', $value);
         });
-        $this->classes = array_unique($classes);
+        $this->classes = array_filter(array_unique($classes), static function (string $value): bool { return $value !== ''; });
     }
 
     public function getClassesString(): string

--- a/packages/guides/src/Nodes/AbstractNode.php
+++ b/packages/guides/src/Nodes/AbstractNode.php
@@ -26,13 +26,13 @@ abstract class AbstractNode implements Node
     /** @var string[] */
     protected array $classes = [];
 
-    /** @var array<string, scalar|null> */
+    /** @var array<string, scalar|scalar[]|null> */
     protected array $options = [];
 
     /** @var TValue */
     protected $value;
 
-    /** @return array<string, scalar|null> */
+    /** @return array<string, scalar|scalar[]|null> */
     public function getOptions(): array
     {
         return $this->options;
@@ -89,7 +89,7 @@ abstract class AbstractNode implements Node
     }
 
     /**
-     * @param array<string, scalar|null> $options
+     * @param array<string, scalar|scalar[]|null> $options
      *
      * @return static
      */

--- a/packages/guides/src/Nodes/AbstractNode.php
+++ b/packages/guides/src/Nodes/AbstractNode.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\Nodes;
 
+use function array_filter;
 use function array_unique;
 use function array_walk;
 use function implode;
@@ -77,7 +78,9 @@ abstract class AbstractNode implements Node
             // strip trailing hyphens
             $value = (string) preg_replace('/-$/', '', $value);
         });
-        $this->classes = array_filter(array_unique($classes), static function (string $value): bool { return $value !== ''; });
+        $this->classes = array_filter(array_unique($classes), static function (string $value): bool {
+            return $value !== '';
+        });
     }
 
     public function getClassesString(): string

--- a/packages/guides/src/Nodes/Node.php
+++ b/packages/guides/src/Nodes/Node.php
@@ -15,10 +15,10 @@ namespace phpDocumentor\Guides\Nodes;
 
 interface Node
 {
-    /** @return array<string, scalar|null> */
+    /** @return array<string, scalar|scalar[]|null> */
     public function getOptions(): array;
 
-    /** @param array<string, scalar|null> $options */
+    /** @param array<string, scalar|scalar[]|null> $options */
     public function withOptions(array $options): Node;
 
     /** @param array<string, scalar|null> $options */

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -76,16 +76,6 @@ parameters:
 			path: packages/guides-markdown/src/Markdown/Parsers/InlineParsers/AbstractInlineTextDecoratorParser.php
 
 		-
-			message: "#^Strict comparison using \\!\\=\\= between Doctrine\\\\Common\\\\Lexer\\\\Token and null will always evaluate to true\\.$#"
-			count: 1
-			path: packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/InternalReferenceRule.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/InternalReferenceRule.php
-
-		-
 			message: "#^Property phpDocumentor\\\\Guides\\\\RestructuredText\\\\Parser\\\\Productions\\\\ListRule\\:\\:\\$logger is never read, only written\\.$#"
 			count: 1
 			path: packages/guides-restructured-text/src/RestructuredText/Parser/Productions/ListRule.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Using PHPStan\\\\Testing\\\\PHPStanTestCaseTrait is not covered by backward compatibility promise\\. The trait might change in a minor PHPStan version\\.$#"
+			count: 1
+			path: packages/guides-restructured-text/tests/unit/PHPStan/ReadOptionReturnTypeExtensionTest.php
+
+		-
 			message: "#^Parameter \\#2 \\$headers of class GuzzleHttp\\\\Psr7\\\\Response constructor expects array\\<array\\<string\\>\\|string\\>, array\\<string, int\\<1, max\\>\\|string\\> given\\.$#"
 			count: 1
 			path: packages/dev-server/src/Internal/HttpHandler.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,144 +1,59 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Using PHPStan\\\\Testing\\\\PHPStanTestCaseTrait is not covered by backward compatibility promise\\. The trait might change in a minor PHPStan version\\.$#"
-			count: 1
-			path: packages/guides-restructured-text/tests/unit/PHPStan/ReadOptionReturnTypeExtensionTest.php
-
-		-
-			message: "#^Parameter \\#2 \\$headers of class GuzzleHttp\\\\Psr7\\\\Response constructor expects array\\<array\\<string\\>\\|string\\>, array\\<string, int\\<1, max\\>\\|string\\> given\\.$#"
+			message: '#^Parameter \#2 \$headers of class GuzzleHttp\\Psr7\\Response constructor expects array\<array\<string\>\|string\>, array\<string, int\<1, max\>\|string\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: packages/dev-server/src/Internal/HttpHandler.php
 
 		-
-			message: "#^Method phpDocumentor\\\\DevServer\\\\Internal\\\\WebSocketHandler\\:\\:onMessage\\(\\) has parameter \\$msg with no value type specified in iterable type Ratchet\\\\RFC6455\\\\Messaging\\\\MessageInterface\\.$#"
+			message: '#^Method phpDocumentor\\DevServer\\Internal\\WebSocketHandler\:\:onMessage\(\) has parameter \$msg with no value type specified in iterable type Ratchet\\RFC6455\\Messaging\\MessageInterface\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: packages/dev-server/src/Internal/WebSocketHandler.php
 
 		-
-			message: "#^Call to an undefined method Symfony\\\\Contracts\\\\EventDispatcher\\\\EventDispatcherInterface\\:\\:addListener\\(\\)\\.$#"
+			message: '#^Call to an undefined method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface\:\:addListener\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: packages/dev-server/src/Server.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between resource and false will always evaluate to false\\.$#"
+			message: '#^Strict comparison using \=\=\= between resource and false will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
 			count: 1
 			path: packages/dev-server/src/Watcher/INotifyWatcher.php
 
 		-
-			message: "#^Call to function method_exists\\(\\) with phpDocumentor\\\\Guides\\\\Settings\\\\ProjectSettings and 'setExcludes' will always evaluate to true\\.$#"
+			message: '#^Call to function method_exists\(\) with phpDocumentor\\Guides\\Settings\\ProjectSettings and ''setExcludes'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: packages/guides-cli/src/Command/SettingsBuilder.php
 
 		-
-			message: "#^Cannot cast mixed to string\\.$#"
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
 			count: 6
 			path: packages/guides-cli/src/Command/SettingsBuilder.php
 
 		-
-			message: "#^Parameter \\#1 \\$outputFormats of method phpDocumentor\\\\Guides\\\\Settings\\\\ProjectSettings\\:\\:setOutputFormats\\(\\) expects array\\<string\\>, mixed given\\.$#"
+			message: '#^Parameter \#1 \$outputFormats of method phpDocumentor\\Guides\\Settings\\ProjectSettings\:\:setOutputFormats\(\) expects array\<string\>, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: packages/guides-cli/src/Command/SettingsBuilder.php
 
 		-
-			message: "#^Parameter \\#1 \\$showProgressBar of method phpDocumentor\\\\Guides\\\\Settings\\\\ProjectSettings\\:\\:setShowProgressBar\\(\\) expects bool, mixed given\\.$#"
+			message: '#^Parameter \#1 \$showProgressBar of method phpDocumentor\\Guides\\Settings\\ProjectSettings\:\:setShowProgressBar\(\) expects bool, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: packages/guides-cli/src/Command/SettingsBuilder.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
+			message: '#^Parameter \#1 \$value of function count expects array\|Countable, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: packages/guides-cli/src/Command/SettingsBuilder.php
 
-		-
-			message: "#^Parameter \\#1 \\$string of function rtrim expects string, string\\|false given\\.$#"
-			count: 1
-			path: packages/guides-cli/src/DependencyInjection/ContainerFactory.php
-
-		-
-			message: "#^Call to function method_exists\\(\\) with phpDocumentor\\\\Guides\\\\Settings\\\\ProjectSettings and 'getExcludes' will always evaluate to true\\.$#"
-			count: 1
-			path: packages/guides-cli/src/Internal/RunCommandHandler.php
-
-		-
-			message: "#^Method phpDocumentor\\\\Guides\\\\Cli\\\\Internal\\\\RunCommandHandler\\:\\:handle\\(\\) should return array\\<phpDocumentor\\\\Guides\\\\Nodes\\\\DocumentNode\\> but returns mixed\\.$#"
-			count: 1
-			path: packages/guides-cli/src/Internal/RunCommandHandler.php
-
-		-
-			message: "#^Parameter \\#1 \\$documents of class phpDocumentor\\\\Guides\\\\Handlers\\\\CompileDocumentsCommand constructor expects array\\<phpDocumentor\\\\Guides\\\\Nodes\\\\DocumentNode\\>, mixed given\\.$#"
-			count: 1
-			path: packages/guides-cli/src/Internal/RunCommandHandler.php
-
-		-
-			message: "#^Parameter \\#2 \\$documentArray of class phpDocumentor\\\\Guides\\\\Handlers\\\\RenderCommand constructor expects array\\<phpDocumentor\\\\Guides\\\\Nodes\\\\DocumentNode\\>, mixed given\\.$#"
-			count: 1
-			path: packages/guides-cli/src/Internal/RunCommandHandler.php
-
-		-
-			message: "#^Method phpDocumentor\\\\Guides\\\\Markdown\\\\Parsers\\\\InlineParsers\\\\AbstractInlineTextDecoratorParser\\<TValue of phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\InlineNodeInterface\\>\\:\\:createInlineNode\\(\\) invoked with 3 parameters, 2 required\\.$#"
-			count: 2
-			path: packages/guides-markdown/src/Markdown/Parsers/InlineParsers/AbstractInlineTextDecoratorParser.php
-
-		-
-			message: "#^Property phpDocumentor\\\\Guides\\\\RestructuredText\\\\Parser\\\\Productions\\\\ListRule\\:\\:\\$logger is never read, only written\\.$#"
-			count: 1
-			path: packages/guides-restructured-text/src/RestructuredText/Parser/Productions/ListRule.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between 'phpDocumentor\\\\\\\\Guides\\\\\\\\Compiler\\\\\\\\CompilerContext' and 'phpDocumentor\\\\\\\\Guides\\\\\\\\Compiler\\\\\\\\CompilerContext' will always evaluate to true\\.$#"
-			count: 1
-			path: packages/guides/src/Compiler/CompilerContext.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: packages/guides/src/Compiler/CompilerContext.php
-
-		-
-			message: "#^Function Symfony\\\\Component\\\\DependencyInjection\\\\Loader\\\\Configurator\\\\tagged_iterator not found\\.$#"
-			count: 2
-			path: packages/guides/src/DependencyInjection/Compiler/RendererPass.php
-
-		-
-			message: "#^Used function Symfony\\\\Component\\\\DependencyInjection\\\\Loader\\\\Configurator\\\\tagged_iterator not found\\.$#"
-			count: 1
-			path: packages/guides/src/DependencyInjection/Compiler/RendererPass.php
-
-		-
-			message: "#^Parameter \\#1 \\$value \\(array\\<phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\InlineNodeInterface\\>\\|string\\) of method phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\AbstractLinkInlineNode\\:\\:setValue\\(\\) should be contravariant with parameter \\$value \\(mixed\\) of method phpDocumentor\\\\Guides\\\\Nodes\\\\Node\\:\\:setValue\\(\\)$#"
-			count: 3
-			path: packages/guides/src/Nodes/Inline/AbstractLinkInlineNode.php
-
-		-
-			message: "#^Return type \\(string\\) of method phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\AbstractLinkInlineNode\\:\\:getValue\\(\\) should be compatible with return type \\(array\\<phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\InlineNodeInterface\\>\\) of method phpDocumentor\\\\Guides\\\\Nodes\\\\AbstractNode\\<array\\<phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\InlineNodeInterface\\>\\>\\:\\:getValue\\(\\)$#"
-			count: 1
-			path: packages/guides/src/Nodes/Inline/AbstractLinkInlineNode.php
-
-		-
-			message: "#^Parameter \\#1 \\$value \\(array\\<phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\InlineNodeInterface\\>\\|string\\) of method phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\EmphasisInlineNode\\:\\:setValue\\(\\) should be contravariant with parameter \\$value \\(mixed\\) of method phpDocumentor\\\\Guides\\\\Nodes\\\\Node\\:\\:setValue\\(\\)$#"
-			count: 2
-			path: packages/guides/src/Nodes/Inline/EmphasisInlineNode.php
-
-		-
-			message: "#^Return type \\(string\\) of method phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\EmphasisInlineNode\\:\\:getValue\\(\\) should be compatible with return type \\(array\\<phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\InlineNodeInterface\\>\\) of method phpDocumentor\\\\Guides\\\\Nodes\\\\AbstractNode\\<array\\<phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\InlineNodeInterface\\>\\>\\:\\:getValue\\(\\)$#"
-			count: 1
-			path: packages/guides/src/Nodes/Inline/EmphasisInlineNode.php
-
-		-
-			message: "#^Parameter \\#1 \\$value \\(array\\<phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\InlineNodeInterface\\>\\|string\\) of method phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\StrongInlineNode\\:\\:setValue\\(\\) should be contravariant with parameter \\$value \\(mixed\\) of method phpDocumentor\\\\Guides\\\\Nodes\\\\Node\\:\\:setValue\\(\\)$#"
-			count: 2
-			path: packages/guides/src/Nodes/Inline/StrongInlineNode.php
-
-		-
-			message: "#^Return type \\(string\\) of method phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\StrongInlineNode\\:\\:getValue\\(\\) should be compatible with return type \\(array\\<phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\InlineNodeInterface\\>\\) of method phpDocumentor\\\\Guides\\\\Nodes\\\\AbstractNode\\<array\\<phpDocumentor\\\\Guides\\\\Nodes\\\\Inline\\\\InlineNodeInterface\\>\\>\\:\\:getValue\\(\\)$#"
-			count: 1
-			path: packages/guides/src/Nodes/Inline/StrongInlineNode.php
-
-		-
-			message: "#^Anonymous class extends @final class phpDocumentor\\\\Guides\\\\Compiler\\\\CompilerContext\\.$#"
-			count: 1
-			path: packages/guides/tests/unit/Compiler/CompilerContextTest.php
 		-
 			message: '#^Method phpDocumentor\\Guides\\Cli\\Config\\XmlFileLoader\:\:load\(\) should return array\<array\<mixed\>\> but returns array\<mixed\>\.$#'
 			identifier: return.type
@@ -188,6 +103,12 @@ parameters:
 			path: packages/guides-cli/src/DependencyInjection/ContainerFactory.php
 
 		-
+			message: '#^Parameter \#1 \$string of function rtrim expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: packages/guides-cli/src/DependencyInjection/ContainerFactory.php
+
+		-
 			message: '#^Parameter \#2 \$config of method phpDocumentor\\Guides\\Cli\\DependencyInjection\\ContainerFactory\:\:loadExtensionConfig\(\) expects array\<mixed\>, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -206,6 +127,30 @@ parameters:
 			path: packages/guides-cli/src/DependencyInjection/ContainerFactory.php
 
 		-
+			message: '#^Call to function method_exists\(\) with phpDocumentor\\Guides\\Settings\\ProjectSettings and ''getExcludes'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: packages/guides-cli/src/Internal/RunCommandHandler.php
+
+		-
+			message: '#^Method phpDocumentor\\Guides\\Cli\\Internal\\RunCommandHandler\:\:handle\(\) should return array\<phpDocumentor\\Guides\\Nodes\\DocumentNode\> but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: packages/guides-cli/src/Internal/RunCommandHandler.php
+
+		-
+			message: '#^Parameter \#1 \$documents of class phpDocumentor\\Guides\\Handlers\\CompileDocumentsCommand constructor expects array\<phpDocumentor\\Guides\\Nodes\\DocumentNode\>, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: packages/guides-cli/src/Internal/RunCommandHandler.php
+
+		-
+			message: '#^Parameter \#2 \$documentArray of class phpDocumentor\\Guides\\Handlers\\RenderCommand constructor expects array\<phpDocumentor\\Guides\\Nodes\\DocumentNode\>, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: packages/guides-cli/src/Internal/RunCommandHandler.php
+
+		-
 			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
 			count: 1
@@ -216,6 +161,12 @@ parameters:
 			identifier: argument.type
 			count: 3
 			path: packages/guides-graphs/src/Graphs/DependencyInjection/GraphsExtension.php
+
+		-
+			message: '#^Method phpDocumentor\\Guides\\Markdown\\Parsers\\InlineParsers\\AbstractInlineTextDecoratorParser\<TValue of phpDocumentor\\Guides\\Nodes\\Inline\\InlineNodeInterface\>\:\:createInlineNode\(\) invoked with 3 parameters, 2 required\.$#'
+			identifier: arguments.count
+			count: 2
+			path: packages/guides-markdown/src/Markdown/Parsers/InlineParsers/AbstractInlineTextDecoratorParser.php
 
 		-
 			message: '#^Cannot access offset ''domain'' on mixed\.$#'
@@ -252,6 +203,36 @@ parameters:
 			identifier: offsetAccess.invalidOffset
 			count: 1
 			path: packages/guides-restructured-text/src/RestructuredText/DependencyInjection/ReStructuredTextExtension.php
+
+		-
+			message: '#^Method phpDocumentor\\Guides\\RestructuredText\\Parser\\Productions\\DirectiveContentRule\:\:apply\(\) should return phpDocumentor\\Guides\\Nodes\\CollectionNode but returns phpDocumentor\\Guides\\Nodes\\CollectionNode\|TParent of phpDocumentor\\Guides\\Nodes\\CompoundNode\.$#'
+			identifier: return.type
+			count: 1
+			path: packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveContentRule.php
+
+		-
+			message: '#^Property phpDocumentor\\Guides\\RestructuredText\\Parser\\Productions\\ListRule\:\:\$logger is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: packages/guides-restructured-text/src/RestructuredText/Parser/Productions/ListRule.php
+
+		-
+			message: '#^Using PHPStan\\Testing\\PHPStanTestCaseTrait is not covered by backward compatibility promise\. The trait might change in a minor PHPStan version\.$#'
+			identifier: phpstanApi.trait
+			count: 1
+			path: packages/guides-restructured-text/tests/unit/PHPStan/ReadOptionReturnTypeExtensionTest.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between ''phpDocumentor\\\\Guides\\\\Compiler\\\\CompilerContext'' and ''phpDocumentor\\\\Guides\\\\Compiler\\\\CompilerContext'' will always evaluate to true\.$#'
+			identifier: identical.alwaysTrue
+			count: 1
+			path: packages/guides/src/Compiler/CompilerContext.php
+
+		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: packages/guides/src/Compiler/CompilerContext.php
 
 		-
 			message: '#^Binary operation "\." between ''phpdoc\.guides…'' and mixed results in an error\.$#'
@@ -302,6 +283,12 @@ parameters:
 			path: packages/guides/src/DependencyInjection/Compiler/RendererPass.php
 
 		-
+			message: '#^Function Symfony\\Component\\DependencyInjection\\Loader\\Configurator\\tagged_iterator not found\.$#'
+			identifier: function.notFound
+			count: 2
+			path: packages/guides/src/DependencyInjection/Compiler/RendererPass.php
+
+		-
 			message: '#^Parameter \#1 \$tag of method phpDocumentor\\Guides\\DependencyInjection\\Compiler\\RendererPass\:\:createDelegatingNodeRender\(\) expects array\{format\: string\}, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -323,6 +310,12 @@ parameters:
 			message: '#^Parameter \#2 \.\.\.\$values of function sprintf expects bool\|float\|int\|string\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 6
+			path: packages/guides/src/DependencyInjection/Compiler/RendererPass.php
+
+		-
+			message: '#^Used function Symfony\\Component\\DependencyInjection\\Loader\\Configurator\\tagged_iterator not found\.$#'
+			identifier: function.notFound
+			count: 1
 			path: packages/guides/src/DependencyInjection/Compiler/RendererPass.php
 
 		-
@@ -540,3 +533,45 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: packages/guides/src/DependencyInjection/GuidesExtension.php
+
+		-
+			message: '#^Parameter \#1 \$value \(array\<phpDocumentor\\Guides\\Nodes\\Inline\\InlineNodeInterface\>\|string\) of method phpDocumentor\\Guides\\Nodes\\Inline\\AbstractLinkInlineNode\:\:setValue\(\) should be contravariant with parameter \$value \(mixed\) of method phpDocumentor\\Guides\\Nodes\\Node\:\:setValue\(\)$#'
+			identifier: method.childParameterType
+			count: 3
+			path: packages/guides/src/Nodes/Inline/AbstractLinkInlineNode.php
+
+		-
+			message: '#^Return type \(string\) of method phpDocumentor\\Guides\\Nodes\\Inline\\AbstractLinkInlineNode\:\:getValue\(\) should be compatible with return type \(array\<phpDocumentor\\Guides\\Nodes\\Inline\\InlineNodeInterface\>\) of method phpDocumentor\\Guides\\Nodes\\AbstractNode\<array\<phpDocumentor\\Guides\\Nodes\\Inline\\InlineNodeInterface\>\>\:\:getValue\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: packages/guides/src/Nodes/Inline/AbstractLinkInlineNode.php
+
+		-
+			message: '#^Parameter \#1 \$value \(array\<phpDocumentor\\Guides\\Nodes\\Inline\\InlineNodeInterface\>\|string\) of method phpDocumentor\\Guides\\Nodes\\Inline\\EmphasisInlineNode\:\:setValue\(\) should be contravariant with parameter \$value \(mixed\) of method phpDocumentor\\Guides\\Nodes\\Node\:\:setValue\(\)$#'
+			identifier: method.childParameterType
+			count: 2
+			path: packages/guides/src/Nodes/Inline/EmphasisInlineNode.php
+
+		-
+			message: '#^Return type \(string\) of method phpDocumentor\\Guides\\Nodes\\Inline\\EmphasisInlineNode\:\:getValue\(\) should be compatible with return type \(array\<phpDocumentor\\Guides\\Nodes\\Inline\\InlineNodeInterface\>\) of method phpDocumentor\\Guides\\Nodes\\AbstractNode\<array\<phpDocumentor\\Guides\\Nodes\\Inline\\InlineNodeInterface\>\>\:\:getValue\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: packages/guides/src/Nodes/Inline/EmphasisInlineNode.php
+
+		-
+			message: '#^Parameter \#1 \$value \(array\<phpDocumentor\\Guides\\Nodes\\Inline\\InlineNodeInterface\>\|string\) of method phpDocumentor\\Guides\\Nodes\\Inline\\StrongInlineNode\:\:setValue\(\) should be contravariant with parameter \$value \(mixed\) of method phpDocumentor\\Guides\\Nodes\\Node\:\:setValue\(\)$#'
+			identifier: method.childParameterType
+			count: 2
+			path: packages/guides/src/Nodes/Inline/StrongInlineNode.php
+
+		-
+			message: '#^Return type \(string\) of method phpDocumentor\\Guides\\Nodes\\Inline\\StrongInlineNode\:\:getValue\(\) should be compatible with return type \(array\<phpDocumentor\\Guides\\Nodes\\Inline\\InlineNodeInterface\>\) of method phpDocumentor\\Guides\\Nodes\\AbstractNode\<array\<phpDocumentor\\Guides\\Nodes\\Inline\\InlineNodeInterface\>\>\:\:getValue\(\)$#'
+			identifier: method.childReturnType
+			count: 1
+			path: packages/guides/src/Nodes/Inline/StrongInlineNode.php
+
+		-
+			message: '#^Anonymous class extends @final class phpDocumentor\\Guides\\Compiler\\CompilerContext\.$#'
+			identifier: class.extendsFinalByPhpDoc
+			count: 1
+			path: packages/guides/tests/unit/Compiler/CompilerContextTest.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,17 +15,6 @@ parameters:
 
     - message: '#Return type .* of method phpDocumentor\\Guides\\RestructuredText\\Parser\\Productions\\InlineMarkupRule::apply\(\) should be covariant with return type .*#'
 
-    # https://github.com/doctrine/lexer/pull/109
-    -
-      message: '#^Result of && is always false.|Strict comparison using \=\=\= between Doctrine\\Common\\Lexer\\Token and null will always evaluate to false\.$#'
-      paths:
-        - packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/AnnotationRoleRule.php
-        - packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/DefaultTextRoleRule.php
-        - packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/EmphasisRule.php
-        - packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/StrongRule.php
-        - packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/TextRoleRule.php
-        - packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/VariableInlineRule.php
-
   paths:
     - packages/dev-server/src
     - packages/filesystem/src

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 includes:
 	- phpstan-baseline.neon
+	- packages/guides-restructured-text/rules.neon
 parameters:
   level: max
 

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -113,7 +113,7 @@ final class FunctionalTest extends ApplicationTestCase
             $compiler = $this->getContainer()->get(Compiler::class);
             assert($compiler instanceof Compiler);
             $projectNode = new ProjectNode();
-            $compiler->run([$document], new CompilerContext($projectNode));
+            [$document] = $compiler->run([$document], new CompilerContext($projectNode));
 
             $inputFilesystem = FlySystemAdapter::createFromFileSystem(new Filesystem(new InMemoryFilesystemAdapter()));
             $inputFilesystem->put('img/test-image.jpg', 'Some image');


### PR DESCRIPTION
## Directive attributes & compile-time directive processing

Introduces a new attribute-based declaration system for reStructuredText directives and moves directive processing from the parse phase into the compile phase.

Moving directive processing to a compiler pass is the groundwork that enables upcoming features such as option validation — with directives now declaratively describing their options via attributes, the framework can inspect and validate them centrally instead of each directive doing ad-hoc parsing.

### Features

**`#[Directive]` and `#[Option]` attributes**
- New `phpDocumentor\Guides\RestructuredText\Directives\Attributes\Directive` attribute declares a directive's name and aliases on the class, replacing the abstract `getName()` / `getAliases()` methods.
- New repeatable `#[Option]` attribute (`OptionType`, default value, description, example) declares the options a directive supports — used for automatic option validation, type coercion, and documentation.

**Compile-time directive processing**
- New `DirectiveNode` represents a parsed directive during compilation and is now processed by a dedicated `DirectiveProcessPass` compiler pass instead of being resolved eagerly by the parser.
- New `ReverseNodeTransformer` interface, with support in `DocumentNodeTraverser`, so parent transforms run after their children.
- Directives expose a `createNode(DirectiveNode)` entry point; a backward-compat `process()` path (with `isUpgraded()`) keeps existing directives working while they are migrated.

**Upgraded directives**
- Migrated to the attribute model: admonitions (attention, caution, danger, error, hint, important, note, tip, warning), version-change directives (versionadded, versionchanged, deprecated), figure, image, include, confval, youtube, and others.
- `readOption()` / `readAllOptions()` on `BaseDirective` now coerce values to the declared `OptionType` and apply attribute defaults (e.g. youtube width/height/allow/allowfullscreen).
- Admonitions now correctly apply the option-provided CSS `class` to the rendered node.

### Deprecations
- Directives without a `#[Directive]` attribute now trigger a deprecation when their name is resolved, pointing to documentation on migrating custom directives.

### Notes
- Includes a base-line merge of `update-security-issues` and a dependency bump.
- This is a first iteration; remaining built-in directives will be migrated to the attribute/compile-time model in follow-ups.