### PR TITLE
[FEATURE] Support selecting an alternate template per document

### DIFF
--- a/packages/guides-restructured-text/resources/config/guides-restructured-text.php
+++ b/packages/guides-restructured-text/resources/config/guides-restructured-text.php
@@ -89,6 +89,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldList\Organizat
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldList\OrphanFieldListItemRule;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldList\ProjectFieldListItemRule;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldList\RevisionFieldListItemRule;
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldList\TemplateFieldListItemRule;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldList\TocDepthFieldListItemRule;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldList\VersionFieldListItemRule;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldListRule;
@@ -352,6 +353,9 @@ return static function (ContainerConfigurator $container): void {
         ->tag('phpdoc.guides.parser.rst.fieldlist')
 
         ->set(TocDepthFieldListItemRule::class)
+        ->tag('phpdoc.guides.parser.rst.fieldlist')
+
+        ->set(TemplateFieldListItemRule::class)
         ->tag('phpdoc.guides.parser.rst.fieldlist')
 
         ->set(VersionFieldListItemRule::class)

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/TemplateFieldListItemRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/FieldList/TemplateFieldListItemRule.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldList;
+
+use phpDocumentor\Guides\Nodes\FieldLists\FieldListItemNode;
+use phpDocumentor\Guides\Nodes\Metadata\MetadataNode;
+use phpDocumentor\Guides\Nodes\Metadata\TemplateNode;
+use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
+
+use function strtolower;
+
+final class TemplateFieldListItemRule implements FieldListItemRule
+{
+    public function applies(FieldListItemNode $fieldListItemNode): bool
+    {
+        return strtolower($fieldListItemNode->getTerm()) === 'template';
+    }
+
+    public function apply(FieldListItemNode $fieldListItemNode, BlockContext $blockContext): MetadataNode
+    {
+        return new TemplateNode($fieldListItemNode->getPlaintextContent());
+    }
+}

--- a/packages/guides-restructured-text/tests/unit/Parser/Productions/FieldList/TemplateFieldListItemRuleTest.php
+++ b/packages/guides-restructured-text/tests/unit/Parser/Productions/FieldList/TemplateFieldListItemRuleTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\RestructuredText\Parser\Productions\FieldList;
+
+use phpDocumentor\Guides\Nodes\FieldLists\FieldListItemNode;
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\RuleTestCase;
+
+final class TemplateFieldListItemRuleTest extends RuleTestCase
+{
+    private TemplateFieldListItemRule $rule;
+
+    protected function setUp(): void
+    {
+        $this->rule = new TemplateFieldListItemRule();
+    }
+
+    public function test_it_applies_to_a_template_field_regardless_of_case(): void
+    {
+        self::assertTrue($this->rule->applies(new FieldListItemNode('template', 'genindex')));
+        self::assertTrue($this->rule->applies(new FieldListItemNode('Template', 'genindex')));
+        self::assertFalse($this->rule->applies(new FieldListItemNode('orphan', '')));
+    }
+}

--- a/packages/guides/resources/config/guides.php
+++ b/packages/guides/resources/config/guides.php
@@ -18,6 +18,7 @@ use phpDocumentor\Guides\NodeRenderers\Html\DocumentNodeRenderer;
 use phpDocumentor\Guides\NodeRenderers\Html\MenuEntryRenderer;
 use phpDocumentor\Guides\NodeRenderers\Html\MenuNodeRenderer;
 use phpDocumentor\Guides\NodeRenderers\Html\TableNodeRenderer;
+use phpDocumentor\Guides\NodeRenderers\Html\TemplateMetadataNodeRenderer;
 use phpDocumentor\Guides\NodeRenderers\OutputAwareDelegatingNodeRenderer;
 use phpDocumentor\Guides\Parser;
 use phpDocumentor\Guides\ReferenceResolvers\AnchorHyperlinkResolver;
@@ -197,6 +198,8 @@ return static function (ContainerConfigurator $container): void {
         )
 
         ->set(DocumentNodeRenderer::class)
+        ->tag('phpdoc.guides.noderenderer.html')
+        ->set(TemplateMetadataNodeRenderer::class)
         ->tag('phpdoc.guides.noderenderer.html')
         ->set(TableNodeRenderer::class)
         ->tag('phpdoc.guides.noderenderer.html')

--- a/packages/guides/src/NodeRenderers/Html/TemplateMetadataNodeRenderer.php
+++ b/packages/guides/src/NodeRenderers/Html/TemplateMetadataNodeRenderer.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\NodeRenderers\Html;
+
+use phpDocumentor\Guides\NodeRenderers\NodeRenderer;
+use phpDocumentor\Guides\Nodes\Metadata\TemplateNode;
+use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RenderContext;
+
+use function is_a;
+
+/**
+ * The `:template:` field is a marker consumed by DocumentNode::getTemplate(),
+ * not visible content — render it as nothing.
+ *
+ * @implements NodeRenderer<TemplateNode>
+ */
+final class TemplateMetadataNodeRenderer implements NodeRenderer
+{
+    public function render(Node $node, RenderContext $renderContext): string
+    {
+        return '';
+    }
+
+    public function supports(string $nodeFqcn): bool
+    {
+        return $nodeFqcn === TemplateNode::class || is_a($nodeFqcn, TemplateNode::class, true);
+    }
+}

--- a/packages/guides/src/Nodes/DocumentNode.php
+++ b/packages/guides/src/Nodes/DocumentNode.php
@@ -20,6 +20,7 @@ use phpDocumentor\Guides\Nodes\DocumentTree\SectionEntryNode;
 use phpDocumentor\Guides\Nodes\Menu\TocNode;
 use phpDocumentor\Guides\Nodes\Metadata\MetadataNode;
 use phpDocumentor\Guides\Nodes\Metadata\NavigationTitleNode;
+use phpDocumentor\Guides\Nodes\Metadata\TemplateNode;
 
 use function array_filter;
 use function max;
@@ -75,6 +76,7 @@ final class DocumentNode extends CompoundNode
     private SectionEntryNode|null $rootSectionEntry = null;
     private bool $isRoot = false;
     private bool $orphan = false;
+    private string|null $template = null;
 
     public function __construct(
         private readonly string $hash,
@@ -142,6 +144,10 @@ final class DocumentNode extends CompoundNode
     {
         if ($node instanceof NavigationTitleNode) {
             $this->navigationTitle = $node->getValue();
+        }
+
+        if ($node instanceof TemplateNode) {
+            $this->template = $node->getValue();
         }
 
         $this->headerNodes[] = $node;
@@ -328,5 +334,10 @@ final class DocumentNode extends CompoundNode
         $this->orphan = $orphan;
 
         return $this;
+    }
+
+    public function getTemplate(): string|null
+    {
+        return $this->template;
     }
 }

--- a/packages/guides/src/Nodes/Metadata/TemplateNode.php
+++ b/packages/guides/src/Nodes/Metadata/TemplateNode.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\Nodes\Metadata;
+
+/**
+ * Selects an alternate template for rendering the document, e.g. `:template: genindex`.
+ */
+final class TemplateNode extends MetadataNode
+{
+    public function __construct(string $template)
+    {
+        parent::__construct($template);
+    }
+}

--- a/packages/guides/tests/unit/NodeRenderers/Html/TemplateMetadataNodeRendererTest.php
+++ b/packages/guides/tests/unit/NodeRenderers/Html/TemplateMetadataNodeRendererTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\NodeRenderers\Html;
+
+use phpDocumentor\Guides\Nodes\Metadata\NavigationTitleNode;
+use phpDocumentor\Guides\Nodes\Metadata\TemplateNode;
+use PHPUnit\Framework\TestCase;
+
+final class TemplateMetadataNodeRendererTest extends TestCase
+{
+    private TemplateMetadataNodeRenderer $renderer;
+
+    protected function setUp(): void
+    {
+        $this->renderer = new TemplateMetadataNodeRenderer();
+    }
+
+    public function test_it_supports_only_template_nodes(): void
+    {
+        self::assertTrue($this->renderer->supports(TemplateNode::class));
+        self::assertFalse($this->renderer->supports(NavigationTitleNode::class));
+    }
+}


### PR DESCRIPTION
Add the generic `:template:` field-list metadata: TemplateNode,
TemplateFieldListItemRule to parse it, TemplateMetadataNodeRenderer to
render it as nothing (it's a marker, not visible content), and
DocumentNode::getTemplate() to expose the selected template name.

Split out of #1358 per review feedback -- the genindex work on that
branch is the first consumer (`:template: genindex`), but the
mechanism itself is generic and reviewable on its own.

Signed-off-by: lina.wolf <lwolf@w-commerce.de>

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01PP4LkejR5PSubbhNmF4RkT)_