### PR TITLE
[DOC] Use the actual theme attribute name in the extension example

### DIFF
--- a/docs/cli/extension-config.xml
+++ b/docs/cli/extension-config.xml
@@ -3,7 +3,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="https://www.phpdoc.org/guides vendor/phpdocumentor/guides-cli/resources/schema/guides.xsd"
 
-        html-theme="bootstrap"
+        theme="bootstrap"
 >
     <extension class="phpDocumentor\Guides\Bootstrap" />
     <extension class="phpDocumentor\Guides\Code">


### PR DESCRIPTION
## Summary
- `docs/cli/extension-config.xml` used `html-theme="bootstrap"`, which isn't a valid attribute -- the schema (`packages/guides-cli/resources/schema/guides.xsd`) and the actual config tree (`GuidesExtension::scalarNode('theme')`) both only recognize `theme`.
- Verified end-to-end: the original example fails `xmllint` schema validation and crashes `vendor/bin/guides` at runtime with `Unrecognized option "html_theme" under "guides"`. The fix validates and builds cleanly.

Extracted from #827, which also proposed an unrelated, unresolved change to the `xsi:schemaLocation` URI -- that part is being tracked separately.

## Test plan
- [x] `xmllint --noout --schema packages/guides-cli/resources/schema/guides.xsd docs/cli/extension-config.xml` validates
- [x] Ran `vendor/bin/guides docs` against a minimal project using this config -- builds successfully after the fix, crashes with the original attribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PP4LkejR5PSubbhNmF4RkT