### PR TITLE
fix: set language on `CodeNode` for markdown fenced code blocks

### DIFF
--- a/packages/guides-markdown/src/Markdown/Parsers/CodeBlockParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/CodeBlockParser.php
@@ -22,6 +22,7 @@ use phpDocumentor\Guides\MarkupLanguageParser;
 use phpDocumentor\Guides\Nodes\CodeNode;
 
 use function assert;
+use function count;
 use function explode;
 
 /** @extends AbstractBlockParser<CodeNode> */
@@ -32,8 +33,11 @@ final class CodeBlockParser extends AbstractBlockParser
         assert($current instanceof IndentedCode || $current instanceof FencedCode);
         $walker->next();
         $codeNode = new CodeNode(explode("\n", $current->getLiteral()));
-        if ($current instanceof FencedCode && $current->getInfo() !== null) {
-            $codeNode = $codeNode->withOptions(['caption' => $current->getInfo()]);
+        if ($current instanceof FencedCode) {
+            $infoWords = $current->getInfoWords();
+            if (count($infoWords) !== 0 && $infoWords[0] !== '') {
+                $codeNode->setLanguage($infoWords[0]);
+            }
         }
 
         return $codeNode;

--- a/packages/guides-markdown/tests/unit/Markdown/Parsers/CodeBlockParserTest.php
+++ b/packages/guides-markdown/tests/unit/Markdown/Parsers/CodeBlockParserTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\Markdown\Parsers;
+
+use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
+use League\CommonMark\Extension\CommonMark\Node\Block\IndentedCode;
+use League\CommonMark\Node\NodeWalker;
+use League\CommonMark\Node\NodeWalkerEvent;
+use phpDocumentor\Guides\MarkupLanguageParser;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class CodeBlockParserTest extends TestCase
+{
+    private CodeBlockParser $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new CodeBlockParser();
+    }
+
+    /** @return array<string, array{string, string}> */
+    public static function languageProvider(): array
+    {
+        return [
+            'php' => ['php', 'php'],
+            'javascript' => ['javascript', 'javascript'],
+            'c++' => ['c++', 'c++'],
+            'first word only from info string' => ['ruby startline=1', 'ruby'],
+        ];
+    }
+
+    #[DataProvider('languageProvider')]
+    public function test_fenced_code_block_sets_language_from_info_string(string $info, string $expectedLanguage): void
+    {
+        $fencedCode = new FencedCode(3, '`', 0);
+        $fencedCode->setInfo($info);
+        $fencedCode->setLiteral("echo \"Hello\";\n");
+
+        $result = $this->parser->parse(
+            $this->createMock(MarkupLanguageParser::class),
+            new NodeWalker($fencedCode),
+            $fencedCode,
+        );
+
+        self::assertSame($expectedLanguage, $result->getLanguage());
+        self::assertSame("echo \"Hello\";\n", $result->getValue());
+    }
+
+    public function test_fenced_code_block_without_info_has_null_language(): void
+    {
+        $fencedCode = new FencedCode(3, '`', 0);
+        $fencedCode->setLiteral("some code\n");
+
+        $result = $this->parser->parse(
+            $this->createMock(MarkupLanguageParser::class),
+            new NodeWalker($fencedCode),
+            $fencedCode,
+        );
+
+        self::assertNull($result->getLanguage());
+        self::assertSame("some code\n", $result->getValue());
+    }
+
+    public function test_fenced_code_block_with_empty_info_has_null_language(): void
+    {
+        $fencedCode = new FencedCode(3, '`', 0);
+        $fencedCode->setInfo('');
+        $fencedCode->setLiteral("some code\n");
+
+        $result = $this->parser->parse(
+            $this->createMock(MarkupLanguageParser::class),
+            new NodeWalker($fencedCode),
+            $fencedCode,
+        );
+
+        self::assertNull($result->getLanguage());
+    }
+
+    public function test_indented_code_block_has_null_language(): void
+    {
+        $indentedCode = new IndentedCode();
+        $indentedCode->setLiteral("some code\n");
+
+        $result = $this->parser->parse(
+            $this->createMock(MarkupLanguageParser::class),
+            new NodeWalker($indentedCode),
+            $indentedCode,
+        );
+
+        self::assertNull($result->getLanguage());
+        self::assertSame("some code\n", $result->getValue());
+    }
+
+    public function test_supports_fenced_code(): void
+    {
+        $fencedCode = new FencedCode(3, '`', 0);
+        $event = new NodeWalkerEvent($fencedCode, true);
+
+        self::assertTrue($this->parser->supports($event));
+    }
+
+    public function test_supports_indented_code(): void
+    {
+        $indentedCode = new IndentedCode();
+        $event = new NodeWalkerEvent($indentedCode, true);
+
+        self::assertTrue($this->parser->supports($event));
+    }
+}

