### PR TITLE
[BUGFIX] Keep navigation menu in toctree order when mixing internal and external entries

### DIFF
--- a/packages/guides/src/Compiler/NodeTransformers/MenuNodeTransformers/ToctreeSortingTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/MenuNodeTransformers/ToctreeSortingTransformer.php
@@ -15,11 +15,18 @@ namespace phpDocumentor\Guides\Compiler\NodeTransformers\MenuNodeTransformers;
 
 use phpDocumentor\Guides\Compiler\CompilerContext;
 use phpDocumentor\Guides\Compiler\NodeTransformer;
+use phpDocumentor\Guides\Nodes\DocumentTree\DocumentEntryNode;
+use phpDocumentor\Guides\Nodes\DocumentTree\ExternalEntryNode;
+use phpDocumentor\Guides\Nodes\Menu\MenuEntryNode;
 use phpDocumentor\Guides\Nodes\Menu\TocNode;
 use phpDocumentor\Guides\Nodes\Node;
 
+use function array_key_first;
 use function array_reverse;
+use function array_values;
+use function count;
 use function is_array;
+use function ksort;
 
 /** @implements NodeTransformer<TocNode> */
 final class ToctreeSortingTransformer implements NodeTransformer
@@ -35,22 +42,108 @@ final class ToctreeSortingTransformer implements NodeTransformer
             return $node;
         }
 
-        if (!$node->isReversed()) {
+        $entries = $node->getValue();
+        if (!is_array($entries)) {
             return $node;
         }
 
-        $entries = $node->getValue();
         $documentEntry = $compilerContext->getDocumentNode()->getDocumentEntry();
-        $documentMenuEntries = $documentEntry->getMenuEntries();
-        if (is_array($entries)) {
+
+        if ($node->isReversed()) {
             $entries = array_reverse($entries);
-            $documentMenuEntries = array_reverse($documentMenuEntries);
+            $node->setValue($entries);
+            $documentEntry->setMenuEntries(array_reverse($documentEntry->getMenuEntries()));
         }
 
-        $documentEntry->setMenuEntries($documentMenuEntries);
-        $node->setValue($entries);
+        // The document entry's menu entries (used to build the navigation menu)
+        // are attached by separate transformers for internal and external menu
+        // entries, each running in its own full tree traversal. As a result the
+        // menu entries end up grouped by type instead of following the authored
+        // toctree order, so the navigation menu disagrees with the order shown
+        // on the page. Realign them with the toctree. Globbed toctrees are
+        // skipped: their order is defined by the glob expansion, not by an
+        // authored sequence.
+        if (!$node->hasOption('glob')) {
+            $documentEntry->setMenuEntries(
+                $this->sortMenuEntriesByToctree($entries, $documentEntry->getMenuEntries()),
+            );
+        }
 
         return $node;
+    }
+
+    /**
+     * Reorders the menu entries that belong to this toctree so they follow the
+     * authored toctree order. The toctree's entries are emitted as one
+     * contiguous block at the position of its first entry; entries that belong
+     * to other toctrees of the same document keep their relative position.
+     * Applied per toctree in document order, this yields the global authored
+     * order even when a document has several toctrees.
+     *
+     * @param array<MenuEntryNode> $tocEntries
+     * @param array<DocumentEntryNode|ExternalEntryNode> $menuEntries
+     *
+     * @return array<DocumentEntryNode|ExternalEntryNode>
+     */
+    private function sortMenuEntriesByToctree(array $tocEntries, array $menuEntries): array
+    {
+        // Map each authored toctree entry to its position. The key match relies
+        // on the entry urls having been resolved to the document file (internal)
+        // or external url by the attach transformers (priority 4500), which run
+        // before this pass.
+        $order = [];
+        $position = 0;
+        foreach ($tocEntries as $tocEntry) {
+            if (!($tocEntry instanceof MenuEntryNode)) {
+                continue;
+            }
+
+            $order[$tocEntry->getUrl()] = $position++;
+        }
+
+        $ordered = [];
+        $matchedIndexes = [];
+        foreach ($menuEntries as $index => $menuEntry) {
+            $key = self::menuEntryKey($menuEntry);
+            if (!isset($order[$key])) {
+                continue;
+            }
+
+            $ordered[$order[$key]] = $menuEntry;
+            $matchedIndexes[$index] = true;
+        }
+
+        // Safety: bail out when entries do not map one-to-one (e.g. the rare
+        // case of duplicate entries within a single toctree).
+        if ($matchedIndexes === [] || count($ordered) !== count($matchedIndexes)) {
+            return $menuEntries;
+        }
+
+        ksort($ordered);
+        $ordered = array_values($ordered);
+        $firstIndex = array_key_first($matchedIndexes);
+
+        $result = [];
+        foreach ($menuEntries as $index => $menuEntry) {
+            if ($index === $firstIndex) {
+                foreach ($ordered as $orderedEntry) {
+                    $result[] = $orderedEntry;
+                }
+            }
+
+            if (isset($matchedIndexes[$index])) {
+                continue;
+            }
+
+            $result[] = $menuEntry;
+        }
+
+        return $result;
+    }
+
+    private static function menuEntryKey(DocumentEntryNode|ExternalEntryNode $entry): string
+    {
+        return $entry instanceof DocumentEntryNode ? $entry->getFile() : $entry->getValue();
     }
 
     public function leaveNode(Node $node, CompilerContext $compilerContext): Node|null

--- a/packages/guides/src/Compiler/NodeTransformers/MenuNodeTransformers/ToctreeSortingTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/MenuNodeTransformers/ToctreeSortingTransformer.php
@@ -15,11 +15,18 @@ namespace phpDocumentor\Guides\Compiler\NodeTransformers\MenuNodeTransformers;
 
 use phpDocumentor\Guides\Compiler\CompilerContext;
 use phpDocumentor\Guides\Compiler\NodeTransformer;
+use phpDocumentor\Guides\Nodes\DocumentTree\DocumentEntryNode;
+use phpDocumentor\Guides\Nodes\DocumentTree\ExternalEntryNode;
+use phpDocumentor\Guides\Nodes\Menu\MenuEntryNode;
 use phpDocumentor\Guides\Nodes\Menu\TocNode;
 use phpDocumentor\Guides\Nodes\Node;
 
+use function array_key_first;
 use function array_reverse;
+use function array_values;
+use function count;
 use function is_array;
+use function ksort;
 
 /** @implements NodeTransformer<TocNode> */
 final class ToctreeSortingTransformer implements NodeTransformer
@@ -35,22 +42,108 @@ final class ToctreeSortingTransformer implements NodeTransformer
             return $node;
         }
 
