### PR TITLE
[TASK] Update hot reloading javascript to remember scroll position

### DIFF
--- a/packages/dev-server/src/Internal/HttpHandler.php
+++ b/packages/dev-server/src/Internal/HttpHandler.php
@@ -135,7 +135,8 @@ final class HttpHandler implements HttpServerInterface
         sessionStorage.removeItem('scrollPosition');
         sessionStorage.removeItem('scrollURL');
     });
-</script>EOT;
+</script>
+EOT;
 
         return str_replace('</body>', $injection . '</body>', $html);
     }


### PR DESCRIPTION
The hot reloading currently only reloads the full page.

However, it would be desirable when doing "live documentation" to reload the page and keeping the current scroll position in sync.

The JavaScript is now adapted to locally store the current position, and restore it after page reload. The temporary sessionStorage is utilized for this, which is tab-specific.

A small timeout ensures that if a page with locationHash is reloaded can properly jump to the stored position.

Debug output is added while this feature is experimental.

Also, the 'ws' URI is auto-detected so it can work on HTTPS and HTTP connections - this is queried via JavaScript and thus can work on reverse proxy setups.