### PR TITLE
Deprecate SpecificationInterface in FileCollector and ParseDirectoryCommand

### DIFF
--- a/packages/guides/src/FileCollector.php
+++ b/packages/guides/src/FileCollector.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides;
 
+use Doctrine\Deprecations\Deprecation;
 use Flyfinder\Specification\AndSpecification;
 use Flyfinder\Specification\HasExtension;
 use Flyfinder\Specification\InPath;
@@ -49,10 +50,22 @@ final class FileCollector
      * objects, and avoids adding files to the parse queue that have
      * not changed and whose direct dependencies have not changed.
      *
-     * @param SpecificationInterface|Exclude|null $excludedSpecification specification that is used to exclude specific files/directories
+     * @param SpecificationInterface|Exclude|null $excludedSpecification specification that is used to exclude specific files/directories.
+     *                                                                   Passing a {@see SpecificationInterface} is deprecated, use {@see Exclude} instead.
      */
     public function collect(FilesystemInterface|FileSystem $filesystem, string $directory, string $extension, SpecificationInterface|Exclude|null $excludedSpecification = null): Files
     {
+        if ($excludedSpecification instanceof SpecificationInterface) {
+            Deprecation::triggerIfCalledFromOutside(
+                'phpdocumentor/guides',
+                'https://github.com/phpDocumentor/guides/issues/1209',
+                'Passing %s to %s::collect() is deprecated, use %s instead.',
+                $excludedSpecification::class,
+                self::class,
+                Exclude::class,
+            );
+        }
+
         $directory = trim($directory, '/');
         $specification = $this->getSpecification($excludedSpecification, $directory, $extension);
 

--- a/packages/guides/src/Handlers/ParseDirectoryCommand.php
+++ b/packages/guides/src/Handlers/ParseDirectoryCommand.php
@@ -34,10 +34,12 @@ final class ParseDirectoryCommand
     ) {
         if ($excludedSpecification instanceof SpecificationInterface) {
             Deprecation::trigger(
-                'phpDocumentor/guides',
+                'phpdocumentor/guides',
                 'https://github.com/phpDocumentor/guides/issues/1209',
-                'Passing ' . $excludedSpecification::class . ' to ' . self::class . 'will be deprecated,'
-                . 'use phpDocumentor\FileSystem\Finder\Exclude instead.',
+                'Passing %s to %s is deprecated, use %s instead.',
+                $excludedSpecification::class,
+                self::class,
+                Exclude::class,
             );
             $this->excludedSpecification = $excludedSpecification;
             $this->exclude = null;
@@ -67,16 +69,16 @@ final class ParseDirectoryCommand
         return $this->projectNode;
     }
 
-    /** @deprecated Specification definition on parse directory is deprecated. Use @{see self::getExclude()} instead.*/
+    /** @deprecated Specification definition on parse directory is deprecated. Use {@see self::getExclude()} instead. */
     public function getExcludedSpecification(): SpecificationInterface|null
     {
-        Deprecation::trigger(
-            'phpDocumentor/guides',
+        Deprecation::triggerIfCalledFromOutside(
+            'phpdocumentor/guides',
             'https://github.com/phpDocumentor/guides/issues/1209',
             'Specification definition on parse directory is deprecated. Use getExclude() instead.',
         );
 
-        return $this->excludedSpecification ?? null;
+        return $this->excludedSpecification;
     }
 
     public function getExclude(): Exclude
@@ -87,5 +89,10 @@ final class ParseDirectoryCommand
     public function hasExclude(): bool
     {
         return isset($this->exclude);
+    }
+
+    public function hasExcludedSpecification(): bool
+    {
+        return isset($this->excludedSpecification);
     }
 }

--- a/packages/guides/src/Handlers/ParseDirectoryCommand.php
+++ b/packages/guides/src/Handlers/ParseDirectoryCommand.php
@@ -91,6 +91,7 @@ final class ParseDirectoryCommand
         return isset($this->exclude);
     }
 