-        if (!$node->isReversed()) {
+        $entries = $node->getValue();
+        if (!is_array($entries)) {
             return $node;
         }
 
-        $entries = $node->getValue();
         $documentEntry = $compilerContext->getDocumentNode()->getDocumentEntry();
-        $documentMenuEntries = $documentEntry->getMenuEntries();
-        if (is_array($entries)) {
+
+        if ($node->isReversed()) {
             $entries = array_reverse($entries);
-            $documentMenuEntries = array_reverse($documentMenuEntries);
+            $node->setValue($entries);
+            $documentEntry->setMenuEntries(array_reverse($documentEntry->getMenuEntries()));
         }
 
-        $documentEntry->setMenuEntries($documentMenuEntries);
-        $node->setValue($entries);
+        // The document entry's menu entries (used to build the navigation menu)
+        // are attached by separate transformers for internal and external menu
+        // entries, each running in its own full tree traversal. As a result the
+        // menu entries end up grouped by type instead of following the authored
+        // toctree order, so the navigation menu disagrees with the order shown
+        // on the page. Realign them with the toctree. Globbed toctrees are
+        // skipped: their order is defined by the glob expansion, not by an
+        // authored sequence.
+        if (!$node->hasOption('glob')) {
+            $documentEntry->setMenuEntries(
+                $this->sortMenuEntriesByToctree($entries, $documentEntry->getMenuEntries()),
+            );
+        }
 
         return $node;
+    }
+
+    /**
+     * Reorders the menu entries that belong to this toctree so they follow the
+     * authored toctree order. The toctree's entries are emitted as one
+     * contiguous block at the position of its first entry; entries that belong
+     * to other toctrees of the same document keep their relative position.
+     * Applied per toctree in document order, this yields the global authored
+     * order even when a document has several toctrees.
+     *
+     * @param array<MenuEntryNode> $tocEntries
+     * @param array<DocumentEntryNode|ExternalEntryNode> $menuEntries
+     *
+     * @return array<DocumentEntryNode|ExternalEntryNode>
+     */
+    private function sortMenuEntriesByToctree(array $tocEntries, array $menuEntries): array
+    {
+        // Map each authored toctree entry to its position. The key match relies
+        // on the entry urls having been resolved to the document file (internal)
+        // or external url by the attach transformers (priority 4500), which run
+        // before this pass.
+        $order = [];
+        $position = 0;
+        foreach ($tocEntries as $tocEntry) {
+            if (!($tocEntry instanceof MenuEntryNode)) {
+                continue;
+            }
+
+            $order[$tocEntry->getUrl()] = $position++;
+        }
+
+        $ordered = [];
+        $matchedIndexes = [];
+        foreach ($menuEntries as $index => $menuEntry) {
+            $key = self::menuEntryKey($menuEntry);
+            if (!isset($order[$key])) {
+                continue;
+            }
+
+            $ordered[$order[$key]] = $menuEntry;
+            $matchedIndexes[$index] = true;
+        }
+
+        // Safety: bail out when entries do not map one-to-one (e.g. the rare
+        // case of duplicate entries within a single toctree).
+        if ($matchedIndexes === [] || count($ordered) !== count($matchedIndexes)) {
+            return $menuEntries;
+        }
+
+        ksort($ordered);
+        $ordered = array_values($ordered);
+        $firstIndex = array_key_first($matchedIndexes);
+
+        $result = [];
+        foreach ($menuEntries as $index => $menuEntry) {
+            if ($index === $firstIndex) {
+                foreach ($ordered as $orderedEntry) {
+                    $result[] = $orderedEntry;
+                }
+            }
+
+            if (isset($matchedIndexes[$index])) {
+                continue;
+            }
+
+            $result[] = $menuEntry;
+        }
+
+        return $result;
+    }
+
+    private static function menuEntryKey(DocumentEntryNode|ExternalEntryNode $entry): string
+    {
+        return $entry instanceof DocumentEntryNode ? $entry->getFile() : $entry->getValue();
     }
 
     public function leaveNode(Node $node, CompilerContext $compilerContext): Node

--- a/packages/guides/src/Compiler/NodeTransformers/MenuNodeTransformers/ToctreeSortingTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/MenuNodeTransformers/ToctreeSortingTransformer.php
@@ -19,14 +19,13 @@ use phpDocumentor\Guides\Nodes\CompoundNode;
 use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\Nodes\DocumentTree\DocumentEntryNode;
 use phpDocumentor\Guides\Nodes\DocumentTree\ExternalEntryNode;
-use phpDocumentor\Guides\Nodes\Menu\GlobMenuEntryNode;
 use phpDocumentor\Guides\Nodes\Menu\MenuEntryNode;
 use phpDocumentor\Guides\Nodes\Menu\TocNode;
 use phpDocumentor\Guides\Nodes\Node;
 
 use function array_reverse;
+use function array_shift;
 use function array_values;
-use function count;
 use function is_array;
 use function ksort;
 
@@ -65,9 +64,9 @@ final class ToctreeSortingTransformer implements NodeTransformer
         if ($sorted !== null) {
             $documentEntry->setMenuEntries($sorted);
         } elseif ($node->isReversed()) {
-            // The sorting cannot map the entries of this document — a glob toctree expands to entries
-            // no authored sequence accounts for. Reversing the menu entries wholesale is the only thing
-            // left that honours `:reversed:` there.
+            // The sorting cannot map the entries of this document: a menu entry is attached that no
+            // toctree of the document accounts for. Reversing the menu entries wholesale is the only
+            // thing left that honours `:reversed:` there, and it is what this pass did before.
             $documentEntry->setMenuEntries(array_reverse($documentEntry->getMenuEntries()));
         }
 
@@ -83,11 +82,9 @@ final class ToctreeSortingTransformer implements NodeTransformer
      * Running this for every toctree of the document is idempotent, and the last run sees every
      * `:reversed:` toctree already reversed.
      *
-     * Nothing is reordered when the entries cannot be mapped one to one — a glob toctree, whose
-     * order is defined by the expansion rather than by an authored sequence, or a menu entry that no
-     * toctree accounts for. Reordering only part of the list would be worse than not reordering it.
-     *
-     * Returns null when the entries cannot be mapped one to one.
+     * Nothing is reordered when a menu entry is attached that no toctree of the document accounts
+     * for: reordering only part of the list would be worse than not reordering it. Null is returned
+     * in that case.
      *
      * @param array<DocumentEntryNode|ExternalEntryNode> $menuEntries
      *
@@ -97,7 +94,10 @@ final class ToctreeSortingTransformer implements NodeTransformer
     {
         // The key match relies on the entry urls having been resolved to the document file (internal)
         // or external url by the attach transformers (priority 4500), which run before this pass.
-        $order = [];
+        // Glob toctrees need nothing of their own here: the compiler drives its passes off a max-heap,
+        // so GlobMenuEntryNodeTransformer (priority 4000) has already replaced every GlobMenuEntryNode
+        // with the entries it expands to, and those carry the urls this matches on.
+        $positions = [];
         $position = 0;
         foreach (self::collectTocNodes($documentNode) as $tocNode) {
             $tocEntries = $tocNode->getValue();
@@ -106,32 +106,26 @@ final class ToctreeSortingTransformer implements NodeTransformer
             }
 
             foreach ($tocEntries as $tocEntry) {
-                if ($tocEntry instanceof GlobMenuEntryNode) {
-                    return null;
-                }
-
                 if (!($tocEntry instanceof MenuEntryNode)) {
                     continue;
                 }
 
-                // An entry listed twice keeps its first authored position; the attach transformers
-                // create a single menu entry for it.
-                $order[$tocEntry->getUrl()] ??= $position++;
+                // One position per occurrence, so a url listed twice can take both. Internal entries
+                // are deduplicated when they are attached, so their single menu entry takes the first
+                // occurrence and the later ones stay unused; external entries are not deduplicated,
+                // so each of them takes the next occurrence in turn.
+                $positions[$tocEntry->getUrl()][] = $position++;
             }
         }
 
         $ordered = [];
         foreach ($menuEntries as $menuEntry) {
             $key = self::menuEntryKey($menuEntry);
-            if (!isset($order[$key])) {
+            if (($positions[$key] ?? []) === []) {
                 return null;
             }
 
-            $ordered[$order[$key]] = $menuEntry;
-        }
-
-        if (count($ordered) !== count($menuEntries)) {
-            return null;
+            $ordered[array_shift($positions[$key])] = $menuEntry;
         }
 
         ksort($ordered);

--- a/packages/guides/src/Compiler/NodeTransformers/MenuNodeTransformers/ToctreeSortingTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/MenuNodeTransformers/ToctreeSortingTransformer.php
@@ -64,9 +64,12 @@ final class ToctreeSortingTransformer implements NodeTransformer
         if ($sorted !== null) {
             $documentEntry->setMenuEntries($sorted);
         } elseif ($node->isReversed()) {
-            // The sorting cannot map the entries of this document: a menu entry is attached that no
-            // toctree of the document accounts for. Reversing the menu entries wholesale is the only
-            // thing left that honours `:reversed:` there, and it is what this pass did before.
+            // The order cannot be derived, so reversing the menu entries wholesale is the only thing
+            // left that honours `:reversed:`, and it is what this pass did before. Nothing in the
+            // test suite reaches this branch: every menu entry is attached from a toctree of its own
+            // document, by the three call sites of attachDocumentEntriesToParents. That it is
+            // unreachable has not been proven though, and dropping it would silently drop
+            // `:reversed:` for whatever does reach it.
             $documentEntry->setMenuEntries(array_reverse($documentEntry->getMenuEntries()));
         }
 

--- a/packages/guides/src/Compiler/NodeTransformers/MenuNodeTransformers/ToctreeSortingTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/MenuNodeTransformers/ToctreeSortingTransformer.php
@@ -65,11 +65,10 @@ final class ToctreeSortingTransformer implements NodeTransformer
             $documentEntry->setMenuEntries($sorted);
         } elseif ($node->isReversed()) {
             // The order cannot be derived, so reversing the menu entries wholesale is the only thing
-            // left that honours `:reversed:`, and it is what this pass did before. Nothing in the
-            // test suite reaches this branch: every menu entry is attached from a toctree of its own
-            // document, by the three call sites of attachDocumentEntriesToParents. That it is
-            // unreachable has not been proven though, and dropping it would silently drop
-            // `:reversed:` for whatever does reach it.
+            // left that honours `:reversed:`, and it is what this pass did before. No `.rst` input in
+            // the suite gets here — every menu entry is attached from a toctree of its own document,
+            // by the three call sites of attachDocumentEntriesToParents — so ToctreeSortingTransformerTest
+            // constructs the state directly rather than leaving the branch uncovered.
             $documentEntry->setMenuEntries(array_reverse($documentEntry->getMenuEntries()));
         }
 

--- a/packages/guides/src/Compiler/NodeTransformers/MenuNodeTransformers/ToctreeSortingTransformer.php
+++ b/packages/guides/src/Compiler/NodeTransformers/MenuNodeTransformers/ToctreeSortingTransformer.php
@@ -15,13 +15,15 @@ namespace phpDocumentor\Guides\Compiler\NodeTransformers\MenuNodeTransformers;
 
 use phpDocumentor\Guides\Compiler\CompilerContext;
 use phpDocumentor\Guides\Compiler\NodeTransformer;
+use phpDocumentor\Guides\Nodes\CompoundNode;
+use phpDocumentor\Guides\Nodes\DocumentNode;
 use phpDocumentor\Guides\Nodes\DocumentTree\DocumentEntryNode;
 use phpDocumentor\Guides\Nodes\DocumentTree\ExternalEntryNode;
+use phpDocumentor\Guides\Nodes\Menu\GlobMenuEntryNode;
 use phpDocumentor\Guides\Nodes\Menu\MenuEntryNode;
 use phpDocumentor\Guides\Nodes\Menu\TocNode;
 use phpDocumentor\Guides\Nodes\Node;
 
-use function array_key_first;
 use function array_reverse;
 use function array_values;
 use function count;
@@ -47,98 +49,121 @@ final class ToctreeSortingTransformer implements NodeTransformer
             return $node;
         }
 
