### PR TITLE
[BUGFIX] Skip symbolic links instead of aborting the file listing

### DIFF
--- a/packages/filesystem/src/FlySystemAdapter.php
+++ b/packages/filesystem/src/FlySystemAdapter.php
@@ -23,6 +23,8 @@ use phpDocumentor\FileSystem\FlysystemV3\FlysystemV3;
 
 use function class_exists;
 
+use const LOCK_EX;
+
 class FlySystemAdapter implements FileSystem
 {
     public function __construct(

--- a/packages/filesystem/src/FlySystemAdapter.php
+++ b/packages/filesystem/src/FlySystemAdapter.php
@@ -34,11 +34,11 @@ class FlySystemAdapter implements FileSystem
     {
         if (class_exists(Local::class)) {
             /** @phpstan-ignore-next-line */
-            $filesystem = new FlysystemV1(new LeagueFilesystem(new Local($path)));
+            $filesystem = new FlysystemV1(new LeagueFilesystem(new Local($path, LOCK_EX, Local::SKIP_LINKS)));
         } else {
             $filesystem = new FlysystemV3(
                 new LeagueFilesystem(
-                    new LocalFilesystemAdapter($path),
+                    new LocalFilesystemAdapter($path, linkHandling: LocalFilesystemAdapter::SKIP_LINKS),
                 ),
             );
         }

--- a/packages/filesystem/src/FlySystemAdapter.php
+++ b/packages/filesystem/src/FlySystemAdapter.php
@@ -34,11 +34,11 @@ class FlySystemAdapter implements FileSystem
     {
         if (class_exists(Local::class)) {
             /** @phpstan-ignore-next-line */
-            $filesystem = new FlysystemV1(new LeagueFilesystem(new Local($path)));
+            $filesystem = new FlysystemV1(new LeagueFilesystem(new Local($path, linkHandling: Local::SKIP_LINKS)));
         } else {
             $filesystem = new FlysystemV3(
                 new LeagueFilesystem(
-                    new LocalFilesystemAdapter($path),
+                    new LocalFilesystemAdapter($path, linkHandling: LocalFilesystemAdapter::SKIP_LINKS),
                 ),
             );
         }

--- a/packages/filesystem/tests/unit/FlySystemAdapterTest.php
+++ b/packages/filesystem/tests/unit/FlySystemAdapterTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\FileSystem;
+
+use PHPUnit\Framework\TestCase;
+
+use function array_map;
+use function file_put_contents;
+use function is_dir;
+use function is_link;
+use function mkdir;
+use function rmdir;
+use function scandir;
+use function symlink;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+use const DIRECTORY_SEPARATOR;
+
+final class FlySystemAdapterTest extends TestCase
+{
+    private string $root;
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('guides-fs-', true);
+        mkdir($this->root, 0777, true);
+
+        file_put_contents($this->root . DIRECTORY_SEPARATOR . 'index.rst', 'Index');
+
+        if (@symlink($this->root . DIRECTORY_SEPARATOR . 'index.rst', $this->root . DIRECTORY_SEPARATOR . 'link.rst') !== false) {
+            return;
+        }
+
+        self::markTestSkipped('The filesystem does not support symbolic links');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->remove($this->root);
+    }
+
+    public function testItListsADirectoryContainingSymbolicLinksInsteadOfAborting(): void
+    {
+        $contents = FlySystemAdapter::createForPath($this->root)->listContents('');
+
+        $names = array_map(static fn (StorageAttributes $item): mixed => $item['basename'], $contents);
+
+        self::assertContains('index.rst', $names, 'A regular file next to a symbolic link must still be listed');
+        self::assertNotContains('link.rst', $names, 'A symbolic link is skipped rather than aborting the listing');
+    }
+
+    /** Removes a tree without following the symbolic links inside it. */
+    private function remove(string $path): void
+    {
+        if (is_link($path) || !is_dir($path)) {
+            unlink($path);
+
+            return;
+        }
+
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $this->remove($path . DIRECTORY_SEPARATOR . $entry);
+        }
+
+        rmdir($path);
+    }
+}


### PR DESCRIPTION
## Problem

`FlySystemAdapter::createForPath()` builds the Local adapter with the default link-handling mode, which is `DISALLOW_LINKS` in both `league/flysystem` v1 and v3. Any symbolic link met during `listContents()` aborts the caller — v1 with `NotSupportedException`, v3 with `SymbolicLinkEncountered` inside `UnableToListContents`.

`ParseDirectoryHandler` uses that listing to find the entrypoint of an input directory, so one symlink anywhere in the tree kills the whole render, including links to files the parser would never read — `CLAUDE.md -> AGENTS.md` for cross-tool AI instructions, vendored references, build artefacts. Excluding the path does not help: the listing walks it before any exclusion applies.

Downstream report in the TYPO3 render-guides wrapper: [TYPO3-Documentation/render-guides#1234](https://github.com/TYPO3-Documentation/render-guides/issues/1234).

## Fix

`SKIP_LINKS` as the `linkHandling` argument on both adapters. Two lines.

```diff
-            $filesystem = new FlysystemV1(new LeagueFilesystem(new Local($path)));
+            $filesystem = new FlysystemV1(new LeagueFilesystem(new Local($path, linkHandling: Local::SKIP_LINKS)));
         } else {
             $filesystem = new FlysystemV3(
                 new LeagueFilesystem(
-                    new LocalFilesystemAdapter($path),
+                    new LocalFilesystemAdapter($path, linkHandling: LocalFilesystemAdapter::SKIP_LINKS),
```

The stance towards symbolic links is unchanged — they are still not followed. Only the reaction changes, from aborting the run to leaving the entry out of the listing.

`DISALLOW_LINKS` with the exception caught at the call sites would have been the alternative. `SKIP_LINKS` is narrower: it fixes every caller at once and needs no error handling in `ParseDirectoryHandler` or in any future consumer.

## What a missing document still looks like

Skipping is not silent where it matters. A symlinked document referenced from a toctree is reported by the existing menu resolution, naming both the entry and the file that references it:

```
app.WARNING: Menu entry "chapter/page" was not found in the document tree. Ignoring it. {"rst-file":"index.rst"}
```

An earlier revision of this branch added a dedicated warning for skipped links. It was dropped: it restated what the menu already says, and it fired for links whose target does not exist — the kind a partial `composer install --no-dev` leaves in `vendor/bin` — turning a passing build into a failing one for a document that was never missing.

One case is not improved by this PR and is worth naming: when the index file itself is a symlink, the run still aborts, now with `Could not find an index file` instead of the Flysystem exception. The file is sitting in plain sight, so that message is misleading. Fixing it needs the handler to explain why the file was not seen, which is a separate change.

## Tests

`packages/filesystem/tests/unit/FlySystemAdapterTest.php` lists a directory holding a regular file next to a symbolic link and asserts the regular file is listed while the link is not.

The guard was checked against a reverted fix on both branches: without `SKIP_LINKS` it fails with `NotSupportedException` on flysystem v1 and with `SymbolicLinkEncountered` on v3.

Run locally across the full CI matrix, 5 PHP versions times lowest/locked/highest, 15 cells, 829 tests each, no failures. The `lowest` column resolves flysystem to 1.1.4 and exercises the v1 branch; `locked` and `highest` run v3.

| PHP | lowest (v1) | locked (v3) | highest (v3) |
| --- | --- | --- | --- |
| 8.1 | pass | pass | pass |
| 8.2 | pass | pass | pass |
| 8.3 | pass | pass | pass |
| 8.4 | pass | pass | pass |
| 8.5 | pass | pass | pass |

## Reproduction

```bash
ln -s AGENTS.md Documentation/CLAUDE.md
docker run --rm -v "$PWD:/project" -w /project \
  ghcr.io/typo3-documentation/render-guides:latest \
  render --config=Documentation --output=out Documentation
```

Fails on `main`, passes with this branch.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_0114KJz3vqq2WWfx4FUdmcss)_
