### PR TITLE
Treat explicit markup lines as non-titles in RST parser

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Parser/LineChecker.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/LineChecker.php
@@ -91,4 +91,15 @@ final class LineChecker
     {
         return preg_match('/^\.\.\s+\[([#a-zA-Z0-9]*)\]\s(.*)$$/mUsi', $line) > 0;
     }
+
+    /**
+     * RST explicit markup blocks (anchors, comments, directives, ...) start with two
+     * dots followed by whitespace, or are a lonely `..`.
+     *
+     * @link https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#explicit-markup-blocks
+     */
+    public static function isExplicitMarkup(string $line): bool
+    {
+        return preg_match('/^\.\.(\s.*|)$/mUsi', $line) > 0;
+    }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/TitleRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/TitleRule.php
@@ -24,7 +24,6 @@ use Symfony\Component\String\Slugger\AsciiSlugger;
 
 use function mb_strlen;
 use function min;
-use function preg_match;
 use function trim;
 
 /**
@@ -45,7 +44,7 @@ final class TitleRule implements Rule
         $line = $blockContext->getDocumentIterator()->current();
         $nextLine = $blockContext->getDocumentIterator()->getNextLine();
 
-        if ($this->isExplicitMarkup($line)) {
+        if (LineChecker::isExplicitMarkup($line)) {
             return false;
         }
 
@@ -112,17 +111,5 @@ final class TitleRule implements Rule
         }
 
         return $letter ?? '';
-    }
-
-    /**
-     * RST explicit markup blocks (anchors, comments, directives, ...) start with two
-     * dots followed by whitespace, or are a lonely `..`. Such a line must never be
-     * treated as a section title, even if the next line happens to look like an underline.
-     *
-     * @see https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#explicit-markup-blocks
-     */
-    private function isExplicitMarkup(string $line): bool
-    {
-        return preg_match('/^\.\.(?:\s|$)/', $line) === 1;
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/TitleRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/TitleRule.php
@@ -24,6 +24,7 @@ use Symfony\Component\String\Slugger\AsciiSlugger;
 
 use function mb_strlen;
 use function min;
+use function preg_match;
 use function trim;
 
 /**
@@ -43,6 +44,10 @@ final class TitleRule implements Rule
     {
         $line = $blockContext->getDocumentIterator()->current();
         $nextLine = $blockContext->getDocumentIterator()->getNextLine();
+
+        if ($this->isExplicitMarkup($line)) {
+            return false;
+        }
 
         return $this->currentLineIsAnOverline($line, $nextLine)
             || $this->nextLineIsAnUnderline($line, $nextLine);
@@ -107,5 +112,17 @@ final class TitleRule implements Rule
         }
 
         return $letter ?? '';
+    }
+
+    /**
+     * RST explicit markup blocks (anchors, comments, directives, ...) start with two
+     * dots followed by whitespace, or are a lonely `..`. Such a line must never be
+     * treated as a section title, even if the next line happens to look like an underline.
+     *
+     * @see https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#explicit-markup-blocks
+     */
+    private function isExplicitMarkup(string $line): bool
+    {
+        return preg_match('/^\.\.(?:\s|$)/', $line) === 1;
     }
 }

--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/TitleRuleTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/TitleRuleTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\RestructuredText\Parser\Productions;
+
+use Generator;
+use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
+use phpDocumentor\Guides\Nodes\InlineCompoundNode;
+use phpDocumentor\Guides\RestructuredText\Parser\InlineParser;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class TitleRuleTest extends RuleTestCase
+{
+    private TitleRule $rule;
+
+    protected function setUp(): void
+    {
+        $inlineParser = $this->createMock(InlineParser::class);
+        $inlineParser->method('parse')->willReturnCallback(
+            static fn (string $text): InlineCompoundNode => new InlineCompoundNode([new PlainTextInlineNode($text)]),
+        );
+
+        $this->rule = new TitleRule($inlineParser);
+    }
+
+    #[DataProvider('provideTitleLines')]
+    public function testAppliesToRegularTitleUnderline(string $content): void
+    {
+        self::assertTrue($this->rule->applies($this->createContext($content)));
+    }
+
+    /** @return Generator<string, array{string}> */
+    public static function provideTitleLines(): Generator
+    {
+        yield 'underline' => ["Title\n=====\n"];
+        yield 'overline + underline' => ["=====\nTitle\n=====\n"];
+        yield 'paragraph starting with three dots is not explicit markup' => ["... and so on\n=============\n"];
+    }
+
+    #[DataProvider('provideExplicitMarkupLines')]
+    public function testDoesNotApplyToExplicitMarkupLineFollowedByUnderline(string $content): void
+    {
+        self::assertFalse($this->rule->applies($this->createContext($content)));
+    }
+
+    /** @return Generator<string, array{string}> */
+    public static function provideExplicitMarkupLines(): Generator
+    {
+        yield 'anchor with single space' => [".. _foo:\n========\n"];
+        yield 'anchor with double space' => ["..  _foo:\n========\n"];
+        yield 'anchor with tab' => [".. \t_foo:\n========\n"];
+        yield 'directive' => [".. note::\n=========\n"];
+        yield 'comment' => [".. some comment\n===============\n"];
+        yield 'lonely double dot' => ["..\n==\n"];
+    }
+}

