### PR TITLE
[BUGFIX] Ensure temp directory exists before calling tempnam() + DI support

### DIFF
--- a/packages/guides-graphs/src/Graphs/Renderer/PlantumlRenderer.php
+++ b/packages/guides-graphs/src/Graphs/Renderer/PlantumlRenderer.php
@@ -28,10 +28,14 @@ use function tempnam;
 
 final class PlantumlRenderer implements DiagramRenderer
 {
-    public const TEMP_SUBDIRECTORY = '/phpdocumentor';
+    private readonly string $tempDirectory;
 
-    public function __construct(private readonly LoggerInterface $logger, private readonly string $plantUmlBinaryPath)
-    {
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly string $plantUmlBinaryPath,
+        string|null $tempDirectory = null,
+    ) {
+        $this->tempDirectory = $tempDirectory ?? sys_get_temp_dir() . '/phpdocumentor';
     }
 
     public function render(RenderContext $renderContext, string $diagram): string|null
@@ -49,12 +53,11 @@ $diagram
 @enduml
 PUML;
 
-        $tempDir = sys_get_temp_dir() . self::TEMP_SUBDIRECTORY;
-        if (!is_dir($tempDir)) {
-            mkdir($tempDir, 0o755, true);
+        if (!is_dir($this->tempDirectory)) {
+            mkdir($this->tempDirectory, 0o755, true);
         }
 
-        $pumlFileLocation = tempnam($tempDir, 'pu_');
+        $pumlFileLocation = tempnam($this->tempDirectory, 'pu_');
         file_put_contents($pumlFileLocation, $output);
         try {
             $process = new Process([$this->plantUmlBinaryPath, '-tsvg', $pumlFileLocation], __DIR__, null, null, 600.0);

--- a/packages/guides-graphs/tests/unit/Renderer/PlantumlRendererTest.php
+++ b/packages/guides-graphs/tests/unit/Renderer/PlantumlRendererTest.php
@@ -17,29 +17,21 @@ use phpDocumentor\Guides\RenderContext;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 
-use function is_dir;
 use function rmdir;
 use function sys_get_temp_dir;
+use function uniqid;
 
 final class PlantumlRendererTest extends TestCase
 {
-    /** @runInSeparateProcess */
     public function testRenderCreatesTempDirectoryWhenMissing(): void
     {
-        $tempDir = sys_get_temp_dir() . PlantumlRenderer::TEMP_SUBDIRECTORY;
+        $tempDir = sys_get_temp_dir() . '/plantuml-test-' . uniqid();
 
-        // Remove the directory if it exists to test creation
-        if (is_dir($tempDir)) {
-            @rmdir($tempDir);
-        }
-
-        // Skip if we can't remove it (contains files from other processes)
-        if (is_dir($tempDir)) {
-            self::markTestSkipped('Cannot remove temp directory - it contains files from other processes');
-        }
+        // Ensure the directory does not exist
+        self::assertDirectoryDoesNotExist($tempDir);
 
         // Use a non-existent binary path - the render will fail but directory should be created first
-        $renderer = new PlantumlRenderer(new NullLogger(), '/non/existent/plantuml');
+        $renderer = new PlantumlRenderer(new NullLogger(), '/non/existent/plantuml', $tempDir);
 
         $renderContext = $this->createMock(RenderContext::class);
         $renderContext->method('getLoggerInformation')->willReturn([]);


### PR DESCRIPTION
## Summary

The `tempnam()` call in `PlantumlRenderer::render()` uses a subdirectory of `sys_get_temp_dir()` that may not exist, which triggers a PHP `E_NOTICE`:

```
Notice: tempnam(): file created in the system's temporary directory
```

This notice can appear in rendered documentation output when error reporting includes `E_NOTICE`.

## Changes

- Create the temp subdirectory if it doesn't exist before calling `tempnam()`
- Add dependency injection for temp directory path (optional constructor parameter, defaults to `sys_get_temp_dir() . '/phpdocumentor'`)
- Add regression test using injected temp directory for proper isolation

## Test plan

- [ ] Configure guides to use local PlantUML binary (`renderer="plantuml"`)
- [ ] Ensure `/tmp/phpdocumentor` does not exist
- [ ] Render documentation with a `.. uml::` directive
- [ ] Verify no `E_NOTICE` is emitted

---

*Moved from https://github.com/phpDocumentor/guides-graphs/pull/2*