--- a/tests/Integration/tests/markdown/code-md/expected/index.html
+++ b/tests/Integration/tests/markdown/code-md/expected/index.html
@@ -18,14 +18,20 @@
 </code></pre>
 
     </div>
-            <div class="section" id="fenced-code-block-with-caption">
-            <h2>Fenced Code Block with caption</h2>
-            <pre><code class="language-">procedure startSwinging(swing, child)
+            <div class="section" id="fenced-code-block-with-language">
+            <h2>Fenced Code Block with language</h2>
+            <pre><code class="language-pseudocode">procedure startSwinging(swing, child)
    while child.isComfortable()
        swing.giveGentlePush()
        waitForNextIteration()
    end while
 end procedure
+</code></pre>
+
+    </div>
+            <div class="section" id="fenced-code-block-with-php">
+            <h2>Fenced Code Block with PHP</h2>
+            <pre><code class="language-php">echo &quot;Hello world!&quot;;
 </code></pre>
 
     </div>

--- a/tests/Integration/tests/markdown/code-md/input/index.md
+++ b/tests/Integration/tests/markdown/code-md/input/index.md
@@ -15,7 +15,7 @@
 }
 ```
 
-## Fenced Code Block with caption
+## Fenced Code Block with language
 
 ```pseudocode
 procedure startSwinging(swing, child)
@@ -24,3 +24,10 @@ procedure startSwinging(swing, child)
        waitForNextIteration()
    end while
 end procedure
+```
+
+## Fenced Code Block with PHP
+
+```php
+echo "Hello world!";
+```

--- a/tests/Integration/tests/markdown/readme-md/expected/index.html
+++ b/tests/Integration/tests/markdown/readme-md/expected/index.html
@@ -42,7 +42,7 @@
     <li><strong>Hold onto the Swing:</strong> Provide support and hold onto the swing until your child is comfortably seated and ready to swing.</li>
     <li>
     <p><strong>Start Swinging:</strong> Give a gentle push to start the swinging motion. Observe your child&#039;s comfort level and adjust the swinging speed accordingly.</p>
-<pre><code class="language-">procedure startSwinging(swing, child)
+<pre><code class="language-pseudocode">procedure startSwinging(swing, child)
     while child.isComfortable()
         swing.giveGentlePush()
         waitForNextIteration()


### PR DESCRIPTION
:warning: **Disclaimer:** This was vibe-coded.  I am not a PHP developer, but I am helping https://github.com/modelcontextprotocol/php-sdk set up documentation using phpDocumentor, and I encountered this issue.  I guided Claude through the investigation and self-review, but I am unable to personally judge the fix.

---

`CodeBlockParser::parse()` stored the fenced code info string in `options['caption']` via `withOptions()`, but nothing ever read that value — `CodeNode::getCaption()` returns the typed `$caption` property, not `getOption('caption')`. As a result, `CodeNode::getLanguage()` always returned `null` for markdown code blocks, producing `class="language-"` in the rendered HTML and preventing syntax highlighting.

Replace the dead `withOptions(['caption' => ...])` call with `setLanguage()` using `getInfoWords()[0]` from the CommonMark `FencedCode` node, matching both the RST parser's behavior (`CodeBlockDirective`) and league/commonmark's own `FencedCodeRenderer`.
