### PR TITLE
[BUGFIX] Render a code block without a language instead of aborting the run

### DIFF
--- a/packages/guides-code/src/Code/Twig/CodeExtension.php
+++ b/packages/guides-code/src/Code/Twig/CodeExtension.php
@@ -36,14 +36,19 @@ final class CodeExtension extends AbstractExtension
         ];
     }
 
-    /** @param array<string, mixed> $context */
-    public function highlight(array $context, string $code, string $language = 'text'): string
+    /**
+     * `CodeNode::getLanguage()` is nullable, and templates pass it straight into this filter, so null has to be
+     * accepted here and mean the same as an omitted language.
+     *
+     * @param array<string, mixed> $context
+     */
+    public function highlight(array $context, string $code, string|null $language = null): string
     {
         $debugInformation = $context['debugInformation'] ?? [];
         if (!is_array($debugInformation)) {
             $debugInformation = [];
         }
 
-        return ($this->highlighter)($language, $code, $debugInformation)->code;
+        return ($this->highlighter)($language ?? 'text', $code, $debugInformation)->code;
     }
 }

--- a/packages/guides-code/tests/unit/Twig/CodeExtensionTest.php
+++ b/packages/guides-code/tests/unit/Twig/CodeExtensionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\Code\Twig;
+
+use Highlight\Highlighter as HighlightPHP;
+use phpDocumentor\Guides\Code\Highlighter\HighlightPhpHighlighter;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+final class CodeExtensionTest extends TestCase
+{
+    private CodeExtension $extension;
+
+    protected function setUp(): void
+    {
+        $this->extension = new CodeExtension(new HighlightPhpHighlighter(new HighlightPHP(), new NullLogger()));
+    }
+
+    public function testItHighlightsCodeWithoutALanguageAsPlainText(): void
+    {
+        // A highlighter treats this differently per language: as "text" the quoted part stays plain, in a
+        // programming language it becomes a string token. Plain input would be returned unchanged by every
+        // language and could therefore not tell the fallback apart from any other one.
+        $code = '<a> & "b"';
+
+        self::assertSame(
+            $this->extension->highlight([], $code, 'text'),
+            $this->extension->highlight([], $code, null),
+            'A CodeNode without a language must be rendered like an explicit "text" language',
+        );
+
+        self::assertNotSame(
+            $this->extension->highlight([], $code, 'php'),
+            $this->extension->highlight([], $code, null),
+            'The fixture must be able to tell the "text" fallback apart from another language',
+        );
+    }
+
+    public function testItHighlightsCodeWithALanguage(): void
+    {
+        self::assertStringContainsString(
+            'hljs-keyword',
+            $this->extension->highlight([], '<?php return 1;', 'php'),
+        );
+    }
+}

--- a/packages/guides/resources/template/html/body/code.html.twig
+++ b/packages/guides/resources/template/html/body/code.html.twig
@@ -7,7 +7,7 @@
             <span class="caption-text">{{ renderNode(node.caption) }}</span>
         </div>
     {%- endif -%}
-    <pre{% if node.classes %} class="{{ node.classesString }}"{% endif %}><code class="language-{{ node.language }}{{ node.startingLineNumber ? ' line-numbers' }}"
+    <pre{% if node.classes %} class="{{ node.classesString }}"{% endif %}><code class="language-{{ node.language ?? 'text' }}{{ node.startingLineNumber ? ' line-numbers' }}"
                 {%- if node.startingLineNumber %} data-start="{{ node.startingLineNumber }}"{% endif -%}
                 {%- if node.emphasizeLines %} data-emphasize-lines="{{ node.emphasizeLines }}"{% endif -%}>
     {%- include "body/code/highlighted-code.html.twig" -%}

--- a/tests/Integration/tests/code/literalinclude-without-language/expected/index.html
+++ b/tests/Integration/tests/code/literalinclude-without-language/expected/index.html
@@ -1,0 +1,18 @@
+<!-- content start -->
+    <div class="section" id="index">
+            <h1>index</h1>
+            <pre><code class="language-text">&lt;?php
+
+declare(strict_types=1);
+
+class Example
+{
+    public function test(): string
+    {
+        return 'this is a test';
+    }
+}
+</code></pre>
+
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/code/literalinclude-without-language/input/_code/_Example.php
+++ b/tests/Integration/tests/code/literalinclude-without-language/input/_code/_Example.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+class Example
+{
+    public function test(): string
+    {
+        return 'this is a test';
+    }
+}

--- a/tests/Integration/tests/code/literalinclude-without-language/input/guides.xml
+++ b/tests/Integration/tests/code/literalinclude-without-language/input/guides.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides xmlns="https://www.phpdoc.org/guides"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd">
+    <!-- The highlighting filter of this extension is where a CodeNode without a language used to abort the run -->
+    <extension class="phpDocumentor\Guides\Code" />
+</guides>

--- a/tests/Integration/tests/code/literalinclude-without-language/input/index.rst
+++ b/tests/Integration/tests/code/literalinclude-without-language/input/index.rst
@@ -1,0 +1,4 @@
+index
+=====
+
+..  literalinclude:: _code/_Example.php

