### PR TITLE
perf: Add O(1) lookup caching for ProjectNode document entries

### DIFF
--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -25,10 +25,8 @@ use phpDocumentor\Guides\ApplicationTestCase;
 use phpDocumentor\Guides\Compiler\Compiler;
 use phpDocumentor\Guides\Compiler\CompilerContext;
 use phpDocumentor\Guides\NodeRenderers\NodeRenderer;
-use phpDocumentor\Guides\Nodes\DocumentTree\DocumentEntryNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\ProjectNode;
-use phpDocumentor\Guides\Nodes\TitleNode;
 use phpDocumentor\Guides\Parser;
 use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\Settings\ProjectSettings;
@@ -110,13 +108,11 @@ final class FunctionalTest extends ApplicationTestCase
 
             $parser = $this->getContainer()->get(Parser::class);
             assert($parser instanceof Parser);
-            $document = $parser->parse($rst);
-            $documentEntry = new DocumentEntryNode($document->getFilePath(), $document->getTitle() ?? TitleNode::fromString(''), true);
+            $document = $parser->parse($rst)->withIsRoot(true);
 
             $compiler = $this->getContainer()->get(Compiler::class);
             assert($compiler instanceof Compiler);
             $projectNode = new ProjectNode();
-            $projectNode->setDocumentEntries([$documentEntry]);
             $compiler->run([$document], new CompilerContext($projectNode));
 
             $inputFilesystem = FlySystemAdapter::createFromFileSystem(new Filesystem(new InMemoryFilesystemAdapter()));


### PR DESCRIPTION
## Summary

Adds O(1) caching for frequently called ProjectNode methods:

- **`getRootDocumentEntry()`**: Caches root document entry on add, eliminating O(n) scan
- **`getDocumentEntry($file)`**: Direct hash lookup by file path instead of iteration
- **`setDocumentEntries()`**: Re-keys array properly via `addDocumentEntry()` to maintain invariants

### Changes

**ProjectNode.php**
- Added `$rootDocumentEntry` cache property
- `addDocumentEntry()`: Caches root entry if `isRoot()` is true
- `getRootDocumentEntry()`: Returns cached root directly (O(1))
- `getDocumentEntry()`: Uses `isset()` for O(1) lookup
- `setDocumentEntries()`: Delegates to `addDocumentEntry()` to maintain cache
- `reset()`: Clears cache

**FunctionalTest.php**
- Updated test to mark document as root via `withIsRoot(true)` before compilation
- Removed pre-creation of DocumentEntryNode (let compiler create it correctly)

### Rationale

For a project with 500 documents, `getRootDocumentEntry()` and `getDocumentEntry()` were O(n) iterations called during rendering. Now they're O(1) lookups.

### Performance Impact

See [Performance Analysis Report](https://cybottm.github.io/render-guides/) for detailed benchmarks.

---

## Related PRs

| PR | Description | Status |
|----|-------------|--------|
| #1287 | Rendering caching layer | Independent |
| #1288 | RST parsing optimizations | Independent |
| #1289 | CLI container caching | Independent |
| #1290 | DocumentEntryNode identity refactoring | Independent |
| #1292 | **This PR** - ProjectNode O(1) document lookup | |

All PRs can be merged independently in any order.