### PR TITLE
[BUG] Internal anchors do not prefer current doc

### DIFF
--- a/packages/guides/src/Nodes/DocumentTree/DocumentEntryNode.php
+++ b/packages/guides/src/Nodes/DocumentTree/DocumentEntryNode.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\Nodes\DocumentTree;
 
+use phpDocumentor\Guides\Meta\InternalTarget;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\SectionNode;
 use phpDocumentor\Guides\Nodes\TitleNode;
@@ -99,9 +100,7 @@ final class DocumentEntryNode extends EntryNode
             if ($sectionNode->getId() === $sectionEntryNode->getId()) {
                 return $sectionEntryNode;
             }
-        }
 
-        foreach ($this->sections as $sectionEntryNode) {
             $subsection = $sectionEntryNode->findSectionEntry($sectionNode);
             if ($subsection !== null) {
                 return $subsection;
@@ -124,5 +123,38 @@ final class DocumentEntryNode extends EntryNode
     public function addAdditionalData(string $key, Node $value): void
     {
         $this->additionalData[$key] = $value;
+    }
+
+    /** Returns the internal target for heading id if exists */
+    public function getInternalTarget(string $id): InternalTarget|null
+    {
+        $entry = $this->findSectionEntryById($id, $this->sections);
+
+        if ($entry === null) {
+            return null;
+        }
+
+        return new InternalTarget(
+            $this->getFile(),
+            $id,
+            $entry->getTitle()->toString(),
+        );
+    }
+
+    /** @param SectionEntryNode[] $sectionEntries */
+    private function findSectionEntryById(string $id, array $sectionEntries): SectionEntryNode|null
+    {
+        foreach ($sectionEntries as $entry) {
+            if ($entry->getId() === $id) {
+                return $entry;
+            }
+
+            $entry = $this->findSectionEntryById($id, $entry->getChildren());
+            if ($entry !== null) {
+                return $entry;
+            }
+        }
+
+        return null;
     }
 }

--- a/packages/guides/src/Nodes/ProjectNode.php
+++ b/packages/guides/src/Nodes/ProjectNode.php
@@ -47,9 +47,6 @@ final class ProjectNode extends CompoundNode
     /** @var array<string, array<string, InternalTarget>> */
     private array $internalLinkTargets = [];
 
-    /** @var array<string, array<string, array<string, InternalTarget>>> documentPath => linkType => anchor => target */
-    private array $documentScopedTargets = [];
-
     /** Cached root document entry for O(1) lookup */
     private DocumentEntryNode|null $rootDocumentEntry = null;
 
@@ -168,7 +165,6 @@ final class ProjectNode extends CompoundNode
         }
 
         $this->internalLinkTargets[$linkType][$anchorName] = $target;
-        $this->documentScopedTargets[$target->getDocumentPath()][$linkType][$anchorName] = $target;
     }
 
     public function hasInternalTarget(string $anchorName, string $linkType = SectionNode::STD_LABEL): bool
@@ -179,19 +175,6 @@ final class ProjectNode extends CompoundNode
     public function getInternalTarget(string $anchorName, string $linkType = SectionNode::STD_LABEL): InternalTarget|null
     {
         return $this->internalLinkTargets[$linkType][$anchorName] ?? null;
-    }
-
-    /**
-     * Returns the target registered for an anchor that belongs to the given document, or null when
-     * no document-scoped target exists. Use this when the lookup should prefer the current page
-     * before falling back to the global {@see self::getInternalTarget()} index.
-     */
-    public function getInternalTargetForDocument(
-        string $anchorName,
-        string $documentPath,
-        string $linkType = SectionNode::STD_LABEL,
-    ): InternalTarget|null {
-        return $this->documentScopedTargets[$documentPath][$linkType][$anchorName] ?? null;
     }
 
     /** @return array<string, array<string, InternalTarget>> */

--- a/packages/guides/src/Nodes/ProjectNode.php
+++ b/packages/guides/src/Nodes/ProjectNode.php
@@ -47,6 +47,9 @@ final class ProjectNode extends CompoundNode
     /** @var array<string, array<string, InternalTarget>> */
     private array $internalLinkTargets = [];
 
+    /** @var array<string, array<string, array<string, InternalTarget>>> documentPath => linkType => anchor => target */
+    private array $documentScopedTargets = [];
+
     /** Cached root document entry for O(1) lookup */
     private DocumentEntryNode|null $rootDocumentEntry = null;
 
@@ -165,6 +168,7 @@ final class ProjectNode extends CompoundNode
         }
 
         $this->internalLinkTargets[$linkType][$anchorName] = $target;
+        $this->documentScopedTargets[$target->getDocumentPath()][$linkType][$anchorName] = $target;
     }
 
     public function hasInternalTarget(string $anchorName, string $linkType = SectionNode::STD_LABEL): bool
