### PR TITLE
[BUGFIX] Resolve cross-page fragment links in markdown

### DIFF
--- a/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/LinkParser.php
+++ b/packages/guides-markdown/src/Markdown/Parsers/InlineParsers/LinkParser.php
@@ -22,7 +22,9 @@ use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 use Psr\Log\LoggerInterface;
 
 use function assert;
+use function explode;
 use function filter_var;
+use function str_contains;
 use function str_ends_with;
 use function substr;
 
@@ -49,10 +51,19 @@ final class LinkParser extends AbstractInlineTextDecoratorParser
     {
         assert($commonMarkNode instanceof Link);
 
-        $url =  $commonMarkNode->getUrl();
+        $url = $commonMarkNode->getUrl();
+        $anchor = '';
+        if (str_contains($url, '#')) {
+            $exploded = explode('#', $url, 2);
+            $url = $exploded[0];
+            $anchor = '#' . $exploded[1];
+        }
+
         if (str_ends_with($url, '.md') && filter_var($url, FILTER_VALIDATE_URL) === false) {
             $url = substr($url, 0, -3);
         }
+
+        $url .= $anchor;
 
         return new HyperLinkNode($content ? [new PlainTextInlineNode($content)] : $children, $url);
     }

--- a/packages/guides-markdown/tests/unit/Markdown/Parsers/InlineParsers/LinkParserTest.php
+++ b/packages/guides-markdown/tests/unit/Markdown/Parsers/InlineParsers/LinkParserTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\Markdown\Parsers\InlineParsers;
+
+use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
+use League\CommonMark\Node\NodeWalker;
+use phpDocumentor\Guides\MarkupLanguageParser;
+use phpDocumentor\Guides\Nodes\Inline\HyperLinkNode;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+final class LinkParserTest extends TestCase
+{
+    private LinkParser $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new LinkParser([], $this->createMock(LoggerInterface::class));
+    }
+
+    #[DataProvider('urlProvider')]
+    public function testMarkdownExtensionAndFragmentHandling(string $expected, string $url): void
+    {
+        $link = new Link($url);
+
+        $result = $this->parser->parse(
+            $this->createMock(MarkupLanguageParser::class),
+            new NodeWalker($link),
+            $link,
+        );
+
+        self::assertInstanceOf(HyperLinkNode::class, $result);
+        self::assertSame($expected, $result->getTargetReference());
+    }
+
+    /** @return array<string, array{string, string}> */
+    public static function urlProvider(): array
+    {
+        return [
+            'no anchor' => [
+                'expected' => 'page',
+                'url' => 'page.md',
+            ],
+            'with anchor' => [
+                'expected' => 'page#section-two',
+                'url' => 'page.md#section-two',
+            ],
+            'duplicate anchor' => [
+                'expected' => 'page#section-two#extra',
+                'url' => 'page.md#section-two#extra',
+            ],
+            'anchor only, no page' => [
+                'expected' => '#anchor',
+                'url' => '#anchor',
+            ],
+            'fragment ends in extension' => [
+                'expected' => 'page#anchor.md',
+                'url' => 'page.md#anchor.md',
+            ],
+        ];
+    }
+}

--- a/packages/guides/src/ReferenceResolvers/PageHyperlinkResolver.php
+++ b/packages/guides/src/ReferenceResolvers/PageHyperlinkResolver.php
@@ -20,6 +20,8 @@ use phpDocumentor\Guides\RenderContext;
 use phpDocumentor\Guides\Renderer\UrlGenerator\UrlGeneratorInterface;
 
 use function count;
+use function explode;
+use function str_contains;
 use function str_ends_with;
 use function strlen;
 use function substr;
@@ -46,7 +48,15 @@ final class PageHyperlinkResolver implements ReferenceResolver
             return false;
         }
 
-        $canonicalDocumentName = $this->documentNameResolver->canonicalUrl($renderContext->getDirName(), $node->getTargetReference());
+        $targetReference = $node->getTargetReference();
+        $anchor = '';
+        if (str_contains($targetReference, '#')) {
+            $exploded = explode('#', $targetReference, 2);
+            $targetReference = $exploded[0];
+            $anchor = '#' . $exploded[1];
+        }
+
+        $canonicalDocumentName = $this->documentNameResolver->canonicalUrl($renderContext->getDirName(), $targetReference);
         if (str_ends_with($canonicalDocumentName, '.' . $renderContext->getOutputFormat())) {
             $canonicalDocumentName = substr($canonicalDocumentName, 0, 0 - strlen('.' . $renderContext->getOutputFormat()));
         }
