### PR TITLE
[FEATURE] Support :sourcecode: as an alias for code-block

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Directives/CodeBlockDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/CodeBlockDirective.php
@@ -49,7 +49,7 @@ final class CodeBlockDirective extends BaseDirective
     /** {@inheritDoc} */
     public function getAliases(): array
     {
-        return ['code', 'parsed-literal'];
+        return ['code', 'parsed-literal', 'sourcecode'];
     }
 
     /** {@inheritDoc} */

--- a/tests/Functional/tests/code-block-sourcecode-alias/code-block-sourcecode-alias.html
+++ b/tests/Functional/tests/code-block-sourcecode-alias/code-block-sourcecode-alias.html
@@ -1,0 +1,3 @@
+<pre><code class="language-c++">#include &lt;iostream&gt; using namespace std; int main(void)
+{ cout &lt;&lt; &quot;Hello world!&quot; &lt;&lt; endl;
+}</code></pre>

--- a/tests/Functional/tests/code-block-sourcecode-alias/code-block-sourcecode-alias.rst
+++ b/tests/Functional/tests/code-block-sourcecode-alias/code-block-sourcecode-alias.rst
@@ -1,0 +1,10 @@
+.. sourcecode:: c++
+
+    #include <iostream>
+
+    using namespace std;
+
+    int main(void)
+    {
+        cout << "Hello world!" << endl;
+    }


### PR DESCRIPTION
Sphinx supports sourcecode as an alias of code-block, alongside the
already-supported code and parsed-literal aliases. Add it here too,
with a functional test fixture covering the alias.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PP4LkejR5PSubbhNmF4RkT
Signed-off-by: lina.wolf