### PR TITLE
[FEATURE] Support Sphinx 9.0's version-added/version-changed/version-deprecated directive names

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Directives/AbstractVersionChangeDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/AbstractVersionChangeDirective.php
@@ -23,8 +23,17 @@ use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
 /** @see https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-versionadded */
 abstract class AbstractVersionChangeDirective extends SubDirective
 {
-    public function __construct(protected Rule $startingRule, private readonly string $type, private readonly string $label)
-    {
+    /**
+     * @param string $name the directive's name, as matched in the .rst source; may differ from $type so
+     *                      that renaming a directive does not also change the CSS class of its rendered output
+     * @param string $type the type passed to VersionChangeNode, also used as the rendered CSS class
+     */
+    public function __construct(
+        protected Rule $startingRule,
+        private readonly string $name,
+        private readonly string $type,
+        private readonly string $label,
+    ) {
         parent::__construct($startingRule);
     }
 
@@ -47,6 +56,6 @@ abstract class AbstractVersionChangeDirective extends SubDirective
 
     final public function getName(): string
     {
-        return $this->type;
+        return $this->name;
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/DeprecatedDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/DeprecatedDirective.php
@@ -15,10 +15,29 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
 
+/**
+ * This directive is used to document that a feature was deprecated in a specific version.
+ *
+ * Basic usage
+ *
+ * ```rst
+ *   .. version-deprecated:: 2.4
+ *
+ *       Don't use this feature, it'll be removed in 3.0.
+ * ```
+ *
+ * The legacy name `deprecated` is supported as an alias.
+ */
 final class DeprecatedDirective extends AbstractVersionChangeDirective
 {
     public function __construct(protected Rule $startingRule)
     {
-        parent::__construct($startingRule, 'deprecated', 'Deprecated since version %s');
+        parent::__construct($startingRule, 'version-deprecated', 'deprecated', 'Deprecated since version %s');
+    }
+
+    /** {@inheritDoc} */
+    public function getAliases(): array
+    {
+        return ['deprecated'];
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/VersionAddedDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/VersionAddedDirective.php
@@ -15,10 +15,29 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
 
+/**
+ * This directive is used to document that a feature was added in a specific version.
+ *
+ * Basic usage
+ *
+ * ```rst
+ *   .. version-added:: 2.0
+ *
+ *       Some feature was introduced.
+ * ```
+ *
+ * The legacy name `versionadded` is supported as an alias.
+ */
 final class VersionAddedDirective extends AbstractVersionChangeDirective
 {
     public function __construct(protected Rule $startingRule)
     {
-        parent::__construct($startingRule, 'versionadded', 'New in version %s');
+        parent::__construct($startingRule, 'version-added', 'versionadded', 'New in version %s');
+    }
+
+    /** {@inheritDoc} */
+    public function getAliases(): array
+    {
+        return ['versionadded'];
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/VersionChangedDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/VersionChangedDirective.php
@@ -15,10 +15,29 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
 
+/**
+ * This directive is used to document that a feature changed behavior in a specific version.
+ *
+ * Basic usage
+ *
+ * ```rst
+ *   .. version-changed:: 2.2
+ *
+ *       Some feature changed, prior to 2.2 it behaved differently.
+ * ```
+ *
+ * The legacy name `versionchanged` is supported as an alias.
+ */
 final class VersionChangedDirective extends AbstractVersionChangeDirective
 {
     public function __construct(protected Rule $startingRule)
     {
-        parent::__construct($startingRule, 'versionchanged', 'Changed in version %s');
+        parent::__construct($startingRule, 'version-changed', 'versionchanged', 'Changed in version %s');
+    }
+
+    /** {@inheritDoc} */
+    public function getAliases(): array
+    {
+        return ['versionchanged'];
     }
 }

--- a/tests/Functional/tests/versionchanges/versionchanges.html
+++ b/tests/Functional/tests/versionchanges/versionchanges.html
@@ -16,3 +16,21 @@
         <p>Don&#039;t use this feature, it&#039;ll be removed in 3.0.</p>
     </article>
 </div>
+<div class="versionchange versionadded">
+    <p class="versionmodified">New in version 2.5</p>
+    <article>
+        <p>Some feature was introduced using the new directive name.</p>
+    </article>
+</div>
+<div class="versionchange versionchanged">
+    <p class="versionmodified">Changed in version 2.6</p>
+    <article>
+        <p>Some feature changed using the new directive name.</p>
+    </article>
+</div>
+<div class="versionchange deprecated">
+    <p class="versionmodified">Deprecated since version 2.7</p>
+    <article>
+        <p>Don&#039;t use this feature, it was deprecated using the new directive name.</p>
+    </article>
+</div>

--- a/tests/Functional/tests/versionchanges/versionchanges.rst
+++ b/tests/Functional/tests/versionchanges/versionchanges.rst
@@ -9,3 +9,15 @@
 .. deprecated:: 2.4
 
     Don't use this feature, it'll be removed in 3.0.
+
+.. version-added:: 2.5
+
+    Some feature was introduced using the new directive name.
+
+.. version-changed:: 2.6
+
+    Some feature changed using the new directive name.
+
+.. version-deprecated:: 2.7
+
+    Don't use this feature, it was deprecated using the new directive name.


### PR DESCRIPTION
Sphinx 9.0 renamed versionadded, versionchanged, and deprecated to
version-added, version-changed, and version-deprecated, keeping the
old names as aliases. Do the same here: decouple the directive's
matched name from its rendered CSS type in
AbstractVersionChangeDirective so the new canonical names can be
used while existing custom CSS/themes keyed on the old class names
(versionadded, versionchanged, deprecated) keep working unchanged.
Extends the versionchanges functional test fixture to cover the new
names.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PP4LkejR5PSubbhNmF4RkT
Signed-off-by: lina.wolf