@@ -175,6 +179,19 @@ final class ProjectNode extends CompoundNode
     public function getInternalTarget(string $anchorName, string $linkType = SectionNode::STD_LABEL): InternalTarget|null
     {
         return $this->internalLinkTargets[$linkType][$anchorName] ?? null;
+    }
+
+    /**
+     * Returns the target registered for an anchor that belongs to the given document, or null when
+     * no document-scoped target exists. Use this when the lookup should prefer the current page
+     * before falling back to the global {@see self::getInternalTarget()} index.
+     */
+    public function getInternalTargetForDocument(
+        string $anchorName,
+        string $documentPath,
+        string $linkType = SectionNode::STD_LABEL,
+    ): InternalTarget|null {
+        return $this->documentScopedTargets[$documentPath][$linkType][$anchorName] ?? null;
     }
 
     /** @return array<string, array<string, InternalTarget>> */

--- a/packages/guides/src/ReferenceResolvers/AnchorHyperlinkResolver.php
+++ b/packages/guides/src/ReferenceResolvers/AnchorHyperlinkResolver.php
@@ -44,19 +44,17 @@ final class AnchorHyperlinkResolver implements ReferenceResolver
         }
 
         $reducedAnchor = $this->anchorReducer->reduceAnchor($node->getTargetReference());
-        $projectNode = $renderContext->getProjectNode();
-        $currentDocumentPath = $renderContext->getDocument()->getFilePath();
-
-        // Prefer an anchor that lives on the current page: RST anonymous references such as
-        // `Heading 1`_ are page-local by nature, and falling through to the global index would
-        // pick up a same-named section from another document.
-        $target = $projectNode->getInternalTargetForDocument($reducedAnchor, $currentDocumentPath)
-            ?? $projectNode->getInternalTargetForDocument($reducedAnchor, $currentDocumentPath, SectionNode::STD_TITLE)
-            ?? $projectNode->getInternalTarget($reducedAnchor)
-            ?? $projectNode->getInternalTarget($reducedAnchor, SectionNode::STD_TITLE);
+        $target = $renderContext->getCurrentDocumentEntry()?->getInternalTarget($reducedAnchor);
 
         if ($target === null) {
-            return false;
+            $target = $renderContext->getProjectNode()->getInternalTarget($reducedAnchor);
+        }
+
+        if ($target === null) {
+            $target = $renderContext->getProjectNode()->getInternalTarget($reducedAnchor, SectionNode::STD_TITLE);
+            if ($target === null) {
+                return false;
+            }
         }
 
         $node->setUrl($this->urlGenerator->generateCanonicalOutputUrl($renderContext, $target->getDocumentPath(), $target->getAnchor()));

--- a/packages/guides/src/ReferenceResolvers/AnchorHyperlinkResolver.php
+++ b/packages/guides/src/ReferenceResolvers/AnchorHyperlinkResolver.php
@@ -44,13 +44,19 @@ final class AnchorHyperlinkResolver implements ReferenceResolver
         }
 
         $reducedAnchor = $this->anchorReducer->reduceAnchor($node->getTargetReference());
-        $target = $renderContext->getProjectNode()->getInternalTarget($reducedAnchor);
+        $projectNode = $renderContext->getProjectNode();
+        $currentDocumentPath = $renderContext->getDocument()->getFilePath();
+
+        // Prefer an anchor that lives on the current page: RST anonymous references such as
+        // `Heading 1`_ are page-local by nature, and falling through to the global index would
+        // pick up a same-named section from another document.
+        $target = $projectNode->getInternalTargetForDocument($reducedAnchor, $currentDocumentPath)
+            ?? $projectNode->getInternalTargetForDocument($reducedAnchor, $currentDocumentPath, SectionNode::STD_TITLE)
+            ?? $projectNode->getInternalTarget($reducedAnchor)
+            ?? $projectNode->getInternalTarget($reducedAnchor, SectionNode::STD_TITLE);
 
         if ($target === null) {
-            $target = $renderContext->getProjectNode()->getInternalTarget($reducedAnchor, SectionNode::STD_TITLE);
-            if ($target === null) {
-                return false;
-            }
+            return false;
         }
 
         $node->setUrl($this->urlGenerator->generateCanonicalOutputUrl($renderContext, $target->getDocumentPath(), $target->getAnchor()));

--- a/tests/Integration/tests/hyperlink-to-heading-on-other-page/expected/page1.html
+++ b/tests/Integration/tests/hyperlink-to-heading-on-other-page/expected/page1.html
@@ -1,0 +1,11 @@
+<!-- content start -->
+    <div class="section" id="page-1">
+        <h1>Page 1</h1>
+
+
+<ul>
+    <li class="dash"><a href="/page2.html#only-on-page-two">Only on page two</a></li>
+</ul>
+
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/hyperlink-to-heading-on-other-page/input/index.rst
+++ b/tests/Integration/tests/hyperlink-to-heading-on-other-page/input/index.rst
@@ -1,0 +1,7 @@
+Hyperlink to heading on another page
+====================================
+
+.. toctree::
+
+   page1
+   page2

