### PR TITLE
[FEATURE] Support :lines: in literalinclude

### DIFF
--- a/docs/reference/restructuredtext/literalinclude.rst
+++ b/docs/reference/restructuredtext/literalinclude.rst
@@ -64,11 +64,15 @@ are included once, in the order of the file.
 ``:lines:`` is applied *after* ``:start-after:`` and ``:end-before:``, so when they are combined the numbers count
 within the marked region rather than within the whole file.
 
+``:emphasize-lines:`` in turn counts within what ``:lines:`` left over, and ``:lineno-start:`` remains a plain
+override of the first number displayed, unrelated to where the selected lines sat in the file.
+
 Prefer markers where a file has them: line numbers change with every edit above the selected region, and nothing in
 the source file records that the documentation depends on them.
 
-If the value cannot be read as a list of line numbers, or if it selects no line at all, a warning is logged and
-nothing is included.
+Every range is warned about separately when it selects no line, for example because it lies beyond the end of the
+region; the remaining ranges are still included. If the option is used without a value, or its value cannot be read
+as a list of line numbers, a warning is logged and nothing is included.
 
 Options
 =======
@@ -90,7 +94,8 @@ Options
     and ``end-before``.
 
 ``:emphasize-lines:``
-    Line numbers to be highlighted, for example ``3,5-6``. Counted within the included region.
+    Line numbers to be highlighted, for example ``3,5-6``. Counted within the included region, that is within what
+    is left after ``start-after``, ``end-before`` and ``lines``.
 
 ``:linenos:``
     Displays line numbers, starting at 1.

--- a/docs/reference/restructuredtext/literalinclude.rst
+++ b/docs/reference/restructuredtext/literalinclude.rst
@@ -47,6 +47,29 @@ publish the very content it was meant to exclude. The same happens when the mark
 when the ``end-before`` text occurs only above the line matched by ``start-after``. Rendering with ``--fail-on-log``
 turns any of these warnings into a failing build.
 
+Selecting lines by number
+=========================
+
+A region can also be selected by line number, which is useful for files that have no natural marker:
+
+..  code-block::
+
+    ..  literalinclude:: Example.php
+        :language: php
+        :lines: 1,3-5,20-
+
+Line numbers start at 1, ranges are inclusive, and an omitted end means "down to the last line". Overlapping ranges
+are included once, in the order of the file.
+
+``:lines:`` is applied *after* ``:start-after:`` and ``:end-before:``, so when they are combined the numbers count
+within the marked region rather than within the whole file.
+
+Prefer markers where a file has them: line numbers change with every edit above the selected region, and nothing in
+the source file records that the documentation depends on them.
+
+If the value cannot be read as a list of line numbers, or if it selects no line at all, a warning is logged and
+nothing is included.
+
 Options
 =======
 
@@ -61,6 +84,10 @@ Options
 
 ``:end-before:``
     Text of the line the included region ends before. The line itself is not included.
+
+``:lines:``
+    Line numbers to be included, for example ``1,3-5,20-``. Counted within the region selected by ``start-after``
+    and ``end-before``.
 
 ``:emphasize-lines:``
     Line numbers to be highlighted, for example ``3,5-6``. Counted within the included region.

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/LiteralincludeDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/LiteralincludeDirective.php
@@ -16,17 +16,24 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 use phpDocumentor\Guides\Nodes\CodeNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Directives\OptionMapper\CodeNodeOptionMapper;
+use phpDocumentor\Guides\RestructuredText\Directives\OptionMapper\DefaultCodeNodeOptionMapper;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 use function array_slice;
+use function array_values;
 use function count;
 use function explode;
 use function is_string;
+use function ksort;
+use function max;
+use function min;
+use function preg_match;
 use function sprintf;
 use function str_contains;
+use function trim;
 
 final class LiteralincludeDirective extends BaseDirective
 {
@@ -140,9 +147,97 @@ final class LiteralincludeDirective extends BaseDirective
                 ),
                 $blockContext->getLoggerInformation(),
             );
