### PR TITLE
[TASK] Migrate remaining directives to #[Directive] via synchronous dispatch

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ClassDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ClassDirective.php
@@ -25,25 +25,14 @@ use function array_map;
 use function array_merge;
 use function explode;
 
+/**
+ * When the default domain contains a class directive, this directive will be shadowed. Therefore, Sphinx re-exports it as rst-class.
+ *
+ * See https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#rstclass
+ */
+#[Attributes\Directive(name: 'class', aliases: ['rst-class'], synchronous: true)]
 final class ClassDirective extends SubDirective
 {
-    public function getName(): string
-    {
-        return 'class';
-    }
-
-    /**
-     * When the default domain contains a class directive, this directive will be shadowed. Therefore, Sphinx re-exports it as rst-class.
-     *
-     * See https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#rstclass
-     *
-     * @return string[]
-     */
-    public function getAliases(): array
-    {
-        return ['rst-class'];
-    }
-
     /** {@inheritDoc}
      *
      * @param Directive $directive

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/CodeBlockDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/CodeBlockDirective.php
@@ -33,23 +33,13 @@ use function trim;
  *
  * @link https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block
  */
+#[Attributes\Directive(name: 'code-block', aliases: ['code', 'parsed-literal', 'sourcecode'], synchronous: true)]
 final class CodeBlockDirective extends BaseDirective
 {
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly CodeNodeOptionMapper $codeNodeOptionMapper,
     ) {
-    }
-
-    public function getName(): string
-    {
-        return 'code-block';
-    }
-
-    /** {@inheritDoc} */
-    public function getAliases(): array
-    {
-        return ['code', 'parsed-literal', 'sourcecode'];
     }
 
     /** {@inheritDoc} */

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ConfigurationBlockDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ConfigurationBlockDirective.php
@@ -29,6 +29,7 @@ use function assert;
 use function get_debug_type;
 use function sprintf;
 
+#[Attributes\Directive(name: 'configuration-block', synchronous: true)]
 final class ConfigurationBlockDirective extends SubDirective
 {
     private SluggerInterface $slugger;
@@ -45,11 +46,6 @@ final class ConfigurationBlockDirective extends SubDirective
         parent::__construct($startingRule);
 
         $this->slugger = new AsciiSlugger();
-    }
-
-    public function getName(): string
-    {
-        return 'configuration-block';
     }
 
     protected function processSub(

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ConfvalDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ConfvalDirective.php
@@ -33,6 +33,7 @@ use function trim;
  *
  * https://sphinx-toolbox.readthedocs.io/en/stable/extensions/confval.html
  */
+#[Attributes\Directive(name: 'confval', synchronous: true)]
 #[Option(name: 'name', description: 'Id of the configuration value, used for linking to it.')]
 #[Option(name: 'type', description: 'Type of the configuration value, e.g. "string", "int", etc.')]
 #[Option(name: 'required', type: OptionType::Boolean, default: false, description: 'Whether the configuration value is required or not.')]
@@ -53,11 +54,6 @@ final class ConfvalDirective extends SubDirective
         parent::__construct($startingRule);
 
         $genericLinkProvider->addGenericLink(self::NAME, ConfvalNode::LINK_TYPE, ConfvalNode::LINK_PREFIX);
-    }
-
-    public function getName(): string
-    {
-        return self::NAME;
     }
 
     /** {@inheritDoc}

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ContentsDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ContentsDirective.php
@@ -26,6 +26,7 @@ use phpDocumentor\Guides\RestructuredText\Parser\Directive;
  *
  * Displays a table of content of the current page
  */
+#[Attributes\Directive(name: 'contents', synchronous: true)]
 #[Option(name: 'local', type: OptionType::Boolean, description: 'If set, the table of contents will only include sections that are local to the current document.', default: false)]
 #[Option(name: 'depth', description: 'The maximum depth of the table of contents.')]
 final class ContentsDirective extends BaseDirective
@@ -33,11 +34,6 @@ final class ContentsDirective extends BaseDirective
     public function __construct(
         private readonly DocumentNameResolverInterface $documentNameResolver,
     ) {
-    }
-
-    public function getName(): string
-    {
-        return 'contents';
     }
 
     /** {@inheritDoc} */

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/CsvTableDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/CsvTableDirective.php
@@ -45,17 +45,13 @@ use function trim;
  *    :widths: 30, 70
  *    :header-rows: 1
  */
+#[Attributes\Directive(name: 'csv-table', synchronous: true)]
 final class CsvTableDirective extends BaseDirective
 {
     public function __construct(
         private RuleContainer $productions,
         private LoggerInterface $logger,
     ) {
-    }
-
-    public function getName(): string
-    {
-        return 'csv-table';
     }
 
     /** {@inheritDoc} */

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/DefaultRoleDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/DefaultRoleDirective.php
@@ -21,13 +21,9 @@ use phpDocumentor\Guides\RestructuredText\Parser\Directive;
  *
  * https://docutils.sourceforge.io/docs/ref/rst/directives.html#default-role
  */
+#[Attributes\Directive(name: 'default-role', synchronous: true)]
 final class DefaultRoleDirective extends ActionDirective
 {
-    public function getName(): string
-    {
-        return 'default-role';
-    }
-
     public function processAction(
         BlockContext $blockContext,
         Directive $directive,

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/DocumentBlockDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/DocumentBlockDirective.php
@@ -20,14 +20,10 @@ use phpDocumentor\Guides\RestructuredText\Directives\Attributes\Option;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
+#[Attributes\Directive(name: 'documentblock', synchronous: true)]
 #[Option(name: 'identifier', type: OptionType::String, description: 'The identifier of the document block')]
 final class DocumentBlockDirective extends SubDirective
 {
-    public function getName(): string
-    {
-        return 'documentblock';
-    }
-
     /** {@inheritDoc}
      *
      * @param Directive $directive

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/FigureDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/FigureDirective.php
@@ -34,6 +34,7 @@ use function dirname;
  *
  *      Here is an awesome caption
  */
+#[Attributes\Directive(name: 'figure', synchronous: true)]
 #[Option(name: 'width', description: 'Width of the image in pixels')]
 #[Option(name: 'height', description: 'Height of the image in pixels')]
 #[Option(name: 'alt', description: 'Alternative text for the image')]
@@ -49,11 +50,6 @@ final class FigureDirective extends SubDirective
         protected Rule $startingRule,
     ) {
         parent::__construct($startingRule);
-    }
-
-    public function getName(): string
-    {
-        return 'figure';
     }
 
     /** {@inheritDoc}

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/HighlightDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/HighlightDirective.php
@@ -21,13 +21,9 @@ use function trim;
 /**
  * https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-highlight
  */
+#[Attributes\Directive(name: 'highlight', synchronous: true)]
 final class HighlightDirective extends ActionDirective
 {
-    public function getName(): string
-    {
-        return 'highlight';
-    }
-
     public function processAction(
         BlockContext $blockContext,
         Directive $directive,

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ImageDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ImageDirective.php
@@ -38,6 +38,7 @@ use const FILTER_VALIDATE_URL;
  *      :width: 100
  *      :title: An image
  */
+#[Attributes\Directive(name: 'image', synchronous: true)]
 #[Option(name: 'width', description: 'Width of the image in pixels')]
 #[Option(name: 'height', description: 'Height of the image in pixels')]
 #[Option(name: 'alt', description: 'Alternative text for the image')]
@@ -57,11 +58,6 @@ final class ImageDirective extends BaseDirective
     public function __construct(
         private readonly DocumentNameResolverInterface $documentNameResolver,
     ) {
-    }
-
-    public function getName(): string
-    {
-        return 'image';
     }
 
     /** {@inheritDoc} */

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/IncludeDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/IncludeDirective.php
@@ -28,17 +28,13 @@ use function explode;
 use function sprintf;
 use function str_replace;
 
+#[Attributes\Directive(name: 'include', synchronous: true)]
 #[Option(name: 'literal', description: 'If set, the contents will be rendered as a literal block.')]
 #[Option(name: 'code', description: 'If set, the contents will be rendered as a code block with the specified language.')]
 final class IncludeDirective extends BaseDirective
 {
     public function __construct(private readonly DocumentRule $startingRule)
     {
-    }
-
-    public function getName(): string
-    {
-        return 'include';
     }
 
     /** {@inheritDoc} */

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/LaTeXMain.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/LaTeXMain.php
@@ -21,13 +21,9 @@ use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 /**
  * Marks the document as LaTeX main
  */
+#[Attributes\Directive(name: 'latex-main', synchronous: true)]
 final class LaTeXMain extends BaseDirective
 {
-    public function getName(): string
-    {
-        return 'latex-main';
-    }
-
     /** {@inheritDoc} */
     public function processNode(
         BlockContext $blockContext,

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ListTableDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ListTableDirective.php
@@ -33,6 +33,7 @@ use function explode;
 use function sprintf;
 use function strval;
 
+#[Attributes\Directive(name: 'list-table', synchronous: true)]
 class ListTableDirective extends SubDirective
 {
     public function __construct(
@@ -40,11 +41,6 @@ class ListTableDirective extends SubDirective
         private readonly LoggerInterface $logger,
     ) {
         parent::__construct($startingRule);
-    }
-
-    public function getName(): string
-    {
-        return 'list-table';
     }
 
     /** {@inheritDoc} */

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/LiteralincludeDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/LiteralincludeDirective.php
@@ -35,17 +35,13 @@ use function sprintf;
 use function str_contains;
 use function trim;
 
+#[Attributes\Directive(name: 'literalinclude', synchronous: true)]
 final class LiteralincludeDirective extends BaseDirective
 {
     public function __construct(
         private readonly CodeNodeOptionMapper $codeNodeOptionMapper,
         private readonly LoggerInterface|null $logger = null,
     ) {
-    }
-
-    public function getName(): string
-    {
-        return 'literalinclude';
     }
 
     /** {@inheritDoc} */

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/MathDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/MathDirective.php
@@ -30,22 +30,12 @@ use Psr\Log\LoggerInterface;
  *
  * @link https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block
  */
+#[Attributes\Directive(name: 'math', synchronous: true)]
 final class MathDirective extends BaseDirective
 {
     public function __construct(
         private readonly LoggerInterface $logger,
     ) {
-    }
-
-    public function getName(): string
-    {
-        return 'math';
-    }
-
-    /** {@inheritDoc} */
-    public function getAliases(): array
-    {
-        return [];
     }
 
     /** {@inheritDoc} */

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/MenuDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/MenuDirective.php
@@ -32,6 +32,7 @@ use function count;
  *
  * By default, it displays a menu of the pages on level 1 up to level 2.
  */
+#[Attributes\Directive(name: 'menu', synchronous: true)]
 final class MenuDirective extends BaseDirective
 {
     private SettingsManager $settingsManager;
@@ -42,11 +43,6 @@ final class MenuDirective extends BaseDirective
     ) {
         // if for backward compatibility reasons no settings manager was passed, use the defaults
         $this->settingsManager = $settingsManager ?? new SettingsManager(new ProjectSettings());
-    }
-
-    public function getName(): string
-    {
-        return 'menu';
     }
 
     /** {@inheritDoc} */

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/MetaDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/MetaDirective.php
@@ -23,13 +23,9 @@ use phpDocumentor\Guides\RestructuredText\Parser\Directive;
  * .. meta::
  *      :key: value
  */
+#[Attributes\Directive(name: 'meta', synchronous: true)]
 final class MetaDirective extends ActionDirective
 {
-    public function getName(): string
-    {
-        return 'meta';
-    }
-
     public function processAction(BlockContext $blockContext, Directive $directive): void
     {
         $document = $blockContext->getDocumentParserContext()->getDocument();

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/OptionDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/OptionDirective.php
@@ -32,6 +32,7 @@ use function str_contains;
  *
  * https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#directive-option
  */
+#[Attributes\Directive(name: 'option', synchronous: true)]
 final class OptionDirective extends SubDirective
 {
     public const NAME = 'option';
@@ -45,11 +46,6 @@ final class OptionDirective extends SubDirective
         parent::__construct($startingRule);
 
         $genericLinkProvider->addGenericLink(self::NAME, OptionNode::LINK_TYPE);
-    }
-
-    public function getName(): string
-    {
-        return self::NAME;
     }
 
     /** {@inheritDoc}

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/RoleDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/RoleDirective.php
@@ -29,16 +29,12 @@ use function trim;
  *
  * https://docutils.sourceforge.io/docs/ref/rst/directives.html#role
  */
+#[Attributes\Directive(name: 'role', synchronous: true)]
 final class RoleDirective extends ActionDirective
 {
     public function __construct(
         private readonly LoggerInterface $logger,
     ) {
-    }
-
-    public function getName(): string
-    {
-        return 'role';
     }
 
     public function processAction(

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/SectionauthorDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/SectionauthorDirective.php
@@ -21,6 +21,7 @@ use Psr\Log\LoggerInterface;
 
 use function preg_match;
 
+#[Attributes\Directive(name: 'sectionauthor', aliases: ['codeauthor'], synchronous: true)]
 final class SectionauthorDirective extends BaseDirective
 {
     /** @see https://regex101.com/r/vGy4Uu/1 */
@@ -29,23 +30,6 @@ final class SectionauthorDirective extends BaseDirective
     public function __construct(
         private readonly LoggerInterface $logger,
     ) {
-    }
-
-    public function getName(): string
-    {
-        return 'sectionauthor';
-    }
-
-    /**
-     * When the default domain contains a class directive, this directive will be shadowed. Therefore, Sphinx re-exports it as rst-class.
-     *
-     * See https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#rstclass
-     *
-     * @return string[]
-     */
-    public function getAliases(): array
-    {
-        return ['codeauthor'];
     }
 
     /** {@inheritDoc}

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/TabDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/TabDirective.php
@@ -27,13 +27,9 @@ use function preg_replace;
 use function str_replace;
 use function strtolower;
 
+#[Attributes\Directive(name: 'tab', synchronous: true)]
 final class TabDirective extends SubDirective
 {
-    public function getName(): string
-    {
-        return 'tab';
-    }
-
     /** {@inheritDoc}
      *
      * @param Directive $directive

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/TableDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/TableDirective.php
@@ -43,6 +43,7 @@ use function strval;
  *     | Row 2, Column 1 | Row 2, Column 2 |
  *     +-----------------+-----------------+
  */
+#[Attributes\Directive(name: 'table', synchronous: true)]
 final class TableDirective extends SubDirective
 {
     public function __construct(
@@ -50,11 +51,6 @@ final class TableDirective extends SubDirective
         private LoggerInterface $logger,
     ) {
         parent::__construct($startingRule);
-    }
-
-    public function getName(): string
-    {
-        return 'table';
     }
 
     /** {@inheritDoc} */

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/TabsDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/TabsDirective.php
@@ -28,6 +28,7 @@ use function class_alias;
 use function class_exists;
 use function is_string;
 
+#[Attributes\Directive(name: 'tabs', synchronous: true)]
 final class TabsDirective extends SubDirective
 {
     private int $tabsCounter = 0;
@@ -39,11 +40,6 @@ final class TabsDirective extends SubDirective
         private readonly AnchorNormalizer $anchorReducer,
     ) {
         parent::__construct($startingRule);
-    }
-
-    public function getName(): string
-    {
-        return 'tabs';
     }
 
     /** {@inheritDoc}

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/TitleDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/TitleDirective.php
@@ -21,13 +21,9 @@ use phpDocumentor\Guides\RestructuredText\Parser\Directive;
  *
  * .. title:: Page title
  */
+#[Attributes\Directive(name: 'title', synchronous: true)]
 final class TitleDirective extends ActionDirective
 {
-    public function getName(): string
-    {
-        return 'title';
-    }
-
     public function processAction(BlockContext $blockContext, Directive $directive): void
     {
         $document = $blockContext->getDocumentParserContext()->getDocument();

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ToctreeDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ToctreeDirective.php
@@ -70,6 +70,7 @@ use phpDocumentor\Guides\Settings\SettingsManager;
  * :maxdepth:
  *     Synonym of :depth:, depth prevails if both are set.
  */
+#[Attributes\Directive(name: 'toctree', synchronous: true)]
 final class ToctreeDirective extends BaseDirective
 {
     private SettingsManager $settingsManager;
@@ -82,11 +83,6 @@ final class ToctreeDirective extends BaseDirective
     ) {
         // if for backward compatibility reasons no settings manager was passed, use the defaults
         $this->settingsManager = $settingsManager ?? new SettingsManager(new ProjectSettings());
-    }
-
-    public function getName(): string
-    {
-        return 'toctree';
     }
 
     /** {@inheritDoc} */

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/TodoDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/TodoDirective.php
@@ -19,13 +19,9 @@ use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 /**
  * Todo directives are treated as comments, omitting all content or options
  */
+#[Attributes\Directive(name: 'todo', synchronous: true)]
 final class TodoDirective extends ActionDirective
 {
-    public function getName(): string
-    {
-        return 'todo';
-    }
-
     public function processAction(BlockContext $blockContext, Directive $directive): void
     {
         // Todo directives are treated as comments


### PR DESCRIPTION
[TASK] Migrate remaining directives to #[Directive] via synchronous dispatch

The remaining directives in guides-restructured-text/Directives/ (or
their external consumers, for Class/Tab/DocumentBlock/Option) all
depend on live BlockContext for logging, path resolution, raw content,
or a role in another pass's ordering -- so they use the synchronous
escape hatch from #1380 rather than the deferred createNode() model,
per #1378's findings. Their process()/processSub() logic is untouched.

Leaves only GeneralDirective (catch-all fallback) and ActionDirective
(abstract base) in this package without the attribute.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PP4LkejR5PSubbhNmF4RkT
Signed-off-by: lina.wolf