--- a/tests/Integration/tests/markdown/code-md/expected/index.html
+++ b/tests/Integration/tests/markdown/code-md/expected/index.html
@@ -2,7 +2,7 @@
 
 <div class="section" id="markdown-with-code-blocks">
             <h1>Markdown with Code Blocks</h1>
-            <pre><code class="language-">&lt;html&gt;
+            <pre><code class="language-text">&lt;html&gt;
   &lt;head&gt;
   &lt;/head&gt;
 &lt;/html&gt;
@@ -10,7 +10,7 @@
 
             <div class="section" id="fenced-code-blocks">
             <h2>Fenced Code Blocks</h2>
-            <pre><code class="language-">{
+            <pre><code class="language-text">{
   &quot;firstName&quot;: &quot;John&quot;,
   &quot;lastName&quot;: &quot;Smith&quot;,
   &quot;age&quot;: 25


### PR DESCRIPTION
## Problem

Rendering a code block whose language is not set aborts the entire run:

```
In CodeExtension.php line 40:
  phpDocumentor\Guides\Code\Twig\CodeExtension::highlight(): Argument #3 ($language) must be of type string, null given
```

`CodeNode::getLanguage()` is nullable, and `packages/guides/resources/template/html/body/code.html.twig` → `body/code/highlighted-code.html.twig` passes it straight into the filter as `{{ node.value|highlight(node.language) }}`. The filter's signature already carries the intended fallback — `string $language = 'text'` — but a default value cannot apply to an argument that is passed explicitly, so null reaches a non-nullable parameter and PHP throws.

## Reproduction

The shortest way to reach a `CodeNode` without a language is a `literalinclude` without `:language:`:

```rst
index
=====

..  literalinclude:: _Example.php
```

`vendor/bin/guides run input --output=out` on that project fails with the `TypeError` above and renders nothing. Measured on `main` at `90594491`, so this is not a regression from anything currently in flight.

The project needs `<extension class="phpDocumentor\Guides\Code"/>` in its `guides.xml`, the way this repository's own `guides.xml` has it. Without the extension the container keeps the fallback template `packages/guides/resources/template/html/body/code/highlighted-code.html.twig`, a bare `{{ node.value }}`, and the filter is never called.

`code-block` is not affected: `CodeBlockDirective` always calls `setLanguage()`, either with the given language or with `getCodeBlockDefaultLanguage()`, which returns a `string`.

## Fix

`CodeExtension::highlight()` accepts `string|null` and falls back to `text`, which is what the existing default already expressed.

`code.html.twig` writes `class="language-{{ node.language ?? 'text' }}"`, so the class attribute names the language the content is actually highlighted with. Without this the block rendered as `text` but was labelled `class="language-"`.

Only null is mapped, matching the filter. An empty-string language still renders `class="language-"`, which is what a literal block (`::`) and a `code-block` without language produce today; the highlighter maps `''` to text as well, so normalizing that too would be consistent, but it rewrites ten further expectations across nine files and is a separate change.

## Tests

`packages/guides-code/tests/unit/Twig/CodeExtensionTest.php` asserts that a null language renders exactly like an explicit `text`, plus one test that a real language still highlights.

The fixture is `<a> & "b"` on purpose: a highlighter returns plain input unchanged for every language, so a plain fixture would pass no matter what the fallback is. With this one, `text` leaves the quoted part alone while `php` wraps it in a string token, and a second assertion states that the two differ, so the fixture itself is pinned as discriminating. Two mutations were checked against it: removing the null acceptance fails with the `TypeError` above, and changing the fallback to `php` fails the equality assertion.

`tests/Integration/tests/code/literalinclude-without-language` runs the reproduction above through the CLI. Its `guides.xml` enables the `Code` extension, because otherwise the fallback template `packages/guides/resources/template/html/body/code/highlighted-code.html.twig` renders and the filter is never reached. Both halves of the fix were mutated against it: reverting the filter signature fails with the original `TypeError` raised in `body/code/highlighted-code.html.twig`, reverting the template fallback fails on `language-` vs `language-text`.

`tests/Integration/tests/markdown/code-md` changes: a fenced code block without an info string carries a null language too, so its two expectations move from `language-` to `language-text`.

The TeX template renders `\lstset{language={{ node.language }}}` without a fallback as well, but null and `''` produce the same `\lstset{language=}` there, which is the committed expectation for a language-less block in `tests/Functional/tests/code/code.tex`. There is nothing null-specific to fix there, so it is left unchanged.

Local run of `phpunit` (unit, functional, integration), `phpcs`, `phpstan` and `deptrac`: green.

## Note

There is a second, complementary option: let `LiteralincludeDirective` fall back to `getCodeBlockDefaultLanguage()` the way `CodeBlockDirective` does — the producer-side approach [#1302](https://github.com/phpDocumentor/guides/pull/1302) took for markdown fenced code blocks. I did not do that here because it would leave the crash reachable from any other producer, and because the type mismatch really is at the template-to-filter boundary. Happy to add the directive-side default as well if you prefer both.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_0129QU37uCnSL1ZkmD8bdqxQ)_
