### PR TITLE
[TASK] Migrate 7 trivial directives to the #[Directive] attribute model

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ContainerDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ContainerDirective.php
@@ -16,6 +16,7 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Nodes\ContainerNode;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
@@ -24,19 +25,9 @@ use phpDocumentor\Guides\RestructuredText\Parser\Directive;
  *
  * @link https://docutils.sourceforge.io/docs/ref/rst/directives.html#container
  */
+#[Attributes\Directive(name: 'container', aliases: ['div'])]
 final class ContainerDirective extends SubDirective
 {
-    public function getName(): string
-    {
-        return 'container';
-    }
-
-    /** {@inheritDoc} */
-    public function getAliases(): array
-    {
-        return ['div'];
-    }
-
     /** {@inheritDoc}
      *
      * @param Directive $directive
@@ -46,6 +37,17 @@ final class ContainerDirective extends SubDirective
         CollectionNode $collectionNode,
         Directive $directive,
     ): Node {
-        return (new ContainerNode($collectionNode->getChildren()))->withOptions(['class' => $directive->getData()]);
+        return $this->createNode(
+            new DirectiveNode(
+                $directive,
+                $collectionNode->getChildren(),
+            ),
+        );
+    }
+
+    public function createNode(DirectiveNode $directiveNode): Node
+    {
+        return (new ContainerNode($directiveNode->getChildren()))
+            ->withOptions(['class' => $directiveNode->getDirective()->getData()]);
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ContainerDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ContainerDirective.php
@@ -13,12 +13,9 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
-use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Nodes\ContainerNode;
 use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
-use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
-use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
 /**
  * Divs a sub document in a div with a given class or set of classes.
@@ -28,23 +25,6 @@ use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 #[Attributes\Directive(name: 'container', aliases: ['div'])]
 final class ContainerDirective extends SubDirective
 {
-    /** {@inheritDoc}
-     *
-     * @param Directive $directive
-     */
-    protected function processSub(
-        BlockContext $blockContext,
-        CollectionNode $collectionNode,
-        Directive $directive,
-    ): Node {
-        return $this->createNode(
-            new DirectiveNode(
-                $directive,
-                $collectionNode->getChildren(),
-            ),
-        );
-    }
-
     public function createNode(DirectiveNode $directiveNode): Node
     {
         return (new ContainerNode($directiveNode->getChildren()))

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/EpigraphDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/EpigraphDirective.php
@@ -13,12 +13,9 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
-use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\QuoteNode;
 use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
-use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
-use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
 /**
  * An epigraph is an apposite (suitable, apt, or pertinent) short inscription,
@@ -30,23 +27,6 @@ use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 #[Attributes\Directive(name: 'epigraph')]
 final class EpigraphDirective extends SubDirective
 {
-    /** {@inheritDoc}
-     *
-     * @param Directive $directive
-     */
-    protected function processSub(
-        BlockContext $blockContext,
-        CollectionNode $collectionNode,
-        Directive $directive,
-    ): Node {
-        return $this->createNode(
-            new DirectiveNode(
-                $directive,
-                $collectionNode->getChildren(),
-            ),
-        );
-    }
-
     public function createNode(DirectiveNode $directiveNode): Node
     {
         return new QuoteNode($directiveNode->getChildren(), ['epigraph']);

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/EpigraphDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/EpigraphDirective.php
@@ -16,6 +16,7 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\QuoteNode;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
@@ -26,13 +27,9 @@ use phpDocumentor\Guides\RestructuredText\Parser\Directive;
  *
  * https://docutils.sourceforge.io/docs/ref/rst/directives.html#epigraph
  */
+#[Attributes\Directive(name: 'epigraph')]
 final class EpigraphDirective extends SubDirective
 {
-    public function getName(): string
-    {
-        return 'epigraph';
-    }
-
     /** {@inheritDoc}
      *
      * @param Directive $directive
@@ -42,6 +39,16 @@ final class EpigraphDirective extends SubDirective
         CollectionNode $collectionNode,
         Directive $directive,
     ): Node {
-        return new QuoteNode($collectionNode->getChildren(), ['epigraph']);
+        return $this->createNode(
+            new DirectiveNode(
+                $directive,
+                $collectionNode->getChildren(),
+            ),
+        );
+    }
+
+    public function createNode(DirectiveNode $directiveNode): Node
+    {
+        return new QuoteNode($directiveNode->getChildren(), ['epigraph']);
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/HighlightsDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/HighlightsDirective.php
@@ -13,12 +13,9 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
-use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\QuoteNode;
 use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
-use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
-use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
 /**
  * Highlights summarize the main points of a document or section, often consisting of a list.
@@ -29,23 +26,6 @@ use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 #[Attributes\Directive(name: 'highlights')]
 final class HighlightsDirective extends SubDirective
 {
-    /** {@inheritDoc}
-     *
-     * @param Directive $directive
-     */
-    protected function processSub(
-        BlockContext $blockContext,
-        CollectionNode $collectionNode,
-        Directive $directive,
-    ): Node {
-        return $this->createNode(
-            new DirectiveNode(
-                $directive,
-                $collectionNode->getChildren(),
-            ),
-        );
-    }
-
     public function createNode(DirectiveNode $directiveNode): Node
     {
         return new QuoteNode($directiveNode->getChildren(), ['highlights']);

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/HighlightsDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/HighlightsDirective.php
@@ -16,6 +16,7 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\QuoteNode;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
@@ -25,13 +26,9 @@ use phpDocumentor\Guides\RestructuredText\Parser\Directive;
  *
  * https://docutils.sourceforge.io/docs/ref/rst/directives.html#highlights
  */
+#[Attributes\Directive(name: 'highlights')]
 final class HighlightsDirective extends SubDirective
 {
-    public function getName(): string
-    {
-        return 'highlights';
-    }
-
     /** {@inheritDoc}
      *
      * @param Directive $directive
@@ -41,6 +38,16 @@ final class HighlightsDirective extends SubDirective
         CollectionNode $collectionNode,
         Directive $directive,
     ): Node {
-        return new QuoteNode($collectionNode->getChildren(), ['highlights']);
+        return $this->createNode(
+            new DirectiveNode(
+                $directive,
+                $collectionNode->getChildren(),
+            ),
+        );
+    }
+
+    public function createNode(DirectiveNode $directiveNode): Node
+    {
+        return new QuoteNode($directiveNode->getChildren(), ['highlights']);
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/IndexDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/IndexDirective.php
@@ -13,10 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
+#[Attributes\Directive(name: 'index')]
 final class IndexDirective extends SubDirective
 {
-    public function getName(): string
-    {
-        return 'index';
-    }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/PullQuoteDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/PullQuoteDirective.php
@@ -16,6 +16,7 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\QuoteNode;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
@@ -26,13 +27,9 @@ use phpDocumentor\Guides\RestructuredText\Parser\Directive;
  *
  * https://docutils.sourceforge.io/docs/ref/rst/directives.html#pull-quote
  */
+#[Attributes\Directive(name: 'pull-quote')]
 final class PullQuoteDirective extends SubDirective
 {
-    public function getName(): string
-    {
-        return 'pull-quote';
-    }
-
     /** {@inheritDoc}
      *
      * @param Directive $directive
@@ -42,6 +39,16 @@ final class PullQuoteDirective extends SubDirective
         CollectionNode $collectionNode,
         Directive $directive,
     ): Node {
-        return new QuoteNode($collectionNode->getChildren(), ['pull-quote']);
+        return $this->createNode(
+            new DirectiveNode(
+                $directive,
+                $collectionNode->getChildren(),
+            ),
+        );
+    }
+
+    public function createNode(DirectiveNode $directiveNode): Node
+    {
+        return new QuoteNode($directiveNode->getChildren(), ['pull-quote']);
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/PullQuoteDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/PullQuoteDirective.php
@@ -13,12 +13,9 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
-use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\QuoteNode;
 use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
-use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
-use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
 /**
  * A pull-quote is a small selection of text "pulled out and quoted", typically in
@@ -30,23 +27,6 @@ use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 #[Attributes\Directive(name: 'pull-quote')]
 final class PullQuoteDirective extends SubDirective
 {
-    /** {@inheritDoc}
-     *
-     * @param Directive $directive
-     */
-    protected function processSub(
-        BlockContext $blockContext,
-        CollectionNode $collectionNode,
-        Directive $directive,
-    ): Node {
-        return $this->createNode(
-            new DirectiveNode(
-                $directive,
-                $collectionNode->getChildren(),
-            ),
-        );
-    }
-
     public function createNode(DirectiveNode $directiveNode): Node
     {
         return new QuoteNode($directiveNode->getChildren(), ['pull-quote']);

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ReplaceDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ReplaceDirective.php
@@ -18,6 +18,7 @@ use phpDocumentor\Guides\Nodes\InlineCompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\ParagraphNode;
 use phpDocumentor\Guides\Nodes\ReplacementNode;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
@@ -28,25 +29,31 @@ use function count;
  *
  * .. |test| replace:: The Test String!
  */
+#[Attributes\Directive(name: 'replace')]
 final class ReplaceDirective extends SubDirective
 {
-    public function getName(): string
-    {
-        return 'replace';
-    }
-
     /** {@inheritDoc}
      *
      * @param Directive $directive
      */
-    final protected function processSub(
+    protected function processSub(
         BlockContext $blockContext,
         CollectionNode $collectionNode,
         Directive $directive,
     ): Node {
+        return $this->createNode(
+            new DirectiveNode(
+                $directive,
+                $collectionNode->getChildren(),
+            ),
+        );
+    }
+
+    public function createNode(DirectiveNode $directiveNode): Node
+    {
         /** @var array<InlineCompoundNode> $children */
-        $children = $collectionNode->getChildren();
-        $data = $directive->getDataNode();
+        $children = $directiveNode->getChildren();
+        $data = $directiveNode->getDirective()->getDataNode();
         if ($data !== null) {
             if (count($children) > 0) {
                 $children[] = new ParagraphNode([$data]);

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ReplaceDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ReplaceDirective.php
@@ -13,14 +13,11 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
-use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\InlineCompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\ParagraphNode;
 use phpDocumentor\Guides\Nodes\ReplacementNode;
 use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
-use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
-use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
 use function count;
 
@@ -32,23 +29,6 @@ use function count;
 #[Attributes\Directive(name: 'replace')]
 final class ReplaceDirective extends SubDirective
 {
-    /** {@inheritDoc}
-     *
-     * @param Directive $directive
-     */
-    protected function processSub(
-        BlockContext $blockContext,
-        CollectionNode $collectionNode,
-        Directive $directive,
-    ): Node {
-        return $this->createNode(
-            new DirectiveNode(
-                $directive,
-                $collectionNode->getChildren(),
-            ),
-        );
-    }
-
     public function createNode(DirectiveNode $directiveNode): Node
     {
         /** @var array<InlineCompoundNode> $children */

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/SidebarDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/SidebarDirective.php
@@ -13,13 +13,10 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
-use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\InlineCompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Nodes\SidebarNode;
-use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
-use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
 /**
  * Divs a sub document in a div with a given class or set of classes.
@@ -29,23 +26,6 @@ use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 #[Attributes\Directive(name: 'sidebar')]
 final class SidebarDirective extends SubDirective
 {
-    /** {@inheritDoc}
-     *
-     * @param Directive $directive
-     */
-    protected function processSub(
-        BlockContext $blockContext,
-        CollectionNode $collectionNode,
-        Directive $directive,
-    ): Node {
-        return $this->createNode(
-            new DirectiveNode(
-                $directive,
-                $collectionNode->getChildren(),
-            ),
-        );
-    }
-
     public function createNode(DirectiveNode $directiveNode): Node
     {
         $directive = $directiveNode->getDirective();

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/SidebarDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/SidebarDirective.php
@@ -16,6 +16,7 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\InlineCompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Nodes\SidebarNode;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
@@ -25,13 +26,9 @@ use phpDocumentor\Guides\RestructuredText\Parser\Directive;
  *
  * https://docutils.sourceforge.io/docs/ref/rst/directives.html#sidebar
  */
+#[Attributes\Directive(name: 'sidebar')]
 final class SidebarDirective extends SubDirective
 {
-    public function getName(): string
-    {
-        return 'sidebar';
-    }
-
     /** {@inheritDoc}
      *
      * @param Directive $directive
@@ -41,9 +38,21 @@ final class SidebarDirective extends SubDirective
         CollectionNode $collectionNode,
         Directive $directive,
     ): Node {
+        return $this->createNode(
+            new DirectiveNode(
+                $directive,
+                $collectionNode->getChildren(),
+            ),
+        );
+    }
+
+    public function createNode(DirectiveNode $directiveNode): Node
+    {
+        $directive = $directiveNode->getDirective();
+
         return new SidebarNode(
             $directive->getDataNode() ?? InlineCompoundNode::getPlainTextInlineNode($directive->getData()),
-            $collectionNode->getChildren(),
+            $directiveNode->getChildren(),
         );
     }
 }


### PR DESCRIPTION
[TASK] Migrate 7 trivial directives to the #[Directive] attribute model

Highlights, PullQuote, Epigraph, Container, Sidebar, Replace, and Index
now declare #[Attributes\Directive(...)] and implement createNode(),
per the pattern from #1231 -- replacing their getName()/getAliases()
overrides. Part of the migration tracked in #1373, requested by
jaapio for the reference-doc generation he's building.

Several other directives that looked equally trivial (Class, Tab,
DocumentBlock) turned out to break real behavior once migrated, for
structural reasons unrelated to their own complexity -- see #1378.
Left those, and anything sharing their root cause, out of this batch.

Verified via Docker (php:8.4-cli, matching CI): phpstan clean, phpcs
clean, unit/functional/integration suites green (970 tests).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PP4LkejR5PSubbhNmF4RkT
Signed-off-by: lina.wolf