### PR TITLE
[BUGFIX] Split fragment before .rst extension check in RST references

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/ReferenceRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/InlineRules/ReferenceRule.php
@@ -19,8 +19,10 @@ use phpDocumentor\Guides\Nodes\Inline\HyperLinkNode;
 use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 
+use function explode;
 use function filter_var;
 use function preg_replace;
+use function str_contains;
 use function str_ends_with;
 use function str_replace;
 use function substr;
@@ -37,13 +39,22 @@ abstract class ReferenceRule extends AbstractInlineRule
         $reference = str_replace("\n", ' ', $reference);
         $reference = trim(preg_replace('/\s+/', ' ', $reference) ?? '');
 
+        $anchor = '';
+        if (str_contains($reference, '#')) {
+            $exploded = explode('#', $reference, 2);
+            $reference = $exploded[0];
+            $anchor = '#' . $exploded[1];
+        }
+
         if (str_ends_with($reference, '.rst') && filter_var($reference, FILTER_VALIDATE_URL) === false) {
-            $reference = substr($reference, 0, -4);
+            $reference = substr($reference, 0, -4) . $anchor;
 
             $text ??= $reference;
 
             return new DocReferenceNode($reference, $text !== '' ? [new PlainTextInlineNode($text)] : []);
         }
+
+        $reference .= $anchor;
 
         if ($registerLink && $text !== null) {
             $blockContext->getDocumentParserContext()->setLink($text, $reference);

--- a/tests/Integration/tests/hyperlink-to-page-fragment/expected/index.html
+++ b/tests/Integration/tests/hyperlink-to-page-fragment/expected/index.html
@@ -1,0 +1,10 @@
+<!-- content start -->
+    <div class="section" id="page-a">
+        <h1>Page A</h1>
+
+<p>See <a href="/page-b.html#section-two">Section Two on Page B</a>.</p>
+
+<p>See <a href="/page-b.html">Page B without fragment</a>.</p>
+
+    </div>
+<!-- content end -->

--- a/tests/Integration/tests/hyperlink-to-page-fragment/input/index.rst
+++ b/tests/Integration/tests/hyperlink-to-page-fragment/input/index.rst
@@ -1,0 +1,6 @@
+Page A
+======
+
+See `Section Two on Page B <page-b.rst#section-two>`_.
+
+See `Page B without fragment <page-b.rst>`_.

--- a/tests/Integration/tests/hyperlink-to-page-fragment/input/page-b.rst
+++ b/tests/Integration/tests/hyperlink-to-page-fragment/input/page-b.rst
@@ -1,0 +1,9 @@
+:orphan:
+
+Page B
+======
+
+Section Two
+-----------
+
+Content here.


### PR DESCRIPTION
Mirrors the fix in phpDocumentor/guides#1300 for the Markdown side:
`ReferenceRule::createReference()` checked `str_ends_with($reference,
'.rst')` on the full reference including any `#fragment`, so an RST
link like `` `text <page-b.rst#section-two>`_ `` never matched, the
".rst" extension was never stripped, and the link fell through to a
generic HyperLinkNode that failed to resolve. Split the fragment off
before the ".rst" check, then reattach it in both the DocReferenceNode
and HyperLinkNode branches.

Add an integration test fixture (hyperlink-to-page-fragment) covering
an RST link with a page + fragment, and a plain page-only link as a
control case.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: lina.wolf