-        $documentEntry = $compilerContext->getDocumentNode()->getDocumentEntry();
-
         if ($node->isReversed()) {
-            $entries = array_reverse($entries);
-            $node->setValue($entries);
-            $documentEntry->setMenuEntries(array_reverse($documentEntry->getMenuEntries()));
+            $node->setValue(array_reverse($entries));
         }
 
-        // The document entry's menu entries (used to build the navigation menu)
-        // are attached by separate transformers for internal and external menu
-        // entries, each running in its own full tree traversal. As a result the
-        // menu entries end up grouped by type instead of following the authored
-        // toctree order, so the navigation menu disagrees with the order shown
-        // on the page. Realign them with the toctree. Globbed toctrees are
-        // skipped: their order is defined by the glob expansion, not by an
-        // authored sequence.
-        if (!$node->hasOption('glob')) {
-            $documentEntry->setMenuEntries(
-                $this->sortMenuEntriesByToctree($entries, $documentEntry->getMenuEntries()),
-            );
+        // The document entry's menu entries (used to build the navigation menu) are attached by
+        // separate transformers for internal and external menu entries, each running in its own full
+        // tree traversal. As a result the menu entries end up grouped by type instead of following the
+        // authored toctree order, so the navigation menu disagrees with the order shown on the page.
+        // Realign them with the toctrees of the document.
+        $documentNode = $compilerContext->getDocumentNode();
+        $documentEntry = $documentNode->getDocumentEntry();
+        $sorted = $this->sortMenuEntriesByToctrees($documentNode, $documentEntry->getMenuEntries());
+
+        if ($sorted !== null) {
+            $documentEntry->setMenuEntries($sorted);
+        } elseif ($node->isReversed()) {
+            // The sorting cannot map the entries of this document — a glob toctree expands to entries
+            // no authored sequence accounts for. Reversing the menu entries wholesale is the only thing
+            // left that honours `:reversed:` there.
+            $documentEntry->setMenuEntries(array_reverse($documentEntry->getMenuEntries()));
         }
 
         return $node;
     }
 
     /**
-     * Reorders the menu entries that belong to this toctree so they follow the
-     * authored toctree order. The toctree's entries are emitted as one
-     * contiguous block at the position of its first entry; entries that belong
-     * to other toctrees of the same document keep their relative position.
-     * Applied per toctree in document order, this yields the global authored
-     * order even when a document has several toctrees.
+     * Reorders the menu entries of a document so they follow the order authored in its toctrees.
      *
-     * @param array<MenuEntryNode> $tocEntries
+     * The order is taken from all toctrees of the document at once, in document order, rather than
+     * from the toctree currently visited: the menu entries the sorting starts from are grouped by
+     * type, so a single toctree cannot tell where its own block belongs relative to the others.
+     * Running this for every toctree of the document is idempotent, and the last run sees every
+     * `:reversed:` toctree already reversed.
+     *
+     * Nothing is reordered when the entries cannot be mapped one to one — a glob toctree, whose
+     * order is defined by the expansion rather than by an authored sequence, or a menu entry that no
+     * toctree accounts for. Reordering only part of the list would be worse than not reordering it.
+     *
+     * Returns null when the entries cannot be mapped one to one.
+     *
      * @param array<DocumentEntryNode|ExternalEntryNode> $menuEntries
      *
-     * @return array<DocumentEntryNode|ExternalEntryNode>
+     * @return array<DocumentEntryNode|ExternalEntryNode>|null
      */