+
+            return [];
+        }
+
+        if ($directive->hasOption('lines')) {
+            $selection = $this->selectLineRanges($selection, $directive, $blockContext);
         }
 
         return $selection;
+    }
+
+    /**
+     * Reduces the included region to the line numbers listed in ``lines``, for example ``1,3-5,20-``.
+     *
+     * Line numbers are 1 based, ranges are inclusive and an omitted end means "up to the last line".
+     * They count within the region selected by ``start-after`` and ``end-before``, not within the file.
+     *
+     * @param string[] $lines
+     *
+     * @return string[]
+     */
+    private function selectLineRanges(array $lines, Directive $directive, BlockContext $blockContext): array
+    {
+        $specification = $this->optionValue($directive, 'lines', $blockContext);
+        if ($specification === null) {
+            return [];
+        }
+
+        if (preg_match(DefaultCodeNodeOptionMapper::LINE_NUMBER_RANGES_REGEX, $specification) !== 1) {
+            $this->logger?->warning(
+                sprintf(
+                    'Invalid value for option ":lines:" of directive "literalinclude": "%s". Expected format: \'1-5, 7, 33\'. Nothing was included.',
+                    $specification,
+                ),
+                $blockContext->getLoggerInformation(),
+            );
+
+            return [];
+        }
+
+        $selected = [];
+        foreach (explode(',', $specification) as $range) {
+            $range = trim($range);
+            [$first, $last] = $this->parseRange($range, count($lines));
+
+            if ($first > $last) {
+                $this->logger?->warning(
+                    sprintf(
+                        'Option ":lines:" of directive "literalinclude": the range "%s" selects no line of "%s".',
+                        $range,
+                        $directive->getData(),
+                    ),
+                    $blockContext->getLoggerInformation(),
+                );
+
+                continue;
+            }
+
+            for ($lineNumber = $first; $lineNumber <= $last; $lineNumber++) {
+                $selected[$lineNumber] = $lines[$lineNumber - 1];
+            }
+        }
+
+        ksort($selected);
+
+        return array_values($selected);
+    }
+
+    /**
+     * Splits a single entry of the ``lines`` option into its first and last line number.
+     *
+     * Both are clamped to the lines actually available, so that a range far beyond the end of the file
+     * does not turn into a loop over the numbers the author wrote down. A first line greater than the
+     * last one means the range selects nothing.
+     *
+     * @return array{int, int}
+     */
+    private function parseRange(string $range, int $lineCount): array
+    {
+        if (!str_contains($range, '-')) {
+            $lineNumber = (int) $range;
+
+            return [max(1, $lineNumber), min($lineNumber, $lineCount)];
+        }
+
+        [$first, $last] = explode('-', $range, 2);
+
+        return [
+            max(1, (int) $first),
+            trim($last) === '' ? $lineCount : min((int) $last, $lineCount),
+        ];
     }
 
     /** Returns the text of an option, or null if the option was used without a usable value. */

--- a/tests/Integration/tests/code/literalinclude-lines-emphasize/expected/index.html
+++ b/tests/Integration/tests/code/literalinclude-lines-emphasize/expected/index.html
@@ -1,0 +1,10 @@
+<!-- content start -->
+    <div class="section" id="index">
+            <h1>index</h1>
+            <pre><code class="language-php" data-emphasize-lines="2">    public function test(): string
+    {
+        return &#039;this is a test&#039;;
+    }</code></pre>
+
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/code/literalinclude-lines-emphasize/input/_code/_Example.php
+++ b/tests/Integration/tests/code/literalinclude-lines-emphasize/input/_code/_Example.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+class Example
+{
+    // begin example
+    public function test(): string
+    {
+        return 'this is a test';
+    }
+
+    // end example
+}

--- a/tests/Integration/tests/code/literalinclude-lines-emphasize/input/index.rst
+++ b/tests/Integration/tests/code/literalinclude-lines-emphasize/input/index.rst
@@ -1,0 +1,7 @@
+index
+=====
+
+..  literalinclude:: _code/_Example.php
+    :language: php
+    :lines: 8-11
+    :emphasize-lines: 2