--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/TitleRuleTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/TitleRuleTest.php
@@ -59,6 +59,8 @@ final class TitleRuleTest extends RuleTestCase
         yield 'anchor with single space' => [".. _foo:\n========\n"];
         yield 'anchor with double space' => ["..  _foo:\n========\n"];
         yield 'anchor with tab' => [".. \t_foo:\n========\n"];
+        yield 'anchor above level-2 underline' => [".. _foo:\n--------\n"];
+        yield 'phrase reference anchor' => [".. _`Foo Bar`:\n==============\n"];
         yield 'directive' => [".. note::\n=========\n"];
         yield 'comment' => [".. some comment\n===============\n"];
         yield 'lonely double dot' => ["..\n==\n"];

--- a/tests/Integration/tests/anchor/anchor-no-blank-line-stacked/expected/index.html
+++ b/tests/Integration/tests/anchor/anchor-no-blank-line-stacked/expected/index.html
@@ -1,0 +1,16 @@
+<!-- content start -->
+    <div class="section" id="release-notes-1">
+            <a id="changelog"></a>
+            <a id="release-notes"></a>
+            <h1>Release Notes</h1>
+
+    <p>Some content</p>
+
+
+    <p>This points to release notes: <a href="/index.html#release-notes">Release Notes</a></p>
+
+
+    <p>This points to changelog: <a href="/index.html#changelog">Release Notes</a></p>
+
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/anchor/anchor-no-blank-line-stacked/input/index.rst
+++ b/tests/Integration/tests/anchor/anchor-no-blank-line-stacked/input/index.rst
@@ -1,0 +1,10 @@
+.. _release-notes:
+.. _changelog:
+Release Notes
+=============
+
+Some content
+
+This points to release notes: :ref:`release-notes`
+
+This points to changelog: :ref:`changelog`

--- a/tests/Integration/tests/anchor/anchor-no-blank-line/expected/index.html
+++ b/tests/Integration/tests/anchor/anchor-no-blank-line/expected/index.html
@@ -1,0 +1,16 @@
+<!-- content start -->
+    <div class="section" id="typo3-cms-system-notes-1">
+            <a id="typo3-cms-system-notes"></a>
+            <h1>TYPO3 CMS System Notes</h1>
+    </div>
+<div class="section" id="feature-99911-1">
+            <a id="feature-99911"></a>
+            <h1>Feature: 99911</h1>
+
+    <p>This is a link to system notes: <a href="/index.html#typo3-cms-system-notes">TYPO3 CMS System Notes</a></p>
+
+
+    <p>This is a link to feature: <a href="/index.html#feature-99911">Feature: 99911</a></p>
+
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/anchor/anchor-no-blank-line/input/index.rst
+++ b/tests/Integration/tests/anchor/anchor-no-blank-line/input/index.rst
@@ -1,0 +1,13 @@
+..  _typo3-cms-system-notes:
+============================
+TYPO3 CMS System Notes
+============================
+
+.. _feature-99911:
+==================
+Feature: 99911
+==================
+
+This is a link to system notes: :ref:`typo3-cms-system-notes`
+
+This is a link to feature: :ref:`feature-99911`


### PR DESCRIPTION
Closes #1240.

When an anchor (or any explicit markup line like a comment or directive) sits directly above a section underline without an intervening blank line, the parser used to greedily treat the markup line as the section title text. With this change, `TitleRule::applies()` skips lines that start with `..` followed by whitespace (or a lonely `..`), so the body rules (e.g. `LinkRule`) can claim them and the next paragraph becomes the actual title, exactly as docutils does.

Validated by a new integration fixture `anchor-no-blank-line/` covering both single-space and double-space anchors directly above section titles.