+    /** @internal Used by {@see ParseDirectoryHandler} to dispatch without triggering the deprecation on {@see self::getExcludedSpecification()}. */
     public function hasExcludedSpecification(): bool
     {
         return isset($this->excludedSpecification);

--- a/packages/guides/src/Handlers/ParseDirectoryHandler.php
+++ b/packages/guides/src/Handlers/ParseDirectoryHandler.php
@@ -69,7 +69,11 @@ final class ParseDirectoryHandler
             $origin,
             $currentDirectory,
             $extension,
-            $command->hasExclude() ? $command->getExclude() : $command->getExcludedSpecification(),
+            match (true) {
+                $command->hasExclude() => $command->getExclude(),
+                $command->hasExcludedSpecification() => $command->getExcludedSpecification(),
+                default => null,
+            },
         );
 
         $postCollectFilesForParsingEvent = $this->eventDispatcher->dispatch(

--- a/packages/guides/tests/unit/FileCollectorTest.php
+++ b/packages/guides/tests/unit/FileCollectorTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides;
+
+use Doctrine\Deprecations\Deprecation;
+use Flyfinder\Path;
+use Flyfinder\Specification\InPath;
+use phpDocumentor\FileSystem\FileSystem;
+use phpDocumentor\FileSystem\Finder\Exclude;
+use PHPUnit\Framework\TestCase;
+
+final class FileCollectorTest extends TestCase
+{
+    public function testCollectDoesNotTriggerDeprecationWhenNoExclusionIsPassed(): void
+    {
+        $filesystem = $this->createMock(FileSystem::class);
+        $filesystem->method('find')->willReturn([]);
+
+        $before = Deprecation::getUniqueTriggeredDeprecationsCount();
+
+        (new FileCollector())->collect($filesystem, 'docs', 'rst');
+
+        self::assertSame($before, Deprecation::getUniqueTriggeredDeprecationsCount());
+    }
+
+    public function testCollectDoesNotTriggerDeprecationWhenExcludeIsPassed(): void
+    {
+        $filesystem = $this->createMock(FileSystem::class);
+        $filesystem->method('find')->willReturn([]);
+
+        $before = Deprecation::getUniqueTriggeredDeprecationsCount();
+
+        (new FileCollector())->collect($filesystem, '', 'rst', new Exclude());
+
+        self::assertSame($before, Deprecation::getUniqueTriggeredDeprecationsCount());
+    }
+
+    public function testCollectTriggersDeprecationWhenSpecificationInterfaceIsPassed(): void
+    {
+        $filesystem = $this->createMock(FileSystem::class);
+        $filesystem->method('find')->willReturn([]);
+
+        $before = Deprecation::getUniqueTriggeredDeprecationsCount();
+
+        (new FileCollector())->collect(
+            $filesystem,
+            'docs',
+            'rst',
+            new InPath(new Path('docs')),
+        );
+
+        self::assertSame(
+            $before + 1,
+            Deprecation::getUniqueTriggeredDeprecationsCount(),
+        );
+    }
+}

--- a/packages/guides/tests/unit/Handlers/ParseDirectoryCommandTest.php
+++ b/packages/guides/tests/unit/Handlers/ParseDirectoryCommandTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\Handlers;
+
+use Doctrine\Deprecations\Deprecation;
+use Flyfinder\Path;
+use Flyfinder\Specification\InPath;
+use League\Flysystem\FilesystemInterface;
+use phpDocumentor\FileSystem\Finder\Exclude;
+use phpDocumentor\Guides\Nodes\ProjectNode;
+use PHPUnit\Framework\TestCase;
+
+final class ParseDirectoryCommandTest extends TestCase
+{
+    public function testNoDeprecationIsTriggeredWhenNoExclusionIsPassed(): void
+    {
+        $before = Deprecation::getUniqueTriggeredDeprecationsCount();
+
+        $command = new ParseDirectoryCommand(
+            $this->createMock(FilesystemInterface::class),
+            'docs',
+            'rst',
+            new ProjectNode(),
+        );
+
+        self::assertSame($before, Deprecation::getUniqueTriggeredDeprecationsCount());
+        self::assertFalse($command->hasExclude());
+        self::assertFalse($command->hasExcludedSpecification());
+    }
+
+    public function testNoDeprecationIsTriggeredWhenExcludeIsPassed(): void
+    {
+        $before = Deprecation::getUniqueTriggeredDeprecationsCount();
+
+        $command = new ParseDirectoryCommand(
+            $this->createMock(FilesystemInterface::class),
+            'docs',
+            'rst',
+            new ProjectNode(),
+            new Exclude(),
+        );
+
+        self::assertSame($before, Deprecation::getUniqueTriggeredDeprecationsCount());
+        self::assertTrue($command->hasExclude());
+        self::assertFalse($command->hasExcludedSpecification());
+    }
+
+    public function testDeprecationIsTriggeredWhenSpecificationInterfaceIsPassed(): void
+    {
+        $before = Deprecation::getUniqueTriggeredDeprecationsCount();
+
+        $command = new ParseDirectoryCommand(
+            $this->createMock(FilesystemInterface::class),
+            'docs',
+            'rst',
+            new ProjectNode(),
+            new InPath(new Path('docs')),
+        );
+
+        self::assertSame(
+            $before + 1,
+            Deprecation::getUniqueTriggeredDeprecationsCount(),
+        );
+        self::assertFalse($command->hasExclude());
+        self::assertTrue($command->hasExcludedSpecification());
+    }
+
+    public function testGetExcludeReturnsEmptyExcludeWhenNoneWasPassed(): void
+    {
+        $command = new ParseDirectoryCommand(
+            $this->createMock(FilesystemInterface::class),
+            'docs',
+            'rst',
+            new ProjectNode(),
+        );
+
+        self::assertEquals(new Exclude(), $command->getExclude());
+    }
+
+    public function testGetExcludedSpecificationReturnsTheStoredSpecification(): void
+    {
+        $specification = new InPath(new Path('docs'));
+        $command = new ParseDirectoryCommand(
+            $this->createMock(FilesystemInterface::class),
+            'docs',
+            'rst',
+            new ProjectNode(),
+            $specification,
+        );
+
+        self::assertSame($specification, $command->getExcludedSpecification());
+    }
+}

--- a/packages/guides/tests/unit/Handlers/ParseDirectoryHandlerTest.php
+++ b/packages/guides/tests/unit/Handlers/ParseDirectoryHandlerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\Handlers;
+
+use Doctrine\Deprecations\Deprecation;
+use Flyfinder\Path;
+use Flyfinder\Specification\InPath;
+use League\Tactician\CommandBus;
+use phpDocumentor\FileSystem\FileSystem;
+use phpDocumentor\FileSystem\Finder\Exclude;
+use phpDocumentor\Guides\FileCollector;
+use phpDocumentor\Guides\Nodes\ProjectNode;
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
+
+final class ParseDirectoryHandlerTest extends TestCase
+{
+    public function testHandlerForwardsExcludeToCollectorWithoutTriggeringSpecificationDeprecation(): void
+    {
+        $command = $this->createCommand(new Exclude(['/excluded']));
+        $handler = $this->createHandler();
+
+        $before = Deprecation::getUniqueTriggeredDeprecationsCount();
+
+        $handler->handle($command);
+
+        self::assertSame($before, Deprecation::getUniqueTriggeredDeprecationsCount());
+    }
+
+    public function testHandlerDoesNotTriggerDeprecationWhenNoExclusionIsConfigured(): void
+    {
+        $command = $this->createCommand();
+        $handler = $this->createHandler();
+
+        $before = Deprecation::getUniqueTriggeredDeprecationsCount();
+
+        $handler->handle($command);
+
+        self::assertSame($before, Deprecation::getUniqueTriggeredDeprecationsCount());
+    }
+
+    public function testHandlerForwardsLegacySpecificationWithoutFiringExtraDeprecation(): void
+    {
+        $command = $this->createCommand(new InPath(new Path('docs')));
+        $handler = $this->createHandler();
+
+        $before = Deprecation::getUniqueTriggeredDeprecationsCount();
+
+        $handler->handle($command);
+
+        self::assertSame(
+            $before,
+            Deprecation::getUniqueTriggeredDeprecationsCount(),
+            'Internal handler dispatch must not re-fire the deprecation already raised at construction.',
+        );
+    }
+
+    private function createCommand(Exclude|InPath|null $exclusion = null): ParseDirectoryCommand
+    {
+        $filesystem = $this->createMock(FileSystem::class);
+        $filesystem->method('listContents')->willReturn([['basename' => 'index.rst']]);
+        $filesystem->method('find')->willReturn([]);
+
+        return new ParseDirectoryCommand(
+            $filesystem,
+            '',
+            'rst',
+            new ProjectNode(),
+            $exclusion,
+        );
+    }
+
+    private function createHandler(): ParseDirectoryHandler
+    {
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->method('dispatch')->willReturnCallback(
+            static fn (object $event): object => $event,
+        );
+
+        return new ParseDirectoryHandler(
+            new FileCollector(),
+            $this->createMock(CommandBus::class),
+            $eventDispatcher,
+        );
+    }
+}


### PR DESCRIPTION
refs #1209.

`FileCollector::collect()` now emits a deprecation when a `Flyfinder\Specification\SpecificationInterface` is passed; users should switch to `phpDocumentor\FileSystem\Finder\Exclude` (which the collector already supports). The deprecation message in `ParseDirectoryCommand` is also fixed (concatenation typos, missing spaces) and uses sprintf placeholders.

Side bugfix: `ParseDirectoryHandler` no longer triggers the deprecation when no exclusion is supplied. It used to call `getExcludedSpecification()` unconditionally on the fallback branch, which fired the deprecation even when the caller did nothing wrong. A new `hasExcludedSpecification()` getter on the command lets the handler choose without touching the deprecated path. Internal call sites use `Deprecation::triggerIfCalledFromOutside()` so user-facing notices stay scoped to actual user code.

Tests added for both `FileCollector::collect()` and `ParseDirectoryCommand` covering the three input variants (null, Exclude, SpecificationInterface).