### PR TITLE
Guard against null token after trailing backslash in text role

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/TextRoleRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/TextRoleRule.php
@@ -76,8 +76,12 @@ final class TextRoleRule extends AbstractInlineRule
 
                     break;
                 case InlineLexer::BACKSLASH:
-                    $rawPart .= $token->value;
                     $lexer->moveNext();
+                    if ($lexer->token === null) {
+                        break 2;
+                    }
+
+                    $rawPart .= $token->value;
                     $part .= $lexer->token->value;
                     $rawPart .= $lexer->token->value;
 

--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/InlineRules/TextRoleRuleTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/InlineRules/TextRoleRuleTest.php
@@ -148,4 +148,31 @@ final class TextRoleRuleTest extends TestCase
          */
         self::assertSame($expectedRawContent, $node->rawContent);
     }
+
+    public function testApplyReturnsNullOnTrailingBackslashWithoutRaisingWarning(): void
+    {
+        $input = ":role:`text\\";
+
+        $textRoleFactory = $this->createMock(TextRoleFactory::class);
+        $textRoleFactory->expects(self::never())->method('getTextRole');
+
+        $lexer = new InlineLexer();
+        $lexer->setInput($input);
+        $lexer->moveNext();
+        $lexer->moveNext();
+
+        $textRoleRule = new TextRoleRule();
+        self::assertTrue($textRoleRule->applies($lexer));
+
+        $documentParserContext = new DocumentParserContext(
+            self::createStub(ParserContext::class),
+            $textRoleFactory,
+            self::createStub(MarkupLanguageParser::class),
+        );
+
+        self::assertNull($textRoleRule->apply(
+            new BlockContext($documentParserContext, ''),
+            $lexer,
+        ));
+    }
 }

--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/InlineRules/TextRoleRuleTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/InlineRules/TextRoleRuleTest.php
@@ -151,7 +151,7 @@ final class TextRoleRuleTest extends TestCase
 
     public function testApplyReturnsNullOnTrailingBackslashWithoutRaisingWarning(): void
     {
-        $input = ":role:`text\\";
+        $input = ':role:`text\\';
 
         $textRoleFactory = $this->createMock(TextRoleFactory::class);
         $textRoleFactory->expects(self::never())->method('getTextRole');


### PR DESCRIPTION
When a text role candidate is followed by a trailing backslash at the end of the stream (or end of the block), `moveNext()` leaves `$lexer->token` as null and the next read on `->value` triggers a `Warning: Attempt to read property "value" on null`.

Bail out of the loop in that case, matching what the other terminal branches already do. The rule then falls through to `rollback()` and returns null, so the input is simply not interpreted as a text role.

Fixes phpDocumentor/phpDocumentor#4082