-    private function sortMenuEntriesByToctree(array $tocEntries, array $menuEntries): array
+    private function sortMenuEntriesByToctrees(DocumentNode $documentNode, array $menuEntries): array|null
     {
-        // Map each authored toctree entry to its position. The key match relies
-        // on the entry urls having been resolved to the document file (internal)
-        // or external url by the attach transformers (priority 4500), which run
-        // before this pass.
+        // The key match relies on the entry urls having been resolved to the document file (internal)
+        // or external url by the attach transformers (priority 4500), which run before this pass.
         $order = [];
         $position = 0;
-        foreach ($tocEntries as $tocEntry) {
-            if (!($tocEntry instanceof MenuEntryNode)) {
+        foreach (self::collectTocNodes($documentNode) as $tocNode) {
+            $tocEntries = $tocNode->getValue();
+            if (!is_array($tocEntries)) {
                 continue;
             }
 
-            $order[$tocEntry->getUrl()] = $position++;
+            foreach ($tocEntries as $tocEntry) {
+                if ($tocEntry instanceof GlobMenuEntryNode) {
+                    return null;
+                }
+
+                if (!($tocEntry instanceof MenuEntryNode)) {
+                    continue;
+                }
+
+                // An entry listed twice keeps its first authored position; the attach transformers
+                // create a single menu entry for it.
+                $order[$tocEntry->getUrl()] ??= $position++;
+            }
         }
 
         $ordered = [];
-        $matchedIndexes = [];
-        foreach ($menuEntries as $index => $menuEntry) {
+        foreach ($menuEntries as $menuEntry) {
             $key = self::menuEntryKey($menuEntry);
             if (!isset($order[$key])) {
-                continue;
+                return null;
             }
 
             $ordered[$order[$key]] = $menuEntry;
-            $matchedIndexes[$index] = true;
         }
 
-        // Safety: bail out when entries do not map one-to-one (e.g. the rare
-        // case of duplicate entries within a single toctree).
-        if ($matchedIndexes === [] || count($ordered) !== count($matchedIndexes)) {
-            return $menuEntries;
+        if (count($ordered) !== count($menuEntries)) {
+            return null;
         }
 
         ksort($ordered);
-        $ordered = array_values($ordered);
-        $firstIndex = array_key_first($matchedIndexes);
 
-        $result = [];
-        foreach ($menuEntries as $index => $menuEntry) {
-            if ($index === $firstIndex) {
-                foreach ($ordered as $orderedEntry) {
-                    $result[] = $orderedEntry;
-                }
-            }
+        return array_values($ordered);
+    }
 
-            if (isset($matchedIndexes[$index])) {
-                continue;
-            }
-
-            $result[] = $menuEntry;
+    /**
+     * Collects the toctrees of a document in document order.
+     *
+     * `DocumentNode::getTocNodes()` is filled by TocNodeTransformer at priority 1000, which runs after
+     * this pass, and `getNodes()` only looks at direct children while a toctree usually sits inside a
+     * section. So the tree is walked here.
+     *
+     * @return TocNode[]
+     */
+    private static function collectTocNodes(Node $node): array
+    {
+        $tocNodes = [];
+        if ($node instanceof TocNode) {
+            $tocNodes[] = $node;
         }
 
-        return $result;
+        if ($node instanceof CompoundNode) {
+            foreach ($node->getChildren() as $child) {
+                foreach (self::collectTocNodes($child) as $tocNode) {
+                    $tocNodes[] = $tocNode;
+                }
+            }
+        }
+
+        return $tocNodes;
     }
 
     private static function menuEntryKey(DocumentEntryNode|ExternalEntryNode $entry): string

--- a/packages/guides/tests/unit/Compiler/NodeTransformers/MenuNodeTransformers/ToctreeSortingTransformerTest.php
+++ b/packages/guides/tests/unit/Compiler/NodeTransformers/MenuNodeTransformers/ToctreeSortingTransformerTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\Compiler\NodeTransformers\MenuNodeTransformers;
+
+use phpDocumentor\Guides\Compiler\CompilerContext;
+use phpDocumentor\Guides\Nodes\DocumentNode;
+use phpDocumentor\Guides\Nodes\DocumentTree\DocumentEntryNode;
+use phpDocumentor\Guides\Nodes\DocumentTree\ExternalEntryNode;
+use phpDocumentor\Guides\Nodes\Menu\ExternalMenuEntryNode;
+use phpDocumentor\Guides\Nodes\Menu\InternalMenuEntryNode;
+use phpDocumentor\Guides\Nodes\Menu\MenuEntryNode;
+use phpDocumentor\Guides\Nodes\Menu\MenuNode;
+use phpDocumentor\Guides\Nodes\Menu\TocNode;
+use phpDocumentor\Guides\Nodes\ProjectNode;
+use phpDocumentor\Guides\Nodes\TitleNode;
+use PHPUnit\Framework\TestCase;
+
+use function array_map;
+use function assert;
+
+/**
+ * The integration fixtures cover what an author can write. This covers what they cannot: the state
+ * the sorting refuses to touch, which no `.rst` input in the suite produces.
+ */
+final class ToctreeSortingTransformerTest extends TestCase
+{
+    private const CURRENT = 'subpage/index';
+
+    /**
+     * A menu entry that no toctree accounts for cannot be placed. Reordering the rest around it would
+     * move entries the author never asked to move, so the list is left exactly as it was.
+     */
+    public function testLeavesMenuEntriesAloneWhenOneIsNotAccountedFor(): void
+    {
+        $toc = new TocNode([self::internalEntry('subpage/alpha')]);
+        $entries = [self::documentEntry('subpage/alpha'), self::documentEntry('subpage/orphan')];
+
+        self::assertSame(
+            ['subpage/alpha', 'subpage/orphan'],
+            self::sortedKeys($toc, $entries),
+        );
+    }
+
+    /**
+     * Same state, but the toctree is `:reversed:`. The order cannot be derived, so the pass falls
+     * back to reversing the whole list, which is what it did before it could derive an order at all.
+     */
+    public function testReversesWholesaleWhenTheOrderCannotBeDerived(): void
+    {
+        $toc = (new TocNode([self::internalEntry('subpage/alpha')]))->withReversed(true);
+        $entries = [self::documentEntry('subpage/alpha'), self::documentEntry('subpage/orphan')];
+
+        self::assertSame(
+            ['subpage/orphan', 'subpage/alpha'],
+            self::sortedKeys($toc, $entries),
+        );
+    }
+
+    /**
+     * An external link listed twice is attached twice, and each of the two menu entries takes the
+     * position it was authored at instead of both collapsing onto the first one.
+     */
+    public function testADuplicatedExternalLinkTakesBothAuthoredPositions(): void
+    {
+        $toc = new TocNode([
+            self::internalEntry('subpage/alpha'),
+            self::externalEntry('https://example.com/a'),
+            self::internalEntry('subpage/beta'),
+            self::externalEntry('https://example.com/a'),
+        ]);
+        // Grouped by type, the way the attach passes leave them.
+        $entries = [
+            new ExternalEntryNode('https://example.com/a', 'External A'),
+            new ExternalEntryNode('https://example.com/a', 'External A'),
+            self::documentEntry('subpage/alpha'),
+            self::documentEntry('subpage/beta'),
+        ];
+
+        self::assertSame(
+            ['subpage/alpha', 'https://example.com/a', 'subpage/beta', 'https://example.com/a'],
+            self::sortedKeys($toc, $entries),
+        );
+    }
+
+    /**
+     * An internal page listed twice is attached once, so its single menu entry takes the first of the
+     * two positions and the second stays unused.
+     */
+    public function testADuplicatedInternalEntryKeepsItsFirstPosition(): void
+    {
+        $toc = new TocNode([
+            self::internalEntry('subpage/alpha'),
+            self::externalEntry('https://example.com/a'),
+            self::internalEntry('subpage/alpha'),
+        ]);
+        $entries = [
+            new ExternalEntryNode('https://example.com/a', 'External A'),
+            self::documentEntry('subpage/alpha'),
+        ];
+
+        self::assertSame(
+            ['subpage/alpha', 'https://example.com/a'],
+            self::sortedKeys($toc, $entries),
+        );
+    }
+
+    /** The order comes from every toctree of the document, in document order, not from one of them. */
+    public function testOrdersAcrossSeveralToctrees(): void
+    {
+        $first = new TocNode([self::internalEntry('subpage/alpha')]);
+        $second = new TocNode([self::externalEntry('https://example.com/a')]);
+        $entries = [
+            new ExternalEntryNode('https://example.com/a', 'External A'),
+            self::documentEntry('subpage/alpha'),
+        ];
+
+        self::assertSame(
+            ['subpage/alpha', 'https://example.com/a'],
+            self::sortedKeys($first, $entries, $second),
+        );
+    }
+
+    /**
+     * Runs the pass over `$visited` and returns the resulting menu entry keys.
+     *
+     * @param array<DocumentEntryNode|ExternalEntryNode> $menuEntries
+     *
+     * @return string[]
+     */
+    private static function sortedKeys(MenuNode $visited, array $menuEntries, TocNode ...$further): array
+    {
+        // withReversed() is declared on MenuNode and widens the type; the pass only acts on a TocNode.
+        assert($visited instanceof TocNode);
+
+        $documentEntry = self::documentEntry(self::CURRENT);
+        $documentEntry->setMenuEntries($menuEntries);
+
+        $document = (new DocumentNode('123', self::CURRENT))->setDocumentEntry($documentEntry);
+        $document->addChildNode($visited);
+        foreach ($further as $tocNode) {
+            $document->addChildNode($tocNode);
+        }
+
+        $context = (new CompilerContext(new ProjectNode()))->withDocumentShadowTree($document);
+        (new ToctreeSortingTransformer())->enterNode($visited, $context);
+
+        return array_map(
+            static fn (DocumentEntryNode|ExternalEntryNode $entry): string => $entry instanceof DocumentEntryNode
+                ? $entry->getFile()
+                : $entry->getValue(),
+            $context->getDocumentNode()->getDocumentEntry()->getMenuEntries(),
+        );
+    }
+
+    private static function documentEntry(string $file): DocumentEntryNode
+    {
+        return new DocumentEntryNode($file, TitleNode::emptyNode());
+    }
+
+    private static function internalEntry(string $url): MenuEntryNode
+    {
+        return new InternalMenuEntryNode($url, TitleNode::emptyNode());
+    }
+
+    private static function externalEntry(string $url): MenuEntryNode
+    {
+        return new ExternalMenuEntryNode($url, TitleNode::emptyNode());
+    }
+}

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-duplicate-external-order/expected/subpage/index.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-duplicate-external-order/expected/subpage/index.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+<head>
+    <title>Subpage</title>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+        
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+</head>
+<body>
+<header class="">
+        
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+    <div class="container">
+
+        <a class="navbar-brand" href="#">Navbar</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                                
+<ul class="navbar-nav me-auto mb-2 mb-lg-0">
+    <li class="nav-item">
+            <a href="/subpage/index.html" class="nav-link current active" aria-current="page">
+                Subpage
+            </a>
+        </li>            
+<ul class="level-">
+    <li class="nav-item">
+        <a href="/subpage/index.html"
+           class="nav-link current active" aria-current="page">Subpage</a>
+    </li>
+</ul>
+</ul>
+
+                    </div>
+    </div>
+</nav>
+</header>
+<main id="main-content">
+    <div class="container">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-3">
+                                <nav class="nav flex-column">
+        <ul class="menu-level-main">
+        <li>
+            <a href="/subpage/index.html"
+               class="nav-link current active" aria-current="page">Subpage</a>                
+<ul class="level-1">
+    <li>
+            <a href="/subpage/alpha.html"
+               class="nav-link">Alpha</a>
+        </li>
+    <li>
+            <a href="https://example.com/a"
+               class="nav-link">External A</a>
+        </li>
+    <li>
+            <a href="/subpage/beta.html"
+               class="nav-link">Beta</a>
+        </li>
+    <li>
+            <a href="https://example.com/a"
+               class="nav-link">External A</a>
+        </li>
+    </ul>
+
+        </li>
+            </ul>
+</nav>
+
+                </div>
+                <div class="col-lg-9">
+                        
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="/index.html">Index</a></li>
+        <li class="breadcrumb-item"><a href="/subpage/index.html">Subpage</a></li>
+            </ol>
+</nav>
+                    <!-- content start -->
+                        <div class="section" id="subpage">
+            <h1>Subpage</h1>
+            
+    <p>An external link listed twice is attached twice, unlike an internal entry, and each of the two
+menu entries keeps the position it was authored at.</p>
+
+            <div class="toc">
+    <ul class="menu-level">
+    <li class="toc-item">
+    <a href="/subpage/alpha.html#alpha">Alpha</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="https://example.com/a">External A</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="/subpage/beta.html#beta">Beta</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="https://example.com/a">External A</a>
+
+
+</li>
+    </ul>
+</div>
+    </div>
+                    <!-- content end -->
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+        
+<!-- Optional JavaScript; choose one of the two! -->
+
+<!-- Option 1: Bootstrap Bundle with Popper -->
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+<!-- Option 2: Separate Popper and Bootstrap JS -->
+<!--
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+-->
+</body>
+</html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-duplicate-external-order/input/guides.xml
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-duplicate-external-order/input/guides.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides xmlns="https://www.phpdoc.org/guides"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd"
+        theme="bootstrap"
+>
+    <extension class="phpDocumentor\Guides\Bootstrap"/>
+</guides>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-duplicate-external-order/input/index.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-duplicate-external-order/input/index.rst
@@ -1,0 +1,6 @@
+Index
+=====
+
+..  toctree::
+
+    subpage/index

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-duplicate-external-order/input/subpage/alpha.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-duplicate-external-order/input/subpage/alpha.rst
@@ -1,0 +1,4 @@
+Alpha
+=====
+
+Lorem Ipsum.

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-duplicate-external-order/input/subpage/beta.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-duplicate-external-order/input/subpage/beta.rst
@@ -1,0 +1,4 @@
+Beta
+====
+
+Lorem Ipsum.

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-duplicate-external-order/input/subpage/index.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-duplicate-external-order/input/subpage/index.rst
@@ -1,0 +1,12 @@
+Subpage
+=======
+
+An external link listed twice is attached twice, unlike an internal entry, and each of the two
+menu entries keeps the position it was authored at.
+
+..  toctree::
+
+    alpha
+    External A <https://example.com/a>
+    beta
+    External A <https://example.com/a>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-glob-external-order/expected/subpage/index.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-glob-external-order/expected/subpage/index.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+<head>
+    <title>Subpage</title>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+        
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+</head>
+<body>
+<header class="">
+        
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+    <div class="container">
+
+        <a class="navbar-brand" href="#">Navbar</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                                
+<ul class="navbar-nav me-auto mb-2 mb-lg-0">
+    <li class="nav-item">
+            <a href="/subpage/index.html" class="nav-link current active" aria-current="page">
+                Subpage
+            </a>
+        </li>            
+<ul class="level-">
+    <li class="nav-item">
+        <a href="/subpage/index.html"
+           class="nav-link current active" aria-current="page">Subpage</a>
+    </li>
+</ul>
+</ul>
+
+                    </div>
+    </div>
+</nav>
+</header>
+<main id="main-content">
+    <div class="container">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-3">
+                                <nav class="nav flex-column">
+        <ul class="menu-level-main">
+        <li>
+            <a href="/subpage/index.html"
+               class="nav-link current active" aria-current="page">Subpage</a>                
+<ul class="level-1">
+    <li>
+            <a href="/subpage/alpha.html"
+               class="nav-link">Alpha</a>
+        </li>
+    <li>
+            <a href="/subpage/beta.html"
+               class="nav-link">Beta</a>
+        </li>
+    <li>
+            <a href="https://example.com/a"
+               class="nav-link">External A</a>
+        </li>
+    </ul>
+
+        </li>
+            </ul>
+</nav>
+
+                </div>
+                <div class="col-lg-9">
+                        
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="/index.html">Index</a></li>
+        <li class="breadcrumb-item"><a href="/subpage/index.html">Subpage</a></li>
+            </ol>
+</nav>
+                    <!-- content start -->
+                        <div class="section" id="subpage">
+            <h1>Subpage</h1>
+            
+    <p>A glob toctree is expanded before this page&#039;s navigation menu is ordered, so its entries are
+ordered together with the external link of the toctree that follows it, and the navigation menu
+shows what the page shows.</p>
+
+            <div class="toc">
+    <ul class="menu-level">
+    <li class="toc-item">
+    <a href="/subpage/alpha.html#alpha">Alpha</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="/subpage/beta.html#beta">Beta</a>
+
+
+</li>
+    </ul>
+</div>
+            <div class="toc">
+    <ul class="menu-level">
+    <li class="toc-item">
+    <a href="https://example.com/a">External A</a>
+
+
+</li>
+    </ul>
+</div>
+    </div>
+                    <!-- content end -->
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+        
+<!-- Optional JavaScript; choose one of the two! -->
+
+<!-- Option 1: Bootstrap Bundle with Popper -->
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+<!-- Option 2: Separate Popper and Bootstrap JS -->
+<!--
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+-->
+</body>
+</html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-glob-external-order/input/guides.xml
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-glob-external-order/input/guides.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides xmlns="https://www.phpdoc.org/guides"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd"
+        theme="bootstrap"
+>
+    <extension class="phpDocumentor\Guides\Bootstrap"/>
+</guides>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-glob-external-order/input/index.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-glob-external-order/input/index.rst
@@ -1,0 +1,6 @@
+Index
+=====
+
+..  toctree::
+
+    subpage/index

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-glob-external-order/input/subpage/alpha.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-glob-external-order/input/subpage/alpha.rst
@@ -1,0 +1,4 @@
+Alpha
+=====
+
+Lorem Ipsum.

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-glob-external-order/input/subpage/beta.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-glob-external-order/input/subpage/beta.rst
@@ -1,0 +1,4 @@
+Beta
+====
+
+Lorem Ipsum.

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-glob-external-order/input/subpage/index.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-glob-external-order/input/subpage/index.rst
@@ -1,0 +1,15 @@
+Subpage
+=======
+
+A glob toctree is expanded before this page's navigation menu is ordered, so its entries are
+ordered together with the external link of the toctree that follows it, and the navigation menu
+shows what the page shows.
+
+..  toctree::
+    :glob:
+
+    *
+
+..  toctree::
+
+    External A <https://example.com/a>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-glob-option-and-duplicate/expected/subpage/index.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-glob-option-and-duplicate/expected/subpage/index.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+<head>
+    <title>Subpage</title>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+        
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+</head>
+<body>
+<header class="">
+        
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+    <div class="container">
+
+        <a class="navbar-brand" href="#">Navbar</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                                
+<ul class="navbar-nav me-auto mb-2 mb-lg-0">
+    <li class="nav-item">
+            <a href="/subpage/index.html" class="nav-link current active" aria-current="page">
+                Subpage
+            </a>
+        </li>            
+<ul class="level-">
+    <li class="nav-item">
+        <a href="/subpage/index.html"
+           class="nav-link current active" aria-current="page">Subpage</a>
+    </li>
+</ul>
+</ul>
+
+                    </div>
+    </div>
+</nav>
+</header>
+<main id="main-content">
+    <div class="container">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-3">
+                                <nav class="nav flex-column">
+        <ul class="menu-level-main">
+        <li>
+            <a href="/subpage/index.html"
+               class="nav-link current active" aria-current="page">Subpage</a>                
+<ul class="level-1">
+    <li>
+            <a href="/subpage/alpha.html"
+               class="nav-link">Alpha</a>
+        </li>
+    <li>
+            <a href="https://example.com/a"
+               class="nav-link">External A</a>
+        </li>
+    <li>
+            <a href="/subpage/beta.html"
+               class="nav-link">Beta</a>
+        </li>
+    </ul>
+
+        </li>
+            </ul>
+</nav>
+
+                </div>
+                <div class="col-lg-9">
+                        
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="/index.html">Index</a></li>
+        <li class="breadcrumb-item"><a href="/subpage/index.html">Subpage</a></li>
+            </ol>
+</nav>
+                    <!-- content start -->
+                        <div class="section" id="subpage">
+            <h1>Subpage</h1>
+            
+    <p>The <code>:glob:</code> option alone does not make a toctree a glob toctree, and an entry listed twice keeps
+its first authored position.</p>
+
+            <div class="toc">
+    <ul class="menu-level">
+    <li class="toc-item">
+    <a href="/subpage/alpha.html#alpha">Alpha</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="https://example.com/a">External A</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="/subpage/beta.html#beta">Beta</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="/subpage/alpha.html#alpha">Alpha</a>
+
+
+</li>
+    </ul>
+</div>
+    </div>
+                    <!-- content end -->
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+        
+<!-- Optional JavaScript; choose one of the two! -->
+
+<!-- Option 1: Bootstrap Bundle with Popper -->
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+<!-- Option 2: Separate Popper and Bootstrap JS -->
+<!--
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+-->
+</body>
+</html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-glob-option-and-duplicate/input/guides.xml
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-glob-option-and-duplicate/input/guides.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides xmlns="https://www.phpdoc.org/guides"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd"
+        theme="bootstrap"
+>
+    <extension class="phpDocumentor\Guides\Bootstrap"/>
+</guides>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-glob-option-and-duplicate/input/index.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-glob-option-and-duplicate/input/index.rst
@@ -1,0 +1,6 @@
+Index
+=====
+
+..  toctree::
+
+    subpage/index

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-glob-option-and-duplicate/input/subpage/alpha.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-glob-option-and-duplicate/input/subpage/alpha.rst
@@ -1,0 +1,4 @@
+Alpha
+=====
+
+Lorem Ipsum.

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-glob-option-and-duplicate/input/subpage/beta.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-glob-option-and-duplicate/input/subpage/beta.rst
@@ -1,0 +1,4 @@
+Beta
+====
+
+Lorem Ipsum.

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-glob-option-and-duplicate/input/subpage/index.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-glob-option-and-duplicate/input/subpage/index.rst
@@ -1,0 +1,13 @@
+Subpage
+=======
+
+The ``:glob:`` option alone does not make a toctree a glob toctree, and an entry listed twice keeps
+its first authored position.
+
+..  toctree::
+    :glob:
+
+    alpha
+    External A <https://example.com/a>
+    beta
+    alpha

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-multiple-toctrees-order/expected/subpage/index.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-multiple-toctrees-order/expected/subpage/index.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+<head>
+    <title>Subpage Title</title>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+        
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+</head>
+<body>
+<header class="">
+        
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+    <div class="container">
+
+        <a class="navbar-brand" href="#">Navbar</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                                
+<ul class="navbar-nav me-auto mb-2 mb-lg-0">
+    <li class="nav-item">
+            <a href="/subpage/index.html" class="nav-link current active" aria-current="page">
+                Subpage Title
+            </a>
+        </li>            
+<ul class="level-">
+    <li class="nav-item">
+        <a href="/subpage/index.html"
+           class="nav-link current active" aria-current="page">Subpage Title</a>
+    </li>
+</ul>
+</ul>
+
+                    </div>
+    </div>
+</nav>
+</header>
+<main id="main-content">
+    <div class="container">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-3">
+                                <nav class="nav flex-column">
+        <ul class="menu-level-main">
+        <li>
+            <a href="/subpage/index.html"
+               class="nav-link current active" aria-current="page">Subpage Title</a>                
+<ul class="level-1">
+    <li>
+            <a href="/subpage/alpha.html"
+               class="nav-link">Alpha</a>
+        </li>
+    <li>
+            <a href="https://example.com/a"
+               class="nav-link">External A</a>
+        </li>
+    <li>
+            <a href="/subpage/beta.html"
+               class="nav-link">Beta</a>
+        </li>
+    <li>
+            <a href="https://example.org/b"
+               class="nav-link">External B</a>
+        </li>
+    </ul>
+
+        </li>
+            </ul>
+</nav>
+
+                </div>
+                <div class="col-lg-9">
+                        
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="/index.html">Document Title</a></li>
+        <li class="breadcrumb-item"><a href="/subpage/index.html">Subpage Title</a></li>
+            </ol>
+</nav>
+                    <!-- content start -->
+                        <div class="section" id="subpage-title">
+            <h1>Subpage Title</h1>
+            <div class="toc">
+            <p class="caption">First</p>
+    <ul class="menu-level">
+    <li class="toc-item">
+    <a href="/subpage/alpha.html#alpha">Alpha</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="https://example.com/a">External A</a>
+
+
+</li>
+    </ul>
+</div>
+            <div class="toc">
+            <p class="caption">Second</p>
+    <ul class="menu-level">
+    <li class="toc-item">
+    <a href="/subpage/beta.html#beta">Beta</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="https://example.org/b">External B</a>
+
+
+</li>
+    </ul>
+</div>
+    </div>
+                    <!-- content end -->
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+        
+<!-- Optional JavaScript; choose one of the two! -->
+
+<!-- Option 1: Bootstrap Bundle with Popper -->
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+<!-- Option 2: Separate Popper and Bootstrap JS -->
+<!--
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+-->
+</body>
+</html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-multiple-toctrees-order/input/guides.xml
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-multiple-toctrees-order/input/guides.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides xmlns="https://www.phpdoc.org/guides"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd"
+        theme="bootstrap"
+>
+    <extension class="phpDocumentor\Guides\Bootstrap"/>
+</guides>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-multiple-toctrees-order/input/index.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-multiple-toctrees-order/input/index.rst
@@ -1,0 +1,6 @@
+Document Title
+==============
+
+..  toctree::
+
+    subpage/index

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-multiple-toctrees-order/input/subpage/alpha.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-multiple-toctrees-order/input/subpage/alpha.rst
@@ -1,0 +1,5 @@
+=====
+Alpha
+=====
+
+Lorem Ipsum Dolor.

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-multiple-toctrees-order/input/subpage/beta.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-multiple-toctrees-order/input/subpage/beta.rst
@@ -1,0 +1,5 @@
+====
+Beta
+====
+
+Lorem Ipsum Dolor.

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-multiple-toctrees-order/input/subpage/index.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-multiple-toctrees-order/input/subpage/index.rst
@@ -1,0 +1,14 @@
+Subpage Title
+=============
+
+..  toctree::
+    :caption: First
+
+    alpha
+    External A <https://example.com/a>
+
+..  toctree::
+    :caption: Second
+
+    beta
+    External B <https://example.org/b>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-nested-external-order/expected/subpage/index.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-nested-external-order/expected/subpage/index.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+<head>
+    <title>Subpage Title</title>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+        
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+</head>
+<body>
+<header class="">
+        
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+    <div class="container">
+
+        <a class="navbar-brand" href="#">Navbar</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                                
+<ul class="navbar-nav me-auto mb-2 mb-lg-0">
+    <li class="nav-item">
+            <a href="/subpage/index.html" class="nav-link current active" aria-current="page">
+                Subpage Title
+            </a>
+        </li>            
+<ul class="level-">
+    <li class="nav-item">
+        <a href="/subpage/index.html"
+           class="nav-link current active" aria-current="page">Subpage Title</a>
+    </li>
+</ul>
+</ul>
+
+                    </div>
+    </div>
+</nav>
+</header>
+<main id="main-content">
+    <div class="container">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-3">
+                                <nav class="nav flex-column">
+        <ul class="menu-level-main">
+        <li>
+            <a href="/subpage/index.html"
+               class="nav-link current active" aria-current="page">Subpage Title</a>                
+<ul class="level-1">
+    <li>
+            <a href="/subpage/page1.html"
+               class="nav-link">Page 1</a>
+        </li>
+    <li>
+            <a href="https://example.com/a"
+               class="nav-link">External A</a>
+        </li>
+    <li>
+            <a href="/subpage/page2.html"
+               class="nav-link">Page 2</a>
+        </li>
+    <li>
+            <a href="https://example.org/b"
+               class="nav-link">External B</a>
+        </li>
+    </ul>
+
+        </li>
+            </ul>
+</nav>
+
+                </div>
+                <div class="col-lg-9">
+                        
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="/index.html">Document Title</a></li>
+        <li class="breadcrumb-item"><a href="/subpage/index.html">Subpage Title</a></li>
+            </ol>
+</nav>
+                    <!-- content start -->
+                        <div class="section" id="subpage-title">
+            <h1>Subpage Title</h1>
+            <div class="toc">
+            <p class="caption">Nested</p>
+    <ul class="menu-level">
+    <li class="toc-item">
+    <a href="/subpage/page1.html#page-1">Page 1</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="https://example.com/a">External A</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="/subpage/page2.html#page-2">Page 2</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="https://example.org/b">External B</a>
+
+
+</li>
+    </ul>
+</div>
+    </div>
+                    <!-- content end -->
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+        
+<!-- Optional JavaScript; choose one of the two! -->
+
+<!-- Option 1: Bootstrap Bundle with Popper -->
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+<!-- Option 2: Separate Popper and Bootstrap JS -->
+<!--
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+-->
+</body>
+</html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-nested-external-order/input/guides.xml
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-nested-external-order/input/guides.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides xmlns="https://www.phpdoc.org/guides"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd"
+        theme="bootstrap"
+>
+    <extension class="phpDocumentor\Guides\Bootstrap"/>
+</guides>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-nested-external-order/input/index.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-nested-external-order/input/index.rst
@@ -1,0 +1,6 @@
+Document Title
+==============
+
+..  toctree::
+
+    subpage/index

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-nested-external-order/input/subpage/index.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-nested-external-order/input/subpage/index.rst
@@ -1,0 +1,10 @@
+Subpage Title
+=============
+
+..  toctree::
+    :caption: Nested
+
+    page1
+    External A <https://example.com/a>
+    page2
+    External B <https://example.org/b>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-nested-external-order/input/subpage/page1.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-nested-external-order/input/subpage/page1.rst
@@ -1,0 +1,5 @@
+======
+Page 1
+======
+
+Lorem Ipsum Dolor.

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-nested-external-order/input/subpage/page2.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-nested-external-order/input/subpage/page2.rst
@@ -1,0 +1,5 @@
+======
+Page 2
+======
+
+Lorem Ipsum Dolor.

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-reversed-external-order/expected/subpage/index.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-reversed-external-order/expected/subpage/index.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+<head>
+    <title>Subpage</title>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+        
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+</head>
+<body>
+<header class="">
+        
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+    <div class="container">
+
+        <a class="navbar-brand" href="#">Navbar</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                                
+<ul class="navbar-nav me-auto mb-2 mb-lg-0">
+    <li class="nav-item">
+            <a href="/subpage/index.html" class="nav-link current active" aria-current="page">
+                Subpage
+            </a>
+        </li>            
+<ul class="level-">
+    <li class="nav-item">
+        <a href="/subpage/index.html"
+           class="nav-link current active" aria-current="page">Subpage</a>
+    </li>
+</ul>
+</ul>
+
+                    </div>
+    </div>
+</nav>
+</header>
+<main id="main-content">
+    <div class="container">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-3">
+                                <nav class="nav flex-column">
+        <ul class="menu-level-main">
+        <li>
+            <a href="/subpage/index.html"
+               class="nav-link current active" aria-current="page">Subpage</a>                
+<ul class="level-1">
+    <li>
+            <a href="/subpage/beta.html"
+               class="nav-link">Beta</a>
+        </li>
+    <li>
+            <a href="https://example.com/a"
+               class="nav-link">External A</a>
+        </li>
+    <li>
+            <a href="/subpage/alpha.html"
+               class="nav-link">Alpha</a>
+        </li>
+    </ul>
+
+        </li>
+            </ul>
+</nav>
+
+                </div>
+                <div class="col-lg-9">
+                        
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="/index.html">Index</a></li>
+        <li class="breadcrumb-item"><a href="/subpage/index.html">Subpage</a></li>
+            </ol>
+</nav>
+                    <!-- content start -->
+                        <div class="section" id="subpage">
+            <h1>Subpage</h1>
+            
+    <p>A <code>:reversed:</code> toctree that mixes internal pages and an external link is reversed once, for the page
+and for the navigation menu alike. The menu is no longer reversed a second time on top of the order
+taken from the toctree.</p>
+
+            <div class="toc">
+    <ul class="menu-level">
+    <li class="toc-item">
+    <a href="/subpage/beta.html#beta">Beta</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="https://example.com/a">External A</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="/subpage/alpha.html#alpha">Alpha</a>
+
+
+</li>
+    </ul>
+</div>
+    </div>
+                    <!-- content end -->
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+        
+<!-- Optional JavaScript; choose one of the two! -->
+
+<!-- Option 1: Bootstrap Bundle with Popper -->
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+<!-- Option 2: Separate Popper and Bootstrap JS -->
+<!--
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+-->
+</body>
+</html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-reversed-external-order/input/guides.xml
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-reversed-external-order/input/guides.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides xmlns="https://www.phpdoc.org/guides"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd"
+        theme="bootstrap"
+>
+    <extension class="phpDocumentor\Guides\Bootstrap"/>
+</guides>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-reversed-external-order/input/index.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-reversed-external-order/input/index.rst
@@ -1,0 +1,6 @@
+Index
+=====
+
+..  toctree::
+
+    subpage/index

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-reversed-external-order/input/subpage/alpha.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-reversed-external-order/input/subpage/alpha.rst
@@ -1,0 +1,4 @@
+Alpha
+=====
+
+Lorem Ipsum.

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-reversed-external-order/input/subpage/beta.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-reversed-external-order/input/subpage/beta.rst
@@ -1,0 +1,4 @@
+Beta
+====
+
+Lorem Ipsum.

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-reversed-external-order/input/subpage/index.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-reversed-external-order/input/subpage/index.rst
@@ -1,0 +1,13 @@
+Subpage
+=======
+
+A `:reversed:` toctree that mixes internal pages and an external link is reversed once, for the page
+and for the navigation menu alike. The menu is no longer reversed a second time on top of the order
+taken from the toctree.
+
+..  toctree::
+    :reversed:
+
+    alpha
+    External A <https://example.com/a>
+    beta

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-separate-toctrees-order/expected/subpage/index.html
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-separate-toctrees-order/expected/subpage/index.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+<head>
+    <title>Subpage</title>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+        
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+</head>
+<body>
+<header class="">
+        
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+    <div class="container">
+
+        <a class="navbar-brand" href="#">Navbar</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+                                
+<ul class="navbar-nav me-auto mb-2 mb-lg-0">
+    <li class="nav-item">
+            <a href="/subpage/index.html" class="nav-link current active" aria-current="page">
+                Subpage
+            </a>
+        </li>            
+<ul class="level-">
+    <li class="nav-item">
+        <a href="/subpage/index.html"
+           class="nav-link current active" aria-current="page">Subpage</a>
+    </li>
+</ul>
+</ul>
+
+                    </div>
+    </div>
+</nav>
+</header>
+<main id="main-content">
+    <div class="container">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-3">
+                                <nav class="nav flex-column">
+        <ul class="menu-level-main">
+        <li>
+            <a href="/subpage/index.html"
+               class="nav-link current active" aria-current="page">Subpage</a>                
+<ul class="level-1">
+    <li>
+            <a href="/subpage/alpha.html"
+               class="nav-link">Alpha</a>
+        </li>
+    <li>
+            <a href="/subpage/beta.html"
+               class="nav-link">Beta</a>
+        </li>
+    <li>
+            <a href="https://example.org/b"
+               class="nav-link">External B</a>
+        </li>
+    </ul>
+
+        </li>
+            </ul>
+</nav>
+
+                </div>
+                <div class="col-lg-9">
+                        
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="/index.html">Index</a></li>
+        <li class="breadcrumb-item"><a href="/subpage/index.html">Subpage</a></li>
+            </ol>
+</nav>
+                    <!-- content start -->
+                        <div class="section" id="subpage">
+            <h1>Subpage</h1>
+            
+    <p>One toctree holds only internal entries, the next only an external one. The navigation menu must
+follow the documents, not the type of the entries.</p>
+
+            <div class="toc">
+            <p class="caption">First</p>
+    <ul class="menu-level">
+    <li class="toc-item">
+    <a href="/subpage/alpha.html#alpha">Alpha</a>
+
+
+</li>
+    <li class="toc-item">
+    <a href="/subpage/beta.html#beta">Beta</a>
+
+
+</li>
+    </ul>
+</div>
+            <div class="toc">
+            <p class="caption">Second</p>
+    <ul class="menu-level">
+    <li class="toc-item">
+    <a href="https://example.org/b">External B</a>
+
+
+</li>
+    </ul>
+</div>
+    </div>
+                    <!-- content end -->
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+        
+<!-- Optional JavaScript; choose one of the two! -->
+
+<!-- Option 1: Bootstrap Bundle with Popper -->
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+
+<!-- Option 2: Separate Popper and Bootstrap JS -->
+<!--
+<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
+-->
+</body>
+</html>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-separate-toctrees-order/input/guides.xml
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-separate-toctrees-order/input/guides.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides xmlns="https://www.phpdoc.org/guides"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd"
+        theme="bootstrap"
+>
+    <extension class="phpDocumentor\Guides\Bootstrap"/>
+</guides>

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-separate-toctrees-order/input/index.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-separate-toctrees-order/input/index.rst
@@ -1,0 +1,6 @@
+Index
+=====
+
+..  toctree::
+
+    subpage/index

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-separate-toctrees-order/input/subpage/alpha.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-separate-toctrees-order/input/subpage/alpha.rst
@@ -1,0 +1,4 @@
+Alpha
+=====
+
+Lorem Ipsum.

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-separate-toctrees-order/input/subpage/beta.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-separate-toctrees-order/input/subpage/beta.rst
@@ -1,0 +1,4 @@
+Beta
+====
+
+Lorem Ipsum.

--- a/tests/Integration/tests-full/bootstrap/bootstrap-menu-separate-toctrees-order/input/subpage/index.rst
+++ b/tests/Integration/tests-full/bootstrap/bootstrap-menu-separate-toctrees-order/input/subpage/index.rst
@@ -1,0 +1,16 @@
+Subpage
+=======
+
+One toctree holds only internal entries, the next only an external one. The navigation menu must
+follow the documents, not the type of the entries.
+
+..  toctree::
+    :caption: First
+
+    alpha
+    beta
+
+..  toctree::
+    :caption: Second
+
+    External B <https://example.org/b>


### PR DESCRIPTION
## Problem

A `toctree` that mixes internal pages and external links builds the **navigation menu** (the document entry's menu entries, used for the sidebar/navbar) with all external entries grouped first, even though the on-page `toctree` keeps the authored order. The navigation therefore disagrees with the page. It shows up for nested toctrees.

## Root cause

Internal and external menu entries are attached to the document entry by two separate transformers — `InternalMenuEntryNodeTransformer` and `ExternalMenuEntryNodeTransformer` — and the compiler runs **one full tree traversal per transformer** at a given priority (both attach at 4500). So every external entry is appended to `DocumentEntryNode::getMenuEntries()` in one pass and every internal entry in another, and the list ends up grouped by type instead of following the toctree. The on-page toctree renders from the `TocNode` value (authored order) and stays correct.

## Fix

`ToctreeSortingTransformer` (priority 3200, after the attach passes) now realigns the document entry's menu entries with the authored toctree order, matching entries by file/URL. It emits each toctree's entries as one contiguous block at the position of its first entry, so a document with **several** mixed toctrees is ordered correctly too. It already ran at the right point to handle the `reversed` option. ~~Globbed toctrees are skipped — their order comes from the glob expansion, not an authored sequence.~~ **That sentence was wrong** and the code it described is gone; see the last section.

## Before / after

Sidebar of a nested subpage whose toctree interleaves internal pages and external links (Bootstrap theme):

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/netresearch/guides/issue-1175-screenshots/before.png) | ![after](https://raw.githubusercontent.com/netresearch/guides/issue-1175-screenshots/after.png) |

## Tests

Seven integration fixtures under `tests-full/bootstrap/`, one per toctree shape, each failing against `main`: `bootstrap-menu-nested-external-order` (one toctree interleaving internal and external), `bootstrap-menu-multiple-toctrees-order` (two mixed toctrees), `bootstrap-menu-separate-toctrees-order` (an internal-only toctree followed by an external-only one), `bootstrap-menu-glob-option-and-duplicate` (the `:glob:` option without a `*`, plus a duplicated internal entry), `bootstrap-menu-duplicate-external-order` (a duplicated external link), `bootstrap-menu-glob-external-order` (a real `*` glob followed by an external toctree) and `bootstrap-menu-reversed-external-order` (`:reversed:` mixing both kinds).

`ToctreeSortingTransformerTest` covers what no `.rst` input can produce, including the fallback branch. Each of its five cases was seen failing on its own injected defect before it was kept — fallback removed, one position per url instead of per occurrence, skipping an unplaceable entry instead of bailing out, the last position instead of the first, and only the visited toctree — five mutations, five distinct failures.

Verified on the final tree: PHPUnit 841 tests green, PHPStan (level max + baseline), PHPCS (Doctrine standard) and deptrac clean.

## Context

Reported downstream at TYPO3-Documentation/render-guides#1175.


## Update: the first commit did not fix the case it set out to fix

A review of this branch found that anchoring each toctree's block at the lowest index it matched in the menu entries uses a position in the type-grouped list, not a position in the document. With one toctree holding only internal entries and the next only an external one — the ordinary "chapters" plus "external links" split — the navigation still contradicted the page:

```
Navigation: External B, Alpha, Beta
Page:       alpha, beta, External B
```

Both fixtures above use toctrees that mix internal and external entries, which is precisely the shape that hides this. Reproduced by rendering, then pinned as `bootstrap-menu-separate-toctrees-order`.

The second commit takes the order from **all** toctrees of the document at once, in document order, and sorts the whole menu entry list by it; when the entries cannot be mapped one to one the list is left untouched rather than partially reordered. The toctrees are collected from the document tree, because `DocumentNode::getTocNodes()` is filled at priority 1000 — after this pass — and `getNodes()` only sees direct children while a toctree usually sits inside a section.

Three further corrections fall out of that. The `:reversed:` handling no longer reverses the document's whole menu entry list when the order can be derived, so it stops displacing entries of other toctrees; the wholesale reversal remains for glob toctrees, where there is no authored sequence to sort by. The glob guard tested `hasOption('glob')`, but `ToctreeBuilder` creates a `GlobMenuEntryNode` from a `*` in the reference and never reads that option, so the guard was wrong in both directions — it now looks at the node type. And an entry listed twice keeps its first authored position, where the last one used to win while the counts still matched, so nothing noticed.

Two more fixtures cover the separate-toctrees case and the glob-option-plus-duplicate case; both fail against the previous state of this branch.



## Update: two review findings from @linawolf, both confirmed and fixed

**A duplicated external link reverted the whole fix.** `ExternalMenuEntryNodeTransformer` builds a fresh `ExternalEntryNode` per occurrence, and the dedup guard in `MenuEntryManagement::attachDocumentEntriesToParents` only covers `DocumentEntryNode` — so a link listed twice is attached twice while the position map collapsed it to one slot. The second entry overwrote the first, the count check tripped, and the sorting bailed out for the whole page, back to the type-grouped order this branch exists to fix. Reproduced by rendering a toctree of `alpha`, `External A`, `beta`, `External A`: sidebar `External A, External A, Alpha, Beta` against page `Alpha, External A, Beta, External A`. The map now records one position per occurrence and hands them out in turn; an internal entry is deduplicated on attach so it takes the first occurrence, the two menu entries of a duplicated external link take both. Every menu entry now consumes a distinct position, so the count check has nothing left to catch and is gone. Pinned as `bootstrap-menu-duplicate-external-order`, which fails on the previous commit of this branch with exactly the order above.

**The glob guard was unreachable.** `Compiler` drives its passes off an `SplPriorityQueue`, a max-heap, so `GlobMenuEntryNodeTransformer` (4000) has already replaced every `GlobMenuEntryNode` with the entries it expands to before this pass runs at 3200. Instrumenting the guard across the integration suite recorded zero hits against 138 sortings — the protection claimed in the "Fix" section above never existed. The guard is removed rather than relocated: the expanded entries carry the urls this matches on, and they sort correctly, which is what the suite was already showing. `bootstrap-menu-glob-external-order` pins that a glob toctree followed by a toctree with an external link produces a navigation menu matching the page; it fails against `main`.

So the sentence "globbed toctrees are skipped" in the **Fix** section is wrong and no longer describes the code — glob toctrees are sorted like any other, on the entries the expansion produced. The remaining `null` return, and with it the wholesale `:reversed:` fallback, now fires only when a menu entry is attached that no toctree of the document accounts for — a condition nothing in the test suite reaches. The branch stays because its unreachability is not proven, and its comment now says that rather than naming a case as if it had been observed.

Rebased onto `main` at 382485e6. Verified on the final tree: full PHPUnit suite 835 tests green (integration 234), PHPStan level max clean, PHPCS clean.

## Update: rebased onto current `main`

Rebased onto `main` at f9b32e7d. One conflict, in `ToctreeSortingTransformer.php`: the PHPStan 2 upgrade (61985992) narrowed `leaveNode(): Node|null` to `Node`, in the same hunk this branch extends with its two private helpers. Resolved as this branch's code plus that narrowing — no `Node|null` remains in the file.

Re-verified on the rebased tree, on PHP 8.2 (the version CI uses; the Makefile default is 8.4): PHPCS clean over 696 files, PHPStan level max reports `No errors` over 643 files, deptrac 0 violations, `test-xml` and `test-docs` clean, and PHPUnit unit 572 / functional 117 / integration 260 green. The counts differ from the run recorded above because `main` has grown since, not because anything changed here.

The seven fixtures listed earlier were confirmed present in the executed set rather than inferred from a green total — a bad conflict resolution can drop test cases while the rest of the suite still passes. `--testdox` filtered to their names shows all seven passing.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_014H1xwaAmrQRWUA3vx8bJcD)_




