### PR TITLE
[FEATURE] Give #[Directive] a rawContent option, migrate RawDirective

### DIFF
--- a/packages/guides-restructured-text/resources/config/guides-restructured-text.php
+++ b/packages/guides-restructured-text/resources/config/guides-restructured-text.php
@@ -229,6 +229,9 @@ return static function (ContainerConfigurator $container): void {
         ->set(OptionDirective::class)
         ->set(PullQuoteDirective::class)
         ->set(RawDirective::class)
+        ->arg('$escapeRawNodes', param('phpdoc.guides.raw_node.escape'))
+        ->arg('$htmlSanitizerConfig', service('phpdoc.guides.raw_node.sanitizer.default'))
+
         ->set(ReplaceDirective::class)
         ->set(RoleDirective::class)
         ->set(SectionauthorDirective::class)

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/Attributes/Directive.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/Attributes/Directive.php
@@ -18,10 +18,19 @@ use Attribute;
 #[Attribute(Attribute::TARGET_CLASS)]
 final class Directive
 {
-    /** @param string[] $aliases */
+    /**
+     * @param string[] $aliases
+     * @param bool $rawContent If set, the directive's body is captured as literal
+     *     source text (DirectiveNode::getRawContent()) instead of being parsed into
+     *     child nodes -- for directives whose content isn't reStructuredText (e.g.
+     *     raw HTML/LaTeX passthrough). Parsing such content as RST would corrupt it
+     *     (e.g. a line that looks like a section title gets misinterpreted), so it's
+     *     skipped entirely rather than parsed and discarded.
+     */
     public function __construct(
         public readonly string $name,
         public readonly array $aliases = [],
+        public readonly bool $rawContent = false,
     ) {
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/BaseDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/BaseDirective.php
@@ -53,6 +53,8 @@ abstract class BaseDirective
     /** @var string[] */
     private array $aliases;
 
+    private bool $rawContent;
+
     /**
      * Get the directive name
      */
@@ -123,6 +125,28 @@ abstract class BaseDirective
         }
 
         return true;
+    }
+
+    /**
+     * Whether this directive's body should be captured as literal source text
+     * (DirectiveNode::getRawContent()) instead of being parsed into child nodes.
+     * Opted into via #[Directive(rawContent: true)] for directives whose content
+     * isn't reStructuredText.
+     *
+     * @internal
+     */
+    final public function usesRawContent(): bool
+    {
+        if (isset($this->rawContent)) {
+            return $this->rawContent;
+        }
+
+        $reflection = new ReflectionClass($this);
+        $attributes = $reflection->getAttributes(Attributes\Directive::class);
+
+        $this->rawContent = count($attributes) === 1 && $attributes[0]->newInstance()->rawContent;
+
+        return $this->rawContent;
     }
 
     /**

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/RawDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/RawDirective.php
@@ -19,13 +19,9 @@ use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\ParagraphNode;
 use phpDocumentor\Guides\Nodes\RawNode;
 use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
-use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
-use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
-
-use function implode;
 
 /**
  * Renders a raw block, example:
@@ -47,17 +43,6 @@ final class RawDirective extends BaseDirective
         HtmlSanitizerConfig $htmlSanitizerConfig,
     ) {
         $this->htmlSanitizer = new HtmlSanitizer($htmlSanitizerConfig);
-    }
-
-    /** {@inheritDoc} */
-    public function process(
-        BlockContext $blockContext,
-        Directive $directive,
-    ): Node {
-        return $this->createNode(new DirectiveNode(
-            $directive,
-            rawContent: implode("\n", $blockContext->getDocumentIterator()->toArray()),
-        ));
     }
 
     public function createNode(DirectiveNode $directiveNode): Node

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/RawDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/RawDirective.php
@@ -13,10 +13,17 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
+use phpDocumentor\Guides\Nodes\Inline\PlainTextInlineNode;
+use phpDocumentor\Guides\Nodes\InlineCompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\Nodes\ParagraphNode;
 use phpDocumentor\Guides\Nodes\RawNode;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
+use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
 
 use function implode;
 
@@ -29,11 +36,17 @@ use function implode;
  *
  * @link https://docutils.sourceforge.io/docs/ref/rst/directives.html#raw-data-pass-through
  */
+#[Attributes\Directive(name: 'raw', rawContent: true)]
 final class RawDirective extends BaseDirective
 {
-    public function getName(): string
-    {
-        return 'raw';
+    private readonly HtmlSanitizer $htmlSanitizer;
+
+    public function __construct(
+        private readonly bool $escapeRawNodes,
+        private readonly LoggerInterface $logger,
+        HtmlSanitizerConfig $htmlSanitizerConfig,
+    ) {
+        $this->htmlSanitizer = new HtmlSanitizer($htmlSanitizerConfig);
     }
 
     /** {@inheritDoc} */
@@ -41,9 +54,33 @@ final class RawDirective extends BaseDirective
         BlockContext $blockContext,
         Directive $directive,
     ): Node {
-        return new RawNode(
-            implode("\n", $blockContext->getDocumentIterator()->toArray()),
-            $directive->getData(),
+        return $this->createNode(new DirectiveNode(
+            $directive,
+            rawContent: implode("\n", $blockContext->getDocumentIterator()->toArray()),
+        ));
+    }
+
+    public function createNode(DirectiveNode $directiveNode): Node
+    {
+        $node = new RawNode(
+            $directiveNode->getRawContent(),
+            $directiveNode->getDirective()->getData(),
         );
+
+        // Escaping/sanitizing here (rather than in a NodeTransformer) is required:
+        // this directive's node is only created once DirectiveProcessPass resolves
+        // it during compile, by which point transformers that ran earlier in the
+        // pipeline (by priority) would never see the final RawNode to act on.
+        if ($this->escapeRawNodes) {
+            $this->logger->warning('We do not support plain HTML for security reasons. Escaping all HTML ');
+
+            return new ParagraphNode([new InlineCompoundNode([new PlainTextInlineNode($node->getValue())])]);
+        }
+
+        if ($node->getOption('format', 'html') === 'html') {
+            return new RawNode($this->htmlSanitizer->sanitize($node->getValue()));
+        }
+
+        return $node;
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Nodes/DirectiveNode.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Nodes/DirectiveNode.php
@@ -22,9 +22,18 @@ final class DirectiveNode extends CompoundNode
 {
     private DirectiveSourceLocation $sourceLocation;
 
-    /** @param Node[] $children */
-    public function __construct(private readonly Directive $directive, array $children = [])
-    {
+    /**
+     * @param Node[] $children
+     * @param string $rawContent the directive's content exactly as written, before
+     *     it was parsed into $children -- available to createNode() for directives
+     *     that need the literal source text (e.g. raw passthrough) rather than (or
+     *     alongside) the parsed node tree
+     */
+    public function __construct(
+        private readonly Directive $directive,
+        array $children = [],
+        private readonly string $rawContent = '',
+    ) {
         parent::__construct($children);
 
         $this->sourceLocation = new DirectiveSourceLocation();
@@ -48,5 +57,10 @@ final class DirectiveNode extends CompoundNode
     public function getSourceLocation(): DirectiveSourceLocation
     {
         return $this->sourceLocation;
+    }
+
+    public function getRawContent(): string
+    {
+        return $this->rawContent;
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
@@ -96,14 +96,20 @@ final class DirectiveRule implements Rule
         $buffer = $this->collectDirectiveContents($documentIterator);
 
         if ($this->startingRule !== null && $directiveHandler->isUpgraded()) {
-            $subBlockContext = new BlockContext($blockContext->getDocumentParserContext(), $buffer->getLinesString(), true, $documentIterator->key());
-            $directiveNode = new DirectiveNode($directive);
-            $node = $this->startingRule->apply($subBlockContext, $directiveNode);
-            // Captured only after the sub-parse has fully consumed $subBlockContext's
-            // content, matching what a directive's own logging call would have seen
-            // under the old (non-upgraded) dispatch, where content is always parsed
-            // before the directive's own code runs.
-            $directiveNode->setSourceLocation(DirectiveSourceLocation::fromLoggerInformation($subBlockContext->getLoggerInformation()));
+            $rawContent = $buffer->getLinesString();
+
+            if ($directiveHandler->usesRawContent()) {
+                $node = new DirectiveNode($directive, rawContent: $rawContent);
+            } else {
+                $subBlockContext = new BlockContext($blockContext->getDocumentParserContext(), $rawContent, true, $documentIterator->key());
+                $directiveNode = new DirectiveNode($directive, rawContent: $rawContent);
+                $node = $this->startingRule->apply($subBlockContext, $directiveNode);
+                // Captured only after the sub-parse has fully consumed $subBlockContext's
+                // content, matching what a directive's own logging call would have seen
+                // under the old (non-upgraded) dispatch, where content is always parsed
+                // before the directive's own code runs.
+                $directiveNode->setSourceLocation(DirectiveSourceLocation::fromLoggerInformation($subBlockContext->getLoggerInformation()));
+            }
 
             if ($node === null) {
                 return null;

--- a/packages/guides/src/DependencyInjection/GuidesExtension.php
+++ b/packages/guides/src/DependencyInjection/GuidesExtension.php
@@ -408,6 +408,20 @@ final class GuidesExtension extends Extension implements CompilerPassInterface, 
         (new ParserRulesPass())->process($container);
         (new NodeRendererPass())->process($container);
         (new RendererPass())->process($container);
+
+        // Guarded because this core package must not depend on
+        // guides-restructured-text, and its RawDirective service is only
+        // registered once that package's own extension has loaded.
+        $rawDirectiveId = 'phpDocumentor\\Guides\\RestructuredText\\Directives\\RawDirective';
+        if (!$container->hasParameter('phpdoc.guides.raw_node.sanitizer_name') || !$container->hasDefinition($rawDirectiveId)) {
+            return;
+        }
+
+        $sanitizerName = $container->getParameter('phpdoc.guides.raw_node.sanitizer_name');
+        assert(is_string($sanitizerName));
+
+        $container->getDefinition($rawDirectiveId)
+            ->setArgument('$htmlSanitizerConfig', new Reference('phpdoc.guides.raw_node.sanitizer.' . $sanitizerName));
     }
 
     /** @param mixed[] $config */
@@ -438,9 +452,17 @@ final class GuidesExtension extends Extension implements CompilerPassInterface, 
     /** @param array<string, mixed> $rawNodeConfig */
     private function configureSanitizers(array $rawNodeConfig, ContainerBuilder $container): void
     {
-        if ($rawNodeConfig['sanitizer_name'] ?? false) {
+        $sanitizerName = $rawNodeConfig['sanitizer_name'] ?? false;
+        if (is_string($sanitizerName) && $sanitizerName !== '') {
             $container->getDefinition(RawNodeEscapeTransformer::class)
-                ->setArgument('$htmlSanitizerConfig', new Reference('phpdoc.guides.raw_node.sanitizer.' . $rawNodeConfig['sanitizer_name']));
+                ->setArgument('$htmlSanitizerConfig', new Reference('phpdoc.guides.raw_node.sanitizer.' . $sanitizerName));
+
+            // Stored for process(): guides-restructured-text's RawDirective (which
+            // registers its own service after this extension's load() runs) needs
+            // the same override, since RawDirective's node is only created at
+            // compile time -- too late for RawNodeEscapeTransformer to act on it.
+            // See #1378.
+            $container->setParameter('phpdoc.guides.raw_node.sanitizer_name', $sanitizerName);
         }
 
         if (!is_array($rawNodeConfig['sanitizers'] ?? false)) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -325,12 +325,6 @@ parameters:
 			path: packages/guides/src/DependencyInjection/GuidesExtension.php
 
 		-
-			message: '#^Binary operation "\." between ''phpdoc\.guides\.raw…'' and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: packages/guides/src/DependencyInjection/GuidesExtension.php
-
-		-
 			message: '#^Cannot access an offset on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 2


### PR DESCRIPTION
[FEATURE] Give #[Directive] a rawContent option, migrate RawDirective

DirectiveNode now captures the directive's body as literal source
text, and #[Directive(rawContent: true)] skips RST-parsing it --
non-RST content (e.g. raw HTML) gets corrupted by the RST parser even
when the result is discarded. Stays on the real createNode() model
per jaapio's feedback on #1380.

Migrates RawDirective using this, including its sanitizer -- another
#1378 ordering case. RawNodeEscapeTransformer is left untouched and
still needed: it's the only sanitizer for RawNode's two other
producers (AuthorsFieldListItemRule, markdown's HtmlParser), which
aren't affected since they never go through DirectiveProcessPass.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PP4LkejR5PSubbhNmF4RkT
Signed-off-by: lina.wolf