### PR TITLE
[TASK] Declare psr/log in the packages that use it

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1715,7 +1715,7 @@
             "dist": {
                 "type": "path",
                 "url": "./packages/guides",
-                "reference": "569c35aee270c467111959c7e4311d1d13eb82df"
+                "reference": "c269414036ffd1340ad67bcc9e4cad66c54b24a1"
             },
             "require": {
                 "doctrine/deprecations": "^1.1",
@@ -1728,6 +1728,7 @@
                 "phpdocumentor/filesystem": "^1.7.4",
                 "phpdocumentor/flyfinder": "^1.1 || ^2.0",
                 "psr/event-dispatcher": "^1.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
                 "symfony/clock": "^6.4.8 || ^7.4 || ^8",
                 "symfony/html-sanitizer": "^6.4.8 || ^7.4 || ^8",
                 "symfony/http-client": "^6.4.9 || ^7.4 || ^8",
@@ -1736,9 +1737,6 @@
                 "symfony/translation-contracts": "^3.5.1",
                 "twig/twig": "~2.15 || ^3.0",
                 "webmozart/assert": "^1.11"
-            },
-            "require-dev": {
-                "psr/log": "^3.0.2"
             },
             "type": "library",
             "extra": {
@@ -1773,13 +1771,14 @@
             "dist": {
                 "type": "path",
                 "url": "./packages/guides-cli",
-                "reference": "129e2a05e223ed1d9dee140bb1f39a23424d3042"
+                "reference": "b36a2d466011e38c0a9648afec67a1a1601eba99"
             },
             "require": {
                 "monolog/monolog": "^3.0",
                 "php": "^8.1",
                 "phpdocumentor/guides": "^1.0 || ^2.0",
                 "phpdocumentor/guides-restructured-text": "^1.0 || ^2.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
                 "symfony/config": "^5.4 || ^6.3 || ^7.0 || ^8.0",
                 "symfony/console": "^5.4 || ^6.3 || ^7.0 || ^8.0",
                 "symfony/dependency-injection": "^5.4 || ^6.3 || ^7.0 || ^8.0",
@@ -1829,11 +1828,12 @@
             "dist": {
                 "type": "path",
                 "url": "./packages/guides-code",
-                "reference": "9968c98c68ab630d39bd25c8b677ebe9fd537995"
+                "reference": "46851d8bad35ffa7e7d442aaddeac5d763c14e21"
             },
             "require": {
                 "php": "^8.1",
-                "scrivo/highlight.php": "^9.18.0"
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "scrivo/highlight.php": "^9.18.1.10"
             },
             "type": "library",
             "extra": {
@@ -1868,13 +1868,14 @@
             "dist": {
                 "type": "path",
                 "url": "./packages/guides-graphs",
-                "reference": "572c91982e3f3256688fd84305951c6143d502e1"
+                "reference": "4c4c92b15973b0172548de8df09979509f04f603"
             },
             "require": {
                 "jawira/plantuml-encoding": "^1.0",
                 "php": "^8.1",
                 "phpdocumentor/guides": "^1.0 || ^2.0",
                 "phpdocumentor/guides-restructured-text": "^1.0 || ^2.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
                 "symfony/process": "^5.4 || ^6.3 || ^7.0 || ^8.0",
                 "twig/twig": "~2.0 || ^3.0"
             },
@@ -1914,12 +1915,13 @@
             "dist": {
                 "type": "path",
                 "url": "./packages/guides-markdown",
-                "reference": "b68c5dbb93b12ea1e9e4526b1e0debc225af8155"
+                "reference": "5e4223c12ba81c5a943c45fb189a777ff97a25a5"
             },
             "require": {
                 "league/commonmark": "^2.4",
                 "php": "^8.1",
                 "phpdocumentor/guides": "^1.0 || ^2.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
                 "symfony/yaml": "^6.4 || ^7.0 || ^8.0"
             },
             "type": "library",
@@ -1955,13 +1957,14 @@
             "dist": {
                 "type": "path",
                 "url": "./packages/guides-restructured-text",
-                "reference": "72eb9213863dcec1603d22f6701aca271fd3ba7a"
+                "reference": "049588f02b220c817fb668368dc27cedf893e6dd"
             },
             "require": {
                 "doctrine/lexer": "^3.0",
                 "league/csv": "^9.27.0",
                 "php": "^8.1",
                 "phpdocumentor/guides": "^1.0 || ^2.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
                 "webmozart/assert": "^1.11"
             },
             "type": "library",
@@ -1997,12 +2000,14 @@
             "dist": {
                 "type": "path",
                 "url": "./packages/guides-theme-bootstrap",
-                "reference": "a3ad78c3fc59928050b1ff3997a676248b0728a1"
+                "reference": "e39675465c2c8f0122592654b0d102f474c9cb99"
             },
             "require": {
+                "doctrine/deprecations": "^1.1",
                 "php": "^8.1",
                 "phpdocumentor/guides": "^1.0 || ^2.0",
-                "phpdocumentor/guides-restructured-text": "^1.0 || ^2.0"
+                "phpdocumentor/guides-restructured-text": "^1.10 || ^2.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0"
             },
             "type": "library",
             "extra": {

--- a/packages/guides-cli/composer.json
+++ b/packages/guides-cli/composer.json
@@ -29,6 +29,7 @@
         "monolog/monolog": "^3.0",
         "phpdocumentor/guides": "^1.0 || ^2.0",
         "phpdocumentor/guides-restructured-text": "^1.0 || ^2.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "symfony/config": "^5.4 || ^6.3 || ^7.0 || ^8.0",
         "symfony/console": "^5.4 || ^6.3 || ^7.0 || ^8.0",
         "symfony/dependency-injection": "^5.4 || ^6.3 || ^7.0 || ^8.0",

--- a/packages/guides-code/composer.json
+++ b/packages/guides-code/composer.json
@@ -21,6 +21,7 @@
     },
     "require": {
         "php": "^8.1",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "scrivo/highlight.php": "^9.18.1.10"
     },
     "extra": {

--- a/packages/guides-graphs/composer.json
+++ b/packages/guides-graphs/composer.json
@@ -25,6 +25,7 @@
         "phpdocumentor/guides": "^1.0 || ^2.0",
         "phpdocumentor/guides-restructured-text": "^1.0 || ^2.0",
         "jawira/plantuml-encoding": "^1.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "symfony/process": "^5.4 || ^6.3 || ^7.0 || ^8.0",
         "twig/twig": "~2.0 || ^3.0"
     },

--- a/packages/guides-markdown/composer.json
+++ b/packages/guides-markdown/composer.json
@@ -24,6 +24,7 @@
         "php": "^8.1",
         "league/commonmark": "^2.4",
         "phpdocumentor/guides": "^1.0 || ^2.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "symfony/yaml": "^6.4 || ^7.0 || ^8.0"
     },
     "extra": {

--- a/packages/guides-restructured-text/composer.json
+++ b/packages/guides-restructured-text/composer.json
@@ -24,6 +24,7 @@
         "php": "^8.1",
         "doctrine/lexer": "^3.0",
         "phpdocumentor/guides": "^1.0 || ^2.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "webmozart/assert": "^1.11",
         "league/csv": "^9.27.0"
     },

--- a/packages/guides-theme-bootstrap/composer.json
+++ b/packages/guides-theme-bootstrap/composer.json
@@ -16,7 +16,8 @@
         "php": "^8.1",
         "doctrine/deprecations": "^1.1",
         "phpdocumentor/guides": "^1.0 || ^2.0",
-        "phpdocumentor/guides-restructured-text": "^1.10 || ^2.0"
+        "phpdocumentor/guides-restructured-text": "^1.10 || ^2.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0"
     },
     "extra": {
         "branch-alias": {

--- a/packages/guides/composer.json
+++ b/packages/guides/composer.json
@@ -31,6 +31,7 @@
         "phpdocumentor/flyfinder": "^1.1 || ^2.0",
         "phpdocumentor/filesystem": "^1.7.4",
         "psr/event-dispatcher": "^1.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "symfony/clock": "^6.4.8 || ^7.4 || ^8",
         "symfony/html-sanitizer": "^6.4.8 || ^7.4 || ^8",
         "symfony/http-client": "^6.4.9 || ^7.4 || ^8",
@@ -39,9 +40,6 @@
         "symfony/translation-contracts": "^3.5.1",
         "twig/twig": "~2.15 || ^3.0",
         "webmozart/assert": "^1.11"
-    },
-    "require-dev": {
-        "psr/log": "^3.0.2"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
## Problem

Seven packages use PSR-3 in their production code without requiring it. `Psr\Log\LoggerInterface` is a required constructor argument in classes such as `ParseFileHandler`, and `Psr\Log\LogLevel` is read in the DI extension — but no package's `require` mentions `psr/log`. `packages/guides` declares it under `require-dev`, which does not cover production use.

It resolves today because `symfony/http-client` (a `require` of `phpdocumentor/guides`) and `monolog/monolog` (a `require` of `phpdocumentor/guides-cli`) both pull `psr/log` in. That is a stable path, not a coincidence, but it is undeclared: if either dependency is dropped or makes `psr/log` optional, every `LoggerInterface` type hint breaks at autoload time and Composer will not have warned about it. Since each package is sub-split into its own published package, the indirection becomes a consumer's problem rather than this repository's.

## Changes

`psr/log: ^1.0 || ^2.0 || ^3.0` added to `require` of guides, guides-cli, guides-code, guides-graphs, guides-markdown, guides-restructured-text and guides-theme-bootstrap. For `packages/guides` this is a move out of `require-dev`.

The range is deliberately the one `symfony/http-client` already allows, so no consumer loses a resolution it has today and nothing here needs to be excluded from a 1.0 backport. It is also what `phpdocumentor/dev-server` already declares in this repository.

That range is safe for the code as written: only `LoggerInterface` and `LogLevel` are used, both unchanged across the three majors, and no class in any package implements `LoggerInterface` — which is where a v1/v3 signature difference would bite.

## Verification

`composer-require-checker` is present in `.phive/phars.xml` but is not invoked by any workflow, composer script or Makefile, so nothing currently detects this class of defect. I ran it manually as a controlled before/after on a standalone install of `guides-code`, the smallest affected package: without the declaration `Psr\Log\LoggerInterface` is listed as an unknown symbol, with it the symbol is gone.

Full suite on the branch: 828 tests, no failures. Also run with `--prefer-lowest`, which resolves `psr/log` to 2.0.0 and passes. `composer validate --strict` passes for the root and every package.

## Note on the lock

The lock refresh carries three corrections that were already stale before this branch: `scrivo/highlight.php` in guides-code, and the `doctrine/deprecations` and `phpdocumentor/guides-restructured-text` entries in guides-theme-bootstrap. They are a side effect of `composer update --lock`, not edits to those `composer.json` files.

## Out of scope

An earlier revision of this branch also added `fig/log-test` to the `require-dev` of guides-code and guides-restructured-text, whose tests use `Psr\Log\Test\TestLogger`. That is dropped: every package marks `/tests export-ignore`, so the published packages contain no tests and the declaration would describe a dependency nothing in the package uses. The root `composer.json`, where the tests actually run, already declares it.

The same tool run against `guides-code` reports further unknown symbols beyond `Psr\Log`, among them `Symfony\Component\DependencyInjection\*`, `Symfony\Component\Config\*`, `Twig\*` and `phpDocumentor\Guides\*`. That is the same class of defect at a larger scale and some of it may be deliberate for optional integrations, so it is left alone. Happy to open an issue, or to wire `composer-require-checker` into CI so it stops recurring.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_0114KJz3vqq2WWfx4FUdmcss)_