--- a/tests/Integration/tests/code/literalinclude-lines-huge-range/expected/index.html
+++ b/tests/Integration/tests/code/literalinclude-lines-huge-range/expected/index.html
@@ -1,0 +1,21 @@
+<!-- content start -->
+    <div class="section" id="index">
+            <h1>index</h1>
+            <pre><code class="language-php">&lt;?php
+
+declare(strict_types=1);
+
+class Example
+{
+    // begin example
+    public function test(): string
+    {
+        return &#039;this is a test&#039;;
+    }
+
+    // end example
+}
+</code></pre>
+
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/code/literalinclude-lines-huge-range/input/_code/_Example.php
+++ b/tests/Integration/tests/code/literalinclude-lines-huge-range/input/_code/_Example.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+class Example
+{
+    // begin example
+    public function test(): string
+    {
+        return 'this is a test';
+    }
+
+    // end example
+}

--- a/tests/Integration/tests/code/literalinclude-lines-huge-range/input/index.rst
+++ b/tests/Integration/tests/code/literalinclude-lines-huge-range/input/index.rst
@@ -1,0 +1,6 @@
+index
+=====
+
+..  literalinclude:: _code/_Example.php
+    :language: php
+    :lines: 1-99999999999999999999

--- a/tests/Integration/tests/code/literalinclude-lines-invalid/expected/index.html
+++ b/tests/Integration/tests/code/literalinclude-lines-invalid/expected/index.html
@@ -1,0 +1,7 @@
+<!-- content start -->
+    <div class="section" id="index">
+            <h1>index</h1>
+            <pre><code class="language-php"></code></pre>
+
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/code/literalinclude-lines-invalid/expected/logs/warning.log
+++ b/tests/Integration/tests/code/literalinclude-lines-invalid/expected/logs/warning.log
@@ -1,0 +1,1 @@
+Invalid value for option ":lines:" of directive "literalinclude": "not a range". Expected format: '1-5, 7, 33'. Nothing was included.

--- a/tests/Integration/tests/code/literalinclude-lines-invalid/input/_code/_Example.php
+++ b/tests/Integration/tests/code/literalinclude-lines-invalid/input/_code/_Example.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+class Example
+{
+    // begin example
+    public function test(): string
+    {
+        return 'this is a test';
+    }
+
+    // end example
+}

--- a/tests/Integration/tests/code/literalinclude-lines-invalid/input/index.rst
+++ b/tests/Integration/tests/code/literalinclude-lines-invalid/input/index.rst
@@ -1,0 +1,6 @@
+index
+=====
+
+..  literalinclude:: _code/_Example.php
+    :language: php
+    :lines: not a range

--- a/tests/Integration/tests/code/literalinclude-lines-lineno-start/expected/index.html
+++ b/tests/Integration/tests/code/literalinclude-lines-lineno-start/expected/index.html
@@ -1,0 +1,10 @@
+<!-- content start -->
+    <div class="section" id="index">
+            <h1>index</h1>
+            <pre><code class="language-php line-numbers" data-start="10">    public function test(): string
+    {
+        return &#039;this is a test&#039;;
+    }</code></pre>
+
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/code/literalinclude-lines-lineno-start/input/_code/_Example.php
+++ b/tests/Integration/tests/code/literalinclude-lines-lineno-start/input/_code/_Example.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+class Example
+{
+    // begin example
+    public function test(): string
+    {
+        return 'this is a test';
+    }
+
+    // end example
+}

--- a/tests/Integration/tests/code/literalinclude-lines-lineno-start/input/index.rst
+++ b/tests/Integration/tests/code/literalinclude-lines-lineno-start/input/index.rst
@@ -1,0 +1,10 @@
+index
+=====
+
+..  literalinclude:: _code/_Example.php
+    :language: php
+    :start-after: // begin example
+    :end-before: // end example
+    :lines: 1-4
+    :linenos:
+    :lineno-start: 10