@@ -56,7 +66,7 @@ final class PageHyperlinkResolver implements ReferenceResolver
             return false;
         }
 
-        $node->setUrl($this->urlGenerator->generateCanonicalOutputUrl($renderContext, $document->getFile()));
+        $node->setUrl($this->urlGenerator->generateCanonicalOutputUrl($renderContext, $document->getFile()) . $anchor);
         if (count($node->getChildren()) === 0) {
             $node->addChildNode(new PlainTextInlineNode($document->getTitle()->toString()));
         }

--- a/packages/guides/tests/unit/ReferenceResolvers/PageHyperlinkResolverTest.php
+++ b/packages/guides/tests/unit/ReferenceResolvers/PageHyperlinkResolverTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\ReferenceResolvers;
+
+use phpDocumentor\Guides\Nodes\DocumentTree\DocumentEntryNode;
+use phpDocumentor\Guides\Nodes\Inline\HyperLinkNode;
+use phpDocumentor\Guides\Nodes\ProjectNode;
+use phpDocumentor\Guides\Nodes\TitleNode;
+use phpDocumentor\Guides\RenderContext;
+use phpDocumentor\Guides\Renderer\UrlGenerator\UrlGeneratorInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class PageHyperlinkResolverTest extends TestCase
+{
+    private RenderContext&MockObject $renderContext;
+    private ProjectNode $projectNode;
+    private MockObject&UrlGeneratorInterface $urlGenerator;
+    private MockObject&DocumentNameResolverInterface $documentNameResolver;
+    private PageHyperlinkResolver $subject;
+
+    protected function setUp(): void
+    {
+        $documentEntry = new DocumentEntryNode('some-document', TitleNode::emptyNode());
+        $this->projectNode = new ProjectNode('some-name');
+        $this->projectNode->addDocumentEntry($documentEntry);
+        $this->renderContext = $this->createMock(RenderContext::class);
+        $this->renderContext->expects(self::any())->method('getProjectNode')->willReturn($this->projectNode);
+        $this->renderContext->method('getDirName')->willReturn('');
+        $this->renderContext->method('getOutputFormat')->willReturn('html');
+        $this->documentNameResolver = self::createMock(DocumentNameResolverInterface::class);
+        $this->urlGenerator = self::createMock(UrlGeneratorInterface::class);
+        $this->subject = new PageHyperlinkResolver($this->urlGenerator, $this->documentNameResolver);
+    }
+
+    #[DataProvider('pathProvider')]
+    public function testPageHyperlinkResolver(string $expected, string $input, string $path): void
+    {
+        $this->documentNameResolver->expects(self::once())->method('canonicalUrl')->with('', $path)->willReturn($path);
+        $node = new HyperLinkNode([], $input);
+        $this->urlGenerator->expects(self::once())->method('generateCanonicalOutputUrl')->willReturn($path);
+        $messages = new Messages();
+        self::assertTrue($this->subject->resolve($node, $this->renderContext, $messages));
+        self::assertEmpty($messages->getWarnings());
+        self::assertEquals($expected, $node->getUrl());
+    }
+
+    public function testDocumentNotFound(): void
+    {
+        $this->documentNameResolver->expects(self::once())->method('canonicalUrl')->with('', 'nonexistent-page')->willReturn('nonexistent-page');
+        $node = new HyperLinkNode([], 'nonexistent-page#anchor');
+        $messages = new Messages();
+        self::assertFalse($this->subject->resolve($node, $this->renderContext, $messages));
+        self::assertEquals('', $node->getUrl());
+    }
+
+    /** @return string[][] */
+    public static function pathProvider(): array
+    {
+        return [
+            'plain' => [
+                'expected' => 'some-document',
+                'input' => 'some-document',
+                'path' => 'some-document',
+            ],
+            'withAnchor' => [
+                'expected' => 'some-document#anchor',
+                'input' => 'some-document#anchor',
+                'path' => 'some-document',
+            ],
+        ];
+    }
+}

