### PR TITLE
[FEATURE] Support :version-removed: directive

### DIFF
--- a/packages/guides-restructured-text/resources/config/guides-restructured-text.php
+++ b/packages/guides-restructured-text/resources/config/guides-restructured-text.php
@@ -59,6 +59,7 @@ use phpDocumentor\Guides\RestructuredText\Directives\ToctreeDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\TodoDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\VersionAddedDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\VersionChangedDirective;
+use phpDocumentor\Guides\RestructuredText\Directives\VersionRemovedDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\WarningDirective;
 use phpDocumentor\Guides\RestructuredText\Directives\YoutubeDirective;
 use phpDocumentor\Guides\RestructuredText\MarkupLanguageParser;
@@ -245,6 +246,7 @@ return static function (ContainerConfigurator $container): void {
         ->set(TodoDirective::class)
         ->set(VersionAddedDirective::class)
         ->set(VersionChangedDirective::class)
+        ->set(VersionRemovedDirective::class)
         ->set(WarningDirective::class)
         ->set(YoutubeDirective::class)
 

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/VersionRemovedDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/VersionRemovedDirective.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\RestructuredText\Directives;
+
+use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
+
+/**
+ * This directive is used to document that a feature was removed in a specific version.
+ *
+ * Basic usage
+ *
+ * ```rst
+ *   .. version-removed:: 3.0
+ *
+ *       This feature was removed.
+ * ```
+ *
+ * The legacy name `versionremoved` is supported as an alias.
+ */
+#[Attributes\Directive(name: 'version-removed', aliases: ['versionremoved'])]
+final class VersionRemovedDirective extends AbstractVersionChangeDirective
+{
+    public function __construct(protected Rule $startingRule)
+    {
+        parent::__construct($startingRule, 'version-removed', 'Removed in version %s');
+    }
+}

--- a/tests/Functional/tests/versionchanges/versionchanges.html
+++ b/tests/Functional/tests/versionchanges/versionchanges.html
@@ -34,3 +34,15 @@
         <p>Don&#039;t use this feature, it was deprecated using the new directive name.</p>
     </article>
 </div>
+<div class="versionchange version-removed">
+    <p class="versionmodified">Removed in version 3.0</p>
+    <article>
+        <p>This feature was removed.</p>
+    </article>
+</div>
+<div class="versionchange version-removed">
+    <p class="versionmodified">Removed in version 3.1</p>
+    <article>
+        <p>This feature was removed using the legacy alias.</p>
+    </article>
+</div>

--- a/tests/Functional/tests/versionchanges/versionchanges.rst
+++ b/tests/Functional/tests/versionchanges/versionchanges.rst
@@ -21,3 +21,11 @@
 .. version-deprecated:: 2.7
 
     Don't use this feature, it was deprecated using the new directive name.
+
+.. version-removed:: 3.0
+
+    This feature was removed.
+
+.. versionremoved:: 3.1
+
+    This feature was removed using the legacy alias.


### PR DESCRIPTION
Add a version-removed directive alongside the existing versionadded,
versionchanged, and deprecated directives, register it in the DI
container, and extend the versionchanges functional test fixture
with coverage. Aligns with Sphinx 9.0's version-removed naming; the
legacy versionremoved name is supported as an alias.

Resolves: #1339
Co-authored-by: Tomas Norre Mikkelsen <tomasnorre@gmail.com>
Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PP4LkejR5PSubbhNmF4RkT
Signed-off-by: lina.wolf