### PR TITLE
Resolve RST anonymous heading refs against the current page first

### DIFF
--- a/packages/guides/src/Nodes/ProjectNode.php
+++ b/packages/guides/src/Nodes/ProjectNode.php
@@ -47,6 +47,9 @@ final class ProjectNode extends CompoundNode
     /** @var array<string, array<string, InternalTarget>> */
     private array $internalLinkTargets = [];
 
+    /** @var array<string, array<string, array<string, InternalTarget>>> documentPath => linkType => anchor => target */
+    private array $documentScopedTargets = [];
+
     /** Cached root document entry for O(1) lookup */
     private DocumentEntryNode|null $rootDocumentEntry = null;
 
@@ -165,6 +168,7 @@ final class ProjectNode extends CompoundNode
         }
 
         $this->internalLinkTargets[$linkType][$anchorName] = $target;
+        $this->documentScopedTargets[$target->getDocumentPath()][$linkType][$anchorName] = $target;
     }
 
     public function hasInternalTarget(string $anchorName, string $linkType = SectionNode::STD_LABEL): bool
@@ -175,6 +179,19 @@ final class ProjectNode extends CompoundNode
     public function getInternalTarget(string $anchorName, string $linkType = SectionNode::STD_LABEL): InternalTarget|null
     {
         return $this->internalLinkTargets[$linkType][$anchorName] ?? null;
+    }
+
+    /**
+     * Returns the target registered for an anchor that belongs to the given document, or null when
+     * no document-scoped target exists. Use this when the lookup should prefer the current page
+     * before falling back to the global {@see self::getInternalTarget()} index.
+     */
+    public function getInternalTargetForDocument(
+        string $anchorName,
+        string $documentPath,
+        string $linkType = SectionNode::STD_LABEL,
+    ): InternalTarget|null {
+        return $this->documentScopedTargets[$documentPath][$linkType][$anchorName] ?? null;
     }
 
     /** @return array<string, array<string, InternalTarget>> */

--- a/packages/guides/src/ReferenceResolvers/AnchorHyperlinkResolver.php
+++ b/packages/guides/src/ReferenceResolvers/AnchorHyperlinkResolver.php
@@ -44,13 +44,19 @@ final class AnchorHyperlinkResolver implements ReferenceResolver
         }
 
         $reducedAnchor = $this->anchorReducer->reduceAnchor($node->getTargetReference());
-        $target = $renderContext->getProjectNode()->getInternalTarget($reducedAnchor);
+        $projectNode = $renderContext->getProjectNode();
+        $currentDocumentPath = $renderContext->getDocument()->getFilePath();
+
+        // Prefer an anchor that lives on the current page: RST anonymous references such as
+        // `Heading 1`_ are page-local by nature, and falling through to the global index would
+        // pick up a same-named section from another document.
+        $target = $projectNode->getInternalTargetForDocument($reducedAnchor, $currentDocumentPath)
+            ?? $projectNode->getInternalTargetForDocument($reducedAnchor, $currentDocumentPath, SectionNode::STD_TITLE)
+            ?? $projectNode->getInternalTarget($reducedAnchor)
+            ?? $projectNode->getInternalTarget($reducedAnchor, SectionNode::STD_TITLE);
 
         if ($target === null) {
-            $target = $renderContext->getProjectNode()->getInternalTarget($reducedAnchor, SectionNode::STD_TITLE);
-            if ($target === null) {
-                return false;
-            }
+            return false;
         }
 
         $node->setUrl($this->urlGenerator->generateCanonicalOutputUrl($renderContext, $target->getDocumentPath(), $target->getAnchor()));

--- a/tests/Integration/tests/hyperlink-to-heading-on-other-page/expected/page1.html
+++ b/tests/Integration/tests/hyperlink-to-heading-on-other-page/expected/page1.html
@@ -1,0 +1,11 @@
+<!-- content start -->
+    <div class="section" id="page-1">
+        <h1>Page 1</h1>
+
+
+<ul>
+    <li class="dash"><a href="/page2.html#only-on-page-two">Only on page two</a></li>
+</ul>
+
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/hyperlink-to-heading-on-other-page/input/index.rst
+++ b/tests/Integration/tests/hyperlink-to-heading-on-other-page/input/index.rst
@@ -1,0 +1,7 @@
+Hyperlink to heading on another page
+====================================
+
+.. toctree::
+
+   page1
+   page2

--- a/tests/Integration/tests/hyperlink-to-heading-on-other-page/input/page1.rst
+++ b/tests/Integration/tests/hyperlink-to-heading-on-other-page/input/page1.rst
@@ -1,0 +1,4 @@
+Page 1
+======
+
+- `Only on page two`_