--- a/tests/Integration/tests/hyperlink-to-heading-on-other-page/input/page1.rst
+++ b/tests/Integration/tests/hyperlink-to-heading-on-other-page/input/page1.rst
@@ -1,0 +1,4 @@
+Page 1
+======
+
+- `Only on page two`_

--- a/tests/Integration/tests/hyperlink-to-heading-on-other-page/input/page2.rst
+++ b/tests/Integration/tests/hyperlink-to-heading-on-other-page/input/page2.rst
@@ -1,0 +1,7 @@
+Page 2
+======
+
+Only on page two
+----------------
+
+Lorem ipsum.

--- a/tests/Integration/tests/hyperlink-to-local-anchor-over-remote-heading/expected/page1.html
+++ b/tests/Integration/tests/hyperlink-to-local-anchor-over-remote-heading/expected/page1.html
@@ -1,0 +1,15 @@
+<!-- content start -->
+    <div class="section" id="page-1">
+        <h1>Page 1</h1>
+
+<p>See the <a href="/page1.html#details">details</a> below.</p>
+
+        <div class="section" id="more-details">
+        <a id="details"></a>
+        <h2>More details</h2>
+
+<p>Lorem ipsum.</p>
+
+    </div>
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/hyperlink-to-local-anchor-over-remote-heading/input/index.rst
+++ b/tests/Integration/tests/hyperlink-to-local-anchor-over-remote-heading/input/index.rst
@@ -1,0 +1,7 @@
+Hyperlink to local anchor over remote heading
+==============================================
+
+.. toctree::
+
+   page1
+   page2

--- a/tests/Integration/tests/hyperlink-to-local-anchor-over-remote-heading/input/page1.rst
+++ b/tests/Integration/tests/hyperlink-to-local-anchor-over-remote-heading/input/page1.rst
@@ -1,0 +1,11 @@
+Page 1
+======
+
+See the `details`_ below.
+
+.. _details:
+
+More details
+------------
+
+Lorem ipsum.

--- a/tests/Integration/tests/hyperlink-to-local-anchor-over-remote-heading/input/page2.rst
+++ b/tests/Integration/tests/hyperlink-to-local-anchor-over-remote-heading/input/page2.rst
@@ -1,0 +1,7 @@
+Page 2
+======
+
+Details
+-------
+
+Lorem ipsum.

--- a/tests/Integration/tests/hyperlink-to-local-heading/expected/page1.html
+++ b/tests/Integration/tests/hyperlink-to-local-heading/expected/page1.html
@@ -1,0 +1,17 @@
+<!-- content start -->
+    <div class="section" id="page-1">
+        <h1>Page 1</h1>
+
+
+<ul>
+    <li class="dash"><a href="/page1.html#shared-heading">Shared heading</a></li>
+</ul>
+
+        <div class="section" id="shared-heading">
+        <h2>Shared heading</h2>
+
+<p>Lorem ipsum.</p>
+
+    </div>
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/hyperlink-to-local-heading/expected/page2.html
+++ b/tests/Integration/tests/hyperlink-to-local-heading/expected/page2.html
@@ -1,0 +1,17 @@
+<!-- content start -->
+    <div class="section" id="page-2">
+        <h1>Page 2</h1>
+
+
+<ul>
+    <li class="dash"><a href="/page2.html#shared-heading">Shared heading</a></li>
+</ul>
+
+        <div class="section" id="shared-heading">
+        <h2>Shared heading</h2>
+
+<p>Lorem ipsum.</p>
+
+    </div>
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/hyperlink-to-local-heading/input/index.rst
+++ b/tests/Integration/tests/hyperlink-to-local-heading/input/index.rst
@@ -1,0 +1,7 @@
+Hyperlink to local heading
+==========================
+
+.. toctree::
+
+   page1
+   page2

--- a/tests/Integration/tests/hyperlink-to-local-heading/input/page1.rst
+++ b/tests/Integration/tests/hyperlink-to-local-heading/input/page1.rst
@@ -1,0 +1,9 @@
+Page 1
+======
+
+- `Shared heading`_
+
+Shared heading
+--------------
+
+Lorem ipsum.

--- a/tests/Integration/tests/hyperlink-to-local-heading/input/page2.rst
+++ b/tests/Integration/tests/hyperlink-to-local-heading/input/page2.rst
@@ -1,0 +1,9 @@
+Page 2
+======
+
+- `Shared heading`_
+
+Shared heading
+--------------
+
+Lorem ipsum.


### PR DESCRIPTION
As reported in https://github.com/phpDocumentor/phpDocumentor/issues/3781 we do not properly reference the current heading ids over the references from other documents. This patch is an improved implementation for the suggestions done in #1329 by @lacatoire and #1301 by @jonathanhefner.

I think less state handling is a better thing when dealing with hot reloads and other state sensitive operations. If we need caching we can do that in the RenderContext if needed. 