### PR TITLE
[FEATURE] Add synchronous dispatch escape hatch for #[Directive]

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Directives/Attributes/Directive.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/Attributes/Directive.php
@@ -18,10 +18,20 @@ use Attribute;
 #[Attribute(Attribute::TARGET_CLASS)]
 final class Directive
 {
-    /** @param string[] $aliases */
+    /**
+     * @param string[] $aliases
+     * @param bool $synchronous Keep processing this directive synchronously at parse
+     *     time via process()/processSub(), instead of deferring node creation to
+     *     createNode() at compile time. Declaring name/aliases here still makes the
+     *     directive discoverable by tooling that reads this attribute; set this when
+     *     the directive's logic genuinely depends on parse-time-only state (e.g. the
+     *     current BlockContext for logging, file paths, or raw/unparsed content) that
+     *     createNode() has no access to.
+     */
     public function __construct(
         public readonly string $name,
         public readonly array $aliases = [],
+        public readonly bool $synchronous = false,
     ) {
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/BaseDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/BaseDirective.php
@@ -53,6 +53,8 @@ abstract class BaseDirective
     /** @var string[] */
     private array $aliases;
 
+    private bool $synchronous;
+
     /**
      * Get the directive name
      */
@@ -123,6 +125,29 @@ abstract class BaseDirective
         }
 
         return true;
+    }
+
+    /**
+     * Whether this directive keeps processing synchronously at parse time via
+     * process()/processSub(), rather than deferring node creation to createNode()
+     * at compile time. Opted into per-directive via #[Directive(synchronous: true)]
+     * for directives whose logic depends on parse-time-only state that createNode()
+     * has no access to (e.g. BlockContext for logging, file paths, or raw content).
+     *
+     * @internal
+     */
+    final public function isSynchronous(): bool
+    {
+        if (isset($this->synchronous)) {
+            return $this->synchronous;
+        }
+
+        $reflection = new ReflectionClass($this);
+        $attributes = $reflection->getAttributes(Attributes\Directive::class);
+
+        $this->synchronous = count($attributes) === 1 && $attributes[0]->newInstance()->synchronous;
+
+        return $this->synchronous;
     }
 
     /**

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/RawDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/RawDirective.php
@@ -29,13 +29,9 @@ use function implode;
  *
  * @link https://docutils.sourceforge.io/docs/ref/rst/directives.html#raw-data-pass-through
  */
+#[Attributes\Directive(name: 'raw', synchronous: true)]
 final class RawDirective extends BaseDirective
 {
-    public function getName(): string
-    {
-        return 'raw';
-    }
-
     /** {@inheritDoc} */
     public function process(
         BlockContext $blockContext,

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/TestLoggerDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/TestLoggerDirective.php
@@ -26,6 +26,7 @@ use Psr\Log\LoggerInterface;
  *
  * @link https://docutils.sourceforge.io/docs/ref/rst/directives.html#container
  */
+#[Attributes\Directive(name: 'testlogger', synchronous: true)]
 final class TestLoggerDirective extends SubDirective
 {
     public function __construct(
@@ -33,11 +34,6 @@ final class TestLoggerDirective extends SubDirective
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct($startingRule);
-    }
-
-    public function getName(): string
-    {
-        return 'testlogger';
     }
 
     /** {@inheritDoc}

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
@@ -94,7 +94,7 @@ final class DirectiveRule implements Rule
         $directiveHandler = $this->getDirectiveHandler($directive);
         $buffer = $this->collectDirectiveContents($documentIterator);
 
-        if ($this->startingRule !== null && $directiveHandler->isUpgraded()) {
+        if ($this->startingRule !== null && $directiveHandler->isUpgraded() && !$directiveHandler->isSynchronous()) {
             $node = $this->startingRule->apply(
                 new BlockContext($blockContext->getDocumentParserContext(), $buffer->getLinesString(), true, $documentIterator->key()),
                 new DirectiveNode($directive),


### PR DESCRIPTION
[FEATURE] Add synchronous dispatch escape hatch for #[Directive]

Migrating a directive to the compile-time createNode() model defers
node creation from parse time to compile time -- createNode() has no
BlockContext, so any directive whose logic depends on live parser
state (logging with line numbers, resolving the current file's path,
raw unparsed content, or re-entering the parser for nested content)
silently loses that ability if migrated the normal way. Found via
#1378 while migrating directives for #1373.

#[Directive] gains an optional synchronous flag: when set, the
directive stays fully declared (name/aliases/options visible to
reflection-based tooling like jaapio's reference-doc generator) but
keeps running through the original process()/processSub() path with
a real, live BlockContext, instead of deferring to createNode() at
compile time.

Proves the concept on the two hardest cases found in #1378:
TestLoggerDirective (asserts an exact log line including parse-time
line number) and RawDirective (needs literal unparsed source text).
Neither needed any change to their actual logic -- just the one-line
attribute addition.

Verified via Docker (php:8.4-cli, matching CI): phpstan clean, phpcs
clean, deptrac 0 violations, unit/functional/integration suites green
(970 tests, 0 failures) -- including byte-for-byte confirmation that
TestLoggerDirective's log line and RawDirective's raw-content tests
are unchanged.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PP4LkejR5PSubbhNmF4RkT
Signed-off-by: lina.wolf