### PR TITLE
Skip asset copy when destination already has the file

### DIFF
--- a/packages/guides/src/Twig/AssetsExtension.php
+++ b/packages/guides/src/Twig/AssetsExtension.php
@@ -178,6 +178,11 @@ final class AssetsExtension extends AbstractExtension
                 return $outputPath;
             }
 
+            $destination = $renderContext->getDestination();
+            if ($destination->has($outputPath)) {
+                return $outputPath;
+            }
+
             $fileContents = $renderContext->getOrigin()->read($normalizedSourcePath);
             if ($fileContents === false) {
                 $this->logger->error(
@@ -188,7 +193,7 @@ final class AssetsExtension extends AbstractExtension
                 return $outputPath;
             }
 
-            $result = $renderContext->getDestination()->put($outputPath, $fileContents);
+            $result = $destination->put($outputPath, $fileContents);
             if ($result === false) {
                 $this->logger->error(
                     sprintf('Unable to write file "%s"', $outputPath),

--- a/packages/guides/tests/unit/Twig/AssetsExtensionTest.php
+++ b/packages/guides/tests/unit/Twig/AssetsExtensionTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\Twig;
+
+use League\Flysystem\FilesystemInterface;
+use phpDocumentor\Guides\NodeRenderers\NodeRenderer;
+use phpDocumentor\Guides\ReferenceResolvers\DocumentNameResolverInterface;
+use phpDocumentor\Guides\RenderContext;
+use phpDocumentor\Guides\Renderer\UrlGenerator\UrlGeneratorInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+final class AssetsExtensionTest extends TestCase
+{
+    private DocumentNameResolverInterface&MockObject $documentNameResolver;
+    private UrlGeneratorInterface&MockObject $urlGenerator;
+    private LoggerInterface&MockObject $logger;
+    private AssetsExtension $extension;
+
+    protected function setUp(): void
+    {
+        $this->documentNameResolver = self::createMock(DocumentNameResolverInterface::class);
+        $this->urlGenerator = self::createMock(UrlGeneratorInterface::class);
+        $this->logger = self::createMock(LoggerInterface::class);
+        $this->extension = new AssetsExtension(
+            $this->logger,
+            self::createMock(NodeRenderer::class),
+            $this->documentNameResolver,
+            $this->urlGenerator,
+        );
+    }
+
+    private function stubRenderContext(): RenderContext&MockObject
+    {
+        $renderContext = self::createMock(RenderContext::class);
+        $renderContext->method('getDirName')->willReturn('docs/cli');
+        $renderContext->method('getDestinationPath')->willReturn('/guides');
+        $this->documentNameResolver->method('canonicalUrl')
+            ->willReturn('docs/cli/first-docs.png');
+        $this->documentNameResolver->method('absoluteUrl')
+            ->willReturn('/guides/docs/cli/first-docs.png');
+        $this->urlGenerator->method('generateInternalUrl')
+            ->willReturn('docs/cli/first-docs.png');
+
+        return $renderContext;
+    }
+
+    /** @link https://github.com/phpDocumentor/phpDocumentor/issues/3635 */
+    public function testAssetSkipsCopyWhenDestinationAlreadyHasTheFile(): void
+    {
+        $renderContext = $this->stubRenderContext();
+        $origin = self::createMock(FilesystemInterface::class);
+        $destination = self::createMock(FilesystemInterface::class);
+        $renderContext->method('getOrigin')->willReturn($origin);
+        $renderContext->method('getDestination')->willReturn($destination);
+
+        $origin->method('has')->with('docs/cli/first-docs.png')->willReturn(true);
+        $destination->method('has')->with('/guides/docs/cli/first-docs.png')->willReturn(true);
+
+        $origin->expects(self::never())->method('read');
+        $destination->expects(self::never())->method('put');
+        $this->logger->expects(self::never())->method('error');
+
+        $this->extension->asset(['env' => $renderContext], 'first-docs.png');
+    }
+
+    public function testAssetCopiesWhenDestinationDoesNotHaveTheFile(): void
+    {
+        $renderContext = $this->stubRenderContext();
+        $origin = self::createMock(FilesystemInterface::class);
+        $destination = self::createMock(FilesystemInterface::class);
+        $renderContext->method('getOrigin')->willReturn($origin);
+        $renderContext->method('getDestination')->willReturn($destination);
+
+        $origin->method('has')->with('docs/cli/first-docs.png')->willReturn(true);
+        $origin->method('read')->with('docs/cli/first-docs.png')->willReturn('PNG BYTES');
+        $destination->method('has')->with('/guides/docs/cli/first-docs.png')->willReturn(false);
+
+        $destination->expects(self::once())
+            ->method('put')
+            ->with('/guides/docs/cli/first-docs.png', 'PNG BYTES')
+            ->willReturn(true);
+        $this->logger->expects(self::never())->method('error');
+
+        $this->extension->asset(['env' => $renderContext], 'first-docs.png');
+    }
+
+    /** @link https://github.com/phpDocumentor/phpDocumentor/issues/3635 */
+    public function testAssetIsIdempotentAcrossConsecutiveCalls(): void
+    {
+        $renderContext = $this->stubRenderContext();
+        $origin = self::createMock(FilesystemInterface::class);
+        $destination = self::createMock(FilesystemInterface::class);
+        $renderContext->method('getOrigin')->willReturn($origin);
+        $renderContext->method('getDestination')->willReturn($destination);
+
+        $origin->method('has')->with('docs/cli/first-docs.png')->willReturn(true);
+        $origin->expects(self::once())
+            ->method('read')
+            ->with('docs/cli/first-docs.png')
+            ->willReturn('PNG BYTES');
+        $destination->method('has')
+            ->with('/guides/docs/cli/first-docs.png')
+            ->willReturnOnConsecutiveCalls(false, true);
+
+        $destination->expects(self::once())
+            ->method('put')
+            ->with('/guides/docs/cli/first-docs.png', 'PNG BYTES')
+            ->willReturn(true);
+        $this->logger->expects(self::never())->method('error');
+
+        $this->extension->asset(['env' => $renderContext], 'first-docs.png');
+        $this->extension->asset(['env' => $renderContext], 'first-docs.png');
+    }
+}


### PR DESCRIPTION
When an RST project references the same image from multiple documents, `AssetsExtension::copyAsset` calls `$destination->put()` once per reference. On repeat copies the Flysystem Local adapter re-enters `ensureDirectory()` and, on Flysystem v1, logs a noisy `Impossible to create the root directory ... mkdir(): File exist` error even though the HTML output itself is fine (see phpDocumentor/phpDocumentor#3635; v3 self-guards via `is_dir()` before `mkdir`).

Short-circuit the copy when the destination already reports the target path: one extra stat per asset reference, no redundant `put`, no noisy mkdir attempt on repeat renders. The scope of this change is explicit: it silences the error for the *repeat render* case that matches the reporter's symptom. A collision where a non-directory already lives at the parent path (someone else put a bare file there) is out of scope, and the error in that case remains meaningful.

A new `AssetsExtensionTest` covers the skip path, the first-copy path, and idempotency across two consecutive `asset()` calls, and asserts no error is logged on those happy paths.

refs https://github.com/phpDocumentor/phpDocumentor/issues/3635