--- a/tests/Integration/tests/hyperlink-to-heading-on-other-page/input/page2.rst
+++ b/tests/Integration/tests/hyperlink-to-heading-on-other-page/input/page2.rst
@@ -1,0 +1,7 @@
+Page 2
+======
+
+Only on page two
+----------------
+
+Lorem ipsum.

--- a/tests/Integration/tests/hyperlink-to-local-anchor-over-remote-heading/expected/page1.html
+++ b/tests/Integration/tests/hyperlink-to-local-anchor-over-remote-heading/expected/page1.html
@@ -1,0 +1,15 @@
+<!-- content start -->
+    <div class="section" id="page-1">
+        <h1>Page 1</h1>
+
+<p>See the <a href="/page1.html#details">details</a> below.</p>
+
+        <div class="section" id="more-details">
+        <a id="details"></a>
+        <h2>More details</h2>
+
+<p>Lorem ipsum.</p>
+
+    </div>
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/hyperlink-to-local-anchor-over-remote-heading/input/index.rst
+++ b/tests/Integration/tests/hyperlink-to-local-anchor-over-remote-heading/input/index.rst
@@ -1,0 +1,7 @@
+Hyperlink to local anchor over remote heading
+==============================================
+
+.. toctree::
+
+   page1
+   page2

--- a/tests/Integration/tests/hyperlink-to-local-anchor-over-remote-heading/input/page1.rst
+++ b/tests/Integration/tests/hyperlink-to-local-anchor-over-remote-heading/input/page1.rst
@@ -1,0 +1,11 @@
+Page 1
+======
+
+See the `details`_ below.
+
+.. _details:
+
+More details
+------------
+
+Lorem ipsum.

--- a/tests/Integration/tests/hyperlink-to-local-anchor-over-remote-heading/input/page2.rst
+++ b/tests/Integration/tests/hyperlink-to-local-anchor-over-remote-heading/input/page2.rst
@@ -1,0 +1,7 @@
+Page 2
+======
+
+Details
+-------
+
+Lorem ipsum.

--- a/tests/Integration/tests/hyperlink-to-local-heading/expected/page1.html
+++ b/tests/Integration/tests/hyperlink-to-local-heading/expected/page1.html
@@ -1,0 +1,17 @@
+<!-- content start -->
+    <div class="section" id="page-1">
+        <h1>Page 1</h1>
+
+
+<ul>
+    <li class="dash"><a href="/page1.html#shared-heading">Shared heading</a></li>
+</ul>
+
+        <div class="section" id="shared-heading">
+        <h2>Shared heading</h2>
+
+<p>Lorem ipsum.</p>
+
+    </div>
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/hyperlink-to-local-heading/expected/page2.html
+++ b/tests/Integration/tests/hyperlink-to-local-heading/expected/page2.html
@@ -1,0 +1,17 @@
+<!-- content start -->
+    <div class="section" id="page-2">
+        <h1>Page 2</h1>
+
+
+<ul>
+    <li class="dash"><a href="/page2.html#shared-heading">Shared heading</a></li>
+</ul>
+
+        <div class="section" id="shared-heading">
+        <h2>Shared heading</h2>
+
+<p>Lorem ipsum.</p>
+
+    </div>
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/hyperlink-to-local-heading/input/index.rst
+++ b/tests/Integration/tests/hyperlink-to-local-heading/input/index.rst
@@ -1,0 +1,7 @@
+Hyperlink to local heading
+==========================
+
+.. toctree::
+
+   page1
+   page2

--- a/tests/Integration/tests/hyperlink-to-local-heading/input/page1.rst
+++ b/tests/Integration/tests/hyperlink-to-local-heading/input/page1.rst
@@ -1,0 +1,9 @@
+Page 1
+======
+
+- `Shared heading`_
+
+Shared heading
+--------------
+
+Lorem ipsum.

--- a/tests/Integration/tests/hyperlink-to-local-heading/input/page2.rst
+++ b/tests/Integration/tests/hyperlink-to-local-heading/input/page2.rst
@@ -1,0 +1,9 @@
+Page 2
+======
+
+- `Shared heading`_
+
+Shared heading
+--------------
+
+Lorem ipsum.


### PR DESCRIPTION
RST anonymous references (``\`Heading 1\`_``) resolved to a same-named heading on another page because the project-wide anchor index silently overwrites `std:title` entries on duplicate keys. Stores link targets in a document-scoped index alongside the global one; `AnchorHyperlinkResolver` now consults the current page before falling back to the global match.

Fixes phpDocumentor/phpDocumentor#3781