--- a/packages/guides/tests/unit/ReferenceResolvers/PageHyperlinkResolverTest.php
+++ b/packages/guides/tests/unit/ReferenceResolvers/PageHyperlinkResolverTest.php
@@ -80,6 +80,11 @@ final class PageHyperlinkResolverTest extends TestCase
                 'input' => 'some-document#anchor',
                 'path' => 'some-document',
             ],
+            'withMultipleHashes' => [
+                'expected' => 'some-document#anchor#extra',
+                'input' => 'some-document#anchor#extra',
+                'path' => 'some-document',
+            ],
         ];
     }
 }

--- a/tests/Integration/tests/markdown/link-page-fragment-md/expected/index.html
+++ b/tests/Integration/tests/markdown/link-page-fragment-md/expected/index.html
@@ -1,0 +1,12 @@
+<!-- content start -->
+
+<div class="section" id="page-a">
+            <h1>Page A</h1>
+
+    <p>See <a href="/page-b.html#section-two">Section Two on Page B</a>.</p>
+
+
+    <p>See <a href="/page-b.html#page-b">Page B without fragment</a>.</p>
+
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/markdown/link-page-fragment-md/expected/index.html
+++ b/tests/Integration/tests/markdown/link-page-fragment-md/expected/index.html
@@ -8,5 +8,8 @@
 
     <p>See <a href="/page-b.html#page-b">Page B without fragment</a>.</p>
 
+
+    <p>See <a href="/page-b.html#section-two#extra">Fragment with an extra hash</a>.</p>
+
     </div>
 <!-- content end -->

--- a/tests/Integration/tests/markdown/link-page-fragment-md/input/guides.xml
+++ b/tests/Integration/tests/markdown/link-page-fragment-md/input/guides.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<guides xmlns="https://www.phpdoc.org/guides"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://www.phpdoc.org/guides packages/guides-cli/resources/schema/guides.xsd"
+        input-format="md"
+>
+    <project title="Project Title" version="1.0"/>
+</guides>

--- a/tests/Integration/tests/markdown/link-page-fragment-md/input/index.md
+++ b/tests/Integration/tests/markdown/link-page-fragment-md/input/index.md
@@ -1,0 +1,5 @@
+# Page A
+
+See [Section Two on Page B](page-b.md#section-two).
+
+See [Page B without fragment](page-b.md).

--- a/tests/Integration/tests/markdown/link-page-fragment-md/input/index.md
+++ b/tests/Integration/tests/markdown/link-page-fragment-md/input/index.md
@@ -3,3 +3,5 @@
 See [Section Two on Page B](page-b.md#section-two).
 
 See [Page B without fragment](page-b.md).
+
+See [Fragment with an extra hash](page-b.md#section-two#extra).

--- a/tests/Integration/tests/markdown/link-page-fragment-md/input/page-b.md
+++ b/tests/Integration/tests/markdown/link-page-fragment-md/input/page-b.md
@@ -1,0 +1,5 @@
+# Page B
+
+## Section Two
+
+Content here.


### PR DESCRIPTION
Markdown links combining a page reference and a fragment anchor, e.g.
`[text](page-b.md#section-two)`, failed to resolve, logging "Reference
page-b.md#section-two could not be resolved". Two independent bugs caused
this:

1. `LinkParser` checked `str_ends_with($url, '.md')` on the full URL
   including the fragment, so the `.md` extension was never stripped.
2. `PageHyperlinkResolver` passed the full target reference (including
   `#fragment`) to `findDocumentEntry()`, which never matches since no
   document is keyed with a fragment suffix.

This ports the fix from phpDocumentor/guides#1300 (originally authored by
Jonathan Hefner <jonathan@hefner.pro>, open since 2026-02-07 and stalled
on a stale-branch/CI mixup unrelated to the fix itself), rebased onto
current `main`, plus additional regression test coverage:

- An integration-test link with two `#` characters
  (`page-b.md#section-two#extra`), confirming only the first `#` is
  treated as the fragment delimiter and the rest is preserved verbatim.
- A matching `PageHyperlinkResolver` unit test case for the same
  multi-hash scenario.
- A new `LinkParserTest`, with data-provider cases covering: no anchor,
  an anchor (the primary bug), a duplicate/multi-hash anchor, an
  anchor-only link with no page, and a fragment that itself ends in
  ".md" (a regression guard against `str_ends_with()` matching on the
  wrong part of the string).

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: lina.wolf