### PR TITLE
[TASK] Remove dependency on gajus/dindent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,6 @@
         "doctrine/coding-standard": "^13.0",
         "fakerphp/faker": "^1.24",
         "fig/log-test": "^1.0",
-        "gajus/dindent": "^2.0.1",
         "jangregor/phpstan-prophecy": "^2.3",
         "league/csv": "^9.0",
         "league/flysystem-memory": "^1.0 || ^3.29",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "15e0a22f2cb927b8ef931f58253dc7fd",
+    "content-hash": "f64b96df208aed10559f784a82b3057c",
     "packages": [
         {
             "name": "cboden/ratchet",
@@ -5787,55 +5787,6 @@
                 "source": "https://github.com/php-fig/log-test/tree/1.2.1"
             },
             "time": "2025-11-11T10:33:05+00:00"
-        },
-        {
-            "name": "gajus/dindent",
-            "version": "2.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/gajus/dindent.git",
-                "reference": "d81c3a6f78fbe1ab26f5e753098bbbef6b6a9f3c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/gajus/dindent/zipball/d81c3a6f78fbe1ab26f5e753098bbbef6b6a9f3c",
-                "reference": "d81c3a6f78fbe1ab26f5e753098bbbef6b6a9f3c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3"
-            },
-            "require-dev": {
-                "satooshi/php-coveralls": "dev-master"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Gajus\\Dindent\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Gajus Kuizinas",
-                    "email": "gk@anuary.com"
-                }
-            ],
-            "description": "HTML indentation library for development and testing.",
-            "homepage": "https://github.com/gajus/dindent",
-            "keywords": [
-                "format",
-                "html",
-                "indent"
-            ],
-            "support": {
-                "issues": "https://github.com/gajus/dindent/issues",
-                "source": "https://github.com/gajus/dindent/tree/master"
-            },
-            "time": "2014-10-08T10:03:04+00:00"
         },
         {
             "name": "jangregor/phpstan-prophecy",

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\Functional;
 
+use DOMDocument;
 use Exception;
-use Gajus\Dindent\Indenter;
 use League\Flysystem\Filesystem;
 use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
 use Monolog\Handler\TestHandler;
@@ -49,7 +49,9 @@ use function file_get_contents;
 use function implode;
 use function in_array;
 use function is_string;
-use function rtrim;
+use function libxml_clear_errors;
+use function libxml_use_internal_errors;
+use function preg_replace;
 use function setlocale;
 use function sprintf;
 use function str_replace;
@@ -65,8 +67,6 @@ if (class_exists('League\Flysystem\Memory\MemoryAdapter')) {
 
 final class FunctionalTest extends ApplicationTestCase
 {
-    private const SKIP_INDENTER_FILES = ['code-block-diff'];
-
     private const IGNORED_WARNINGS = ['Document has no title'];
 
     protected function setUp(): void
@@ -81,7 +81,6 @@ final class FunctionalTest extends ApplicationTestCase
         string $format,
         string $rst,
         string $expected,
-        bool $useIndenter = true,
         array $expectedLogs = [],
     ): void {
         $expectedLines = explode("\n", $expected);
@@ -146,19 +145,40 @@ final class FunctionalTest extends ApplicationTestCase
                 );
             }
 
-            if ($format === 'html' && $useIndenter) {
-                $indenter = new Indenter();
-                $rendered = $indenter->indent($rendered);
-            }
-
             if (isset($expectedExceptionMessage)) {
                 return;
             }
 
-            self::assertSame(
-                $this->trimTrailingWhitespace($expected),
-                $this->trimTrailingWhitespace($rendered),
-            );
+            if ($format === 'html') {
+                $rendered = $this->removeRedundantWhitespaceFromHtml($rendered);
+                $expected = $this->removeRedundantWhitespaceFromHtml($expected);
+
+                $previousUseInternalErrors = libxml_use_internal_errors(true);
+                try {
+                    $expectedDom = new DOMDocument();
+                    $expectedDom->loadHTML($expected);
+                    $expectedDom->preserveWhiteSpace = false;
+
+                    $actualDom = new DOMDocument();
+                    $actualDom->loadHTML($rendered);
+                    $actualDom->preserveWhiteSpace = false;
+
+                    $expectedHtml = $expectedDom->saveHTML();
+                    $actualHtml = $actualDom->saveHTML();
+
+                    self::assertIsString($expectedHtml);
+                    self::assertIsString($actualHtml);
+
+                    self::assertXmlStringEqualsXmlString($expectedHtml, $actualHtml);
+                } catch (Throwable) {
+                    self::assertSame(trim($expected), trim($rendered));
+                } finally {
+                    libxml_clear_errors();
+                    libxml_use_internal_errors($previousUseInternalErrors);
+                }
+            } else {
+                self::assertSame(trim($expected), trim($rendered));
+            }
 
             $logHandler = $this->getContainer()->get(TestHandler::class);
             assert($logHandler instanceof TestHandler);
@@ -227,8 +247,6 @@ final class FunctionalTest extends ApplicationTestCase
 
                 $expected = $file->getContents();
 
-                $useIndenter = !in_array($basename, self::SKIP_INDENTER_FILES, true);
-
                 $logFile = $file->getPath() . '/' . $file->getFilenameWithoutExtension() . '.log';
                 $logs = [];
                 if (file_exists($logFile)) {
@@ -237,21 +255,20 @@ final class FunctionalTest extends ApplicationTestCase
                     $logs = array_map(trim(...), $logFileContent);
                 }
 
-                $tests[$basename . '_' . $format] = [$basename, $format, $rst, trim($expected), $useIndenter, $logs];
+                $tests[$basename . '_' . $format] = [$basename, $format, $rst, trim($expected), $logs];
             }
         }
 
         return $tests;
     }
 
-    private function trimTrailingWhitespace(string $string): string
+    private function removeRedundantWhitespaceFromHtml(string $html): string
     {
-        $lines = explode("\n", $string);
+        $html = implode("\n", array_map('trim', explode("\n", $html)));
+        $html = preg_replace('#\s+#', ' ', $html) ?? $html;
+        $html = preg_replace('#\s<#', '<', $html) ?? $html;
+        $html = preg_replace('#>\s#', '>', $html) ?? $html;
 
-        $lines = array_map(static function (string $line): string {
-            return rtrim($line);
-        }, $lines);
-
-        return trim(implode("\n", $lines));
+        return $html;
     }
 }


### PR DESCRIPTION
The project has been unmaintained since 2021 and its handling of
whitespace inside `<pre>` elements is broken (gajus/dindent#25), which
forced the functional tests to special-case the code-block-diff
fixture. Replace the indent-then-string-diff comparison in
FunctionalTest with whitespace normalization plus a DOM comparison
(falling back to a string comparison if the HTML fails to parse),
mirroring the same fix already applied in doctrine/rst-parser.

Resolves #224

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PP4LkejR5PSubbhNmF4RkT
Signed-off-by: lina.wolf