--- a/tests/Integration/tests/code/literalinclude-lines-no-value/expected/index.html
+++ b/tests/Integration/tests/code/literalinclude-lines-no-value/expected/index.html
@@ -1,0 +1,7 @@
+<!-- content start -->
+    <div class="section" id="index">
+            <h1>index</h1>
+            <pre><code class="language-php"></code></pre>
+
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/code/literalinclude-lines-no-value/expected/logs/warning.log
+++ b/tests/Integration/tests/code/literalinclude-lines-no-value/expected/logs/warning.log
@@ -1,0 +1,1 @@
+Option ":lines:" of directive "literalinclude" requires a value, nothing was included.

--- a/tests/Integration/tests/code/literalinclude-lines-no-value/input/_code/_Example.php
+++ b/tests/Integration/tests/code/literalinclude-lines-no-value/input/_code/_Example.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+class Example
+{
+    // begin example
+    public function test(): string
+    {
+        return 'this is a test';
+    }
+
+    // end example
+}

--- a/tests/Integration/tests/code/literalinclude-lines-no-value/input/index.rst
+++ b/tests/Integration/tests/code/literalinclude-lines-no-value/input/index.rst
@@ -1,0 +1,6 @@
+index
+=====
+
+..  literalinclude:: _code/_Example.php
+    :language: php
+    :lines:

--- a/tests/Integration/tests/code/literalinclude-lines-open-end/expected/index.html
+++ b/tests/Integration/tests/code/literalinclude-lines-open-end/expected/index.html
@@ -1,0 +1,14 @@
+<!-- content start -->
+    <div class="section" id="index">
+            <h1>index</h1>
+            <pre><code class="language-php">    public function test(): string
+    {
+        return &#039;this is a test&#039;;
+    }
+
+    // end example
+}
+</code></pre>
+
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/code/literalinclude-lines-open-end/input/_code/_Example.php
+++ b/tests/Integration/tests/code/literalinclude-lines-open-end/input/_code/_Example.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+class Example
+{
+    // begin example
+    public function test(): string
+    {
+        return 'this is a test';
+    }
+
+    // end example
+}

--- a/tests/Integration/tests/code/literalinclude-lines-open-end/input/index.rst
+++ b/tests/Integration/tests/code/literalinclude-lines-open-end/input/index.rst
@@ -1,0 +1,6 @@
+index
+=====
+
+..  literalinclude:: _code/_Example.php
+    :language: php
+    :lines: 8-

--- a/tests/Integration/tests/code/literalinclude-lines-out-of-range/expected/index.html
+++ b/tests/Integration/tests/code/literalinclude-lines-out-of-range/expected/index.html
@@ -1,0 +1,7 @@
+<!-- content start -->
+    <div class="section" id="index">
+            <h1>index</h1>
+            <pre><code class="language-php"></code></pre>
+
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/code/literalinclude-lines-out-of-range/expected/logs/warning.log
+++ b/tests/Integration/tests/code/literalinclude-lines-out-of-range/expected/logs/warning.log
@@ -1,0 +1,1 @@
+Option ":lines:" of directive "literalinclude": the range "100-200" selects no line of "_code/_Example.php".

--- a/tests/Integration/tests/code/literalinclude-lines-out-of-range/input/_code/_Example.php
+++ b/tests/Integration/tests/code/literalinclude-lines-out-of-range/input/_code/_Example.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+class Example
+{
+    // begin example
+    public function test(): string
+    {
+        return 'this is a test';
+    }
+
+    // end example
+}

--- a/tests/Integration/tests/code/literalinclude-lines-out-of-range/input/index.rst
+++ b/tests/Integration/tests/code/literalinclude-lines-out-of-range/input/index.rst
@@ -1,0 +1,6 @@
+index
+=====
+
+..  literalinclude:: _code/_Example.php
+    :language: php
+    :lines: 100-200

--- a/tests/Integration/tests/code/literalinclude-lines-overlapping/expected/index.html
+++ b/tests/Integration/tests/code/literalinclude-lines-overlapping/expected/index.html
@@ -1,0 +1,9 @@
+<!-- content start -->
+    <div class="section" id="index">
+            <h1>index</h1>
+            <pre><code class="language-php">&lt;?php
+class Example
+{</code></pre>
+
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/code/literalinclude-lines-overlapping/input/_code/_Example.php
+++ b/tests/Integration/tests/code/literalinclude-lines-overlapping/input/_code/_Example.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+class Example
+{
+    // begin example
+    public function test(): string
+    {
+        return 'this is a test';
+    }
+
+    // end example
+}

--- a/tests/Integration/tests/code/literalinclude-lines-overlapping/input/index.rst
+++ b/tests/Integration/tests/code/literalinclude-lines-overlapping/input/index.rst
@@ -1,0 +1,6 @@
+index
+=====
+
+..  literalinclude:: _code/_Example.php
+    :language: php
+    :lines: 5-6,1,5

--- a/tests/Integration/tests/code/literalinclude-lines-partly-out-of-range/expected/index.html
+++ b/tests/Integration/tests/code/literalinclude-lines-partly-out-of-range/expected/index.html
@@ -1,0 +1,8 @@
+<!-- content start -->
+    <div class="section" id="index">
+            <h1>index</h1>
+            <pre><code class="language-php">&lt;?php
+</code></pre>
+
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/code/literalinclude-lines-partly-out-of-range/expected/logs/warning.log
+++ b/tests/Integration/tests/code/literalinclude-lines-partly-out-of-range/expected/logs/warning.log
@@ -1,0 +1,1 @@
+Option ":lines:" of directive "literalinclude": the range "100" selects no line of "_code/_Example.php".

--- a/tests/Integration/tests/code/literalinclude-lines-partly-out-of-range/input/_code/_Example.php
+++ b/tests/Integration/tests/code/literalinclude-lines-partly-out-of-range/input/_code/_Example.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+class Example
+{
+    // begin example
+    public function test(): string
+    {
+        return 'this is a test';
+    }
+
+    // end example
+}

--- a/tests/Integration/tests/code/literalinclude-lines-partly-out-of-range/input/index.rst
+++ b/tests/Integration/tests/code/literalinclude-lines-partly-out-of-range/input/index.rst
@@ -1,0 +1,6 @@
+index
+=====
+
+..  literalinclude:: _code/_Example.php
+    :language: php
+    :lines: 1-2,100

--- a/tests/Integration/tests/code/literalinclude-lines-within-markers/expected/index.html
+++ b/tests/Integration/tests/code/literalinclude-lines-within-markers/expected/index.html
@@ -1,0 +1,10 @@
+<!-- content start -->
+    <div class="section" id="index">
+            <h1>index</h1>
+            <pre><code class="language-php">    public function test(): string
+    {
+        return &#039;this is a test&#039;;
+    }</code></pre>
+
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/code/literalinclude-lines-within-markers/input/_code/_Example.php
+++ b/tests/Integration/tests/code/literalinclude-lines-within-markers/input/_code/_Example.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+class Example
+{
+    // begin example
+    public function test(): string
+    {
+        return 'this is a test';
+    }
+
+    // end example
+}

--- a/tests/Integration/tests/code/literalinclude-lines-within-markers/input/index.rst
+++ b/tests/Integration/tests/code/literalinclude-lines-within-markers/input/index.rst
@@ -1,0 +1,8 @@
+index
+=====
+
+..  literalinclude:: _code/_Example.php
+    :language: php
+    :start-after: // begin example
+    :end-before: // end example
+    :lines: 1-4

--- a/tests/Integration/tests/code/literalinclude-lines/expected/index.html
+++ b/tests/Integration/tests/code/literalinclude-lines/expected/index.html
@@ -1,0 +1,10 @@
+<!-- content start -->
+    <div class="section" id="index">
+            <h1>index</h1>
+            <pre><code class="language-php">&lt;?php
+declare(strict_types=1);
+class Example
+{</code></pre>
+
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/code/literalinclude-lines/input/_code/_Example.php
+++ b/tests/Integration/tests/code/literalinclude-lines/input/_code/_Example.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+class Example
+{
+    // begin example
+    public function test(): string
+    {
+        return 'this is a test';
+    }
+
+    // end example
+}

--- a/tests/Integration/tests/code/literalinclude-lines/input/index.rst
+++ b/tests/Integration/tests/code/literalinclude-lines/input/index.rst
@@ -1,0 +1,6 @@
+index
+=====
+
+..  literalinclude:: _code/_Example.php
+    :language: php
+    :lines: 1,3,5-6


### PR DESCRIPTION
Rebased onto `main` now that [#1351](https://github.com/phpDocumentor/guides/pull/1351) has been merged, so the two commits here are the only ones left. @linawolf's two review points are addressed and the change has had another pass since; ready for review.

## What this adds

The Sphinx option `:lines:` for `literalinclude`, so a region can also be selected by line number:

```rst
..  literalinclude:: Example.php
    :language: php
    :lines: 1,3-5,20-
```

Line numbers are 1 based, ranges are inclusive, an omitted end means "up to the last line", and overlapping ranges are included once, in the order of the file. Both ends are clamped to the lines that exist, so `:lines: 1-99999999999` selects the whole region instead of iterating over the number the author wrote down.

The accepted spelling is validated with `DefaultCodeNodeOptionMapper::LINE_NUMBER_RANGES_REGEX`, the pattern already used for `:emphasize-lines:`, so both options are written the same way. If you would rather not have the directive reference the mapper's constant, say so and I will move the pattern to a shared place.

## Order of application

Like Sphinx, `:lines:` is applied **after** `:start-after:` and `:end-before:`, so the numbers count within the marked region rather than within the file. There is an integration test for that combination.

One deliberate deviation from Sphinx: Sphinx keeps the order the ranges were written in and repeats a line that two ranges both select, so `:lines: 5,1` yields line 5 followed by line 1. This implementation sorts and de-duplicates, because a code sample read out of order is far more likely to be a typo than an intention. It is documented on the reference page and pinned by an integration test.

I would still describe markers as the more valuable half of this: line numbers break on every edit above the selected region, markers do not. `:lines:` is here for Sphinx compatibility and for files that have no natural marker.

## Behaviour on an invalid or empty selection

Each range that selects no line is warned about on its own, naming that range, and the remaining ranges are still included — `:lines: 1-2,100` on a 14 line file includes lines 1 and 2 and says that `100` selected nothing. A missing value or a value that is not a list of line numbers logs a warning and includes nothing, consistent with a marker that is not found in [#1351](https://github.com/phpDocumentor/guides/pull/1351).

## Interaction with the numbering options

`:emphasize-lines:` counts within what `:lines:` left over, and `:lineno-start:` stays a plain override of the first number displayed, unrelated to where the selected lines sat in the file. Neither was stated on the reference page and neither was pinned by a test; both are now.

## Documentation

The reference page added in [#1351](https://github.com/phpDocumentor/guides/pull/1351) gets a section on selecting lines by number, including the order of application and the advice to prefer markers where a file has them.

## Tests

Eleven integration tests: a mixed range list, an open ended range, an invalid specification, a range beyond the end of the file, a range list where only one entry is beyond the end, `:lines:` used without a value, a range whose end exceeds `PHP_INT_MAX` as a regression test for the clamping, overlapping ranges given out of order, `:lines:` combined with markers, `:lines:` combined with markers and `:lineno-start:`, and `:lines:` combined with `:emphasize-lines:`.

Local run on the rebased tree: `phpunit` (935 tests, unit + functional + integration), `phpcs`, `phpstan` and `deptrac` all green, `tools/xmllint.sh` clean.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01Mf63edGvCVRQz6mwF8gxcC)_

