### PR TITLE
[FEATURE] Give DirectiveNode logger info, migrate logging directives

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ConfigurationBlockDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ConfigurationBlockDirective.php
@@ -18,8 +18,7 @@ use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\Configuration\ConfigurationBlockNode;
 use phpDocumentor\Guides\Nodes\Configuration\ConfigurationTab;
 use phpDocumentor\Guides\Nodes\Node;
-use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
-use phpDocumentor\Guides\RestructuredText\Parser\Directive;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\String\Slugger\AsciiSlugger;
@@ -29,6 +28,7 @@ use function assert;
 use function get_debug_type;
 use function sprintf;
 
+#[Attributes\Directive(name: 'configuration-block')]
 final class ConfigurationBlockDirective extends SubDirective
 {
     private SluggerInterface $slugger;
@@ -47,22 +47,14 @@ final class ConfigurationBlockDirective extends SubDirective
         $this->slugger = new AsciiSlugger();
     }
 
-    public function getName(): string
+    public function createNode(DirectiveNode $directiveNode): Node
     {
-        return 'configuration-block';
-    }
-
-    protected function processSub(
-        BlockContext $blockContext,
-        CollectionNode $collectionNode,
-        Directive $directive,
-    ): Node {
         $tabs = [];
-        foreach ($collectionNode->getValue() as $child) {
+        foreach ($directiveNode->getChildren() as $child) {
             if (!$child instanceof CodeNode) {
                 $this->logger->warning(
                     sprintf('The ".. configuration-block::" directive only supports code blocks, "%s" given.', get_debug_type($child)),
-                    $blockContext->getLoggerInformation(),
+                    $directiveNode->getLoggerInformation(),
                 );
 
                 continue;

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/ConfigurationBlockDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/ConfigurationBlockDirective.php
@@ -54,7 +54,7 @@ final class ConfigurationBlockDirective extends SubDirective
             if (!$child instanceof CodeNode) {
                 $this->logger->warning(
                     sprintf('The ".. configuration-block::" directive only supports code blocks, "%s" given.', get_debug_type($child)),
-                    $directiveNode->getLoggerInformation(),
+                    $directiveNode->getSourceLocation()->toLoggerInformation(),
                 );
 
                 continue;

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/SectionauthorDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/SectionauthorDirective.php
@@ -42,13 +42,13 @@ final class SectionauthorDirective extends BaseDirective
         $input = $directive->getData();
         $directiveName = $directive->getName();
         if ($input === '') {
-            $this->logger->warning('`.. ' . $directiveName . ' ::` directive could not be parsed: `' . $input . '`', $directiveNode->getLoggerInformation());
+            $this->logger->warning('`.. ' . $directiveName . ' ::` directive could not be parsed: `' . $input . '`', $directiveNode->getSourceLocation()->toLoggerInformation());
 
             return null;
         }
 
         if (!preg_match(self::NAME_EMAIL_REGEX, $input, $matches)) {
-            $this->logger->warning('Content of `.. ' . $directiveName . ':: name <email>` must specify a name and can also specify an email', $directiveNode->getLoggerInformation());
+            $this->logger->warning('Content of `.. ' . $directiveName . ':: name <email>` must specify a name and can also specify an email', $directiveNode->getSourceLocation()->toLoggerInformation());
 
             return null;
         }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/SectionauthorDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/SectionauthorDirective.php
@@ -15,12 +15,17 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 use phpDocumentor\Guides\Nodes\AuthorNode;
 use phpDocumentor\Guides\Nodes\Node;
-use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
-use phpDocumentor\Guides\RestructuredText\Parser\Directive;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use Psr\Log\LoggerInterface;
 
 use function preg_match;
 
+/**
+ * When the default domain contains a class directive, this directive will be shadowed. Therefore, Sphinx re-exports it as rst-class.
+ *
+ * See https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#rstclass
+ */
+#[Attributes\Directive(name: 'sectionauthor', aliases: ['codeauthor'])]
 final class SectionauthorDirective extends BaseDirective
 {
     /** @see https://regex101.com/r/vGy4Uu/1 */
@@ -31,41 +36,19 @@ final class SectionauthorDirective extends BaseDirective
     ) {
     }
 
-    public function getName(): string
+    public function createNode(DirectiveNode $directiveNode): Node|null
     {
-        return 'sectionauthor';
-    }
-
-    /**
-     * When the default domain contains a class directive, this directive will be shadowed. Therefore, Sphinx re-exports it as rst-class.
-     *
-     * See https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#rstclass
-     *
-     * @return string[]
-     */
-    public function getAliases(): array
-    {
-        return ['codeauthor'];
-    }
-
-    /** {@inheritDoc}
-     *
-     * @param Directive $directive
-     */
-    public function process(
-        BlockContext $blockContext,
-        Directive $directive,
-    ): Node|null {
+        $directive = $directiveNode->getDirective();
         $input = $directive->getData();
         $directiveName = $directive->getName();
         if ($input === '') {
-            $this->logger->warning('`.. ' . $directiveName . ' ::` directive could not be parsed: `' . $input . '`', $blockContext->getLoggerInformation());
+            $this->logger->warning('`.. ' . $directiveName . ' ::` directive could not be parsed: `' . $input . '`', $directiveNode->getLoggerInformation());
 
             return null;
         }
 
         if (!preg_match(self::NAME_EMAIL_REGEX, $input, $matches)) {
-            $this->logger->warning('Content of `.. ' . $directiveName . ':: name <email>` must specify a name and can also specify an email', $blockContext->getLoggerInformation());
+            $this->logger->warning('Content of `.. ' . $directiveName . ':: name <email>` must specify a name and can also specify an email', $directiveNode->getLoggerInformation());
 
             return null;
         }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/TabDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/TabDirective.php
@@ -13,12 +13,10 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
-use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\InlineCompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Nodes\TabNode;
-use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
-use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 
 use function class_alias;
 use function class_exists;
@@ -27,22 +25,13 @@ use function preg_replace;
 use function str_replace;
 use function strtolower;
 
+#[Attributes\Directive(name: 'tab')]
 final class TabDirective extends SubDirective
 {
-    public function getName(): string
+    public function createNode(DirectiveNode $directiveNode): Node
     {
-        return 'tab';
-    }
+        $directive = $directiveNode->getDirective();
 
-    /** {@inheritDoc}
-     *
-     * @param Directive $directive
-     */
-    protected function processSub(
-        BlockContext $blockContext,
-        CollectionNode $collectionNode,
-        Directive $directive,
-    ): Node {
         if (is_string($directive->getOption('key')->getValue())) {
             $key = strtolower($directive->getOption('key')->getValue());
         } else {
@@ -59,7 +48,7 @@ final class TabDirective extends SubDirective
             $directive->getDataNode() ?? new InlineCompoundNode(),
             $key,
             $active,
-            $collectionNode->getChildren(),
+            $directiveNode->getChildren(),
         );
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/TabsDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/TabsDirective.php
@@ -61,7 +61,7 @@ final class TabsDirective extends SubDirective
             } else {
                 $this->logger->warning(
                     'The "tabs" directive may only contain children of type "tab". The following node was found: ' . $child::class,
-                    $directiveNode->getLoggerInformation(),
+                    $directiveNode->getSourceLocation()->toLoggerInformation(),
                 );
             }
         }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/TabsDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/TabsDirective.php
@@ -18,9 +18,8 @@ use phpDocumentor\Guides\Nodes\InlineCompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\ReferenceResolvers\AnchorNormalizer;
 use phpDocumentor\Guides\RestructuredText\Nodes\AbstractTabNode;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Nodes\TabsNode;
-use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
-use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
 use Psr\Log\LoggerInterface;
 
@@ -28,6 +27,7 @@ use function class_alias;
 use function class_exists;
 use function is_string;
 
+#[Attributes\Directive(name: 'tabs')]
 final class TabsDirective extends SubDirective
 {
     private int $tabsCounter = 0;
@@ -41,23 +41,12 @@ final class TabsDirective extends SubDirective
         parent::__construct($startingRule);
     }
 
-    public function getName(): string
+    public function createNode(DirectiveNode $directiveNode): Node
     {
-        return 'tabs';
-    }
-
-    /** {@inheritDoc}
-     *
-     * @param Directive $directive
-     */
-    protected function processSub(
-        BlockContext $blockContext,
-        CollectionNode $collectionNode,
-        Directive $directive,
-    ): Node {
+        $directive = $directiveNode->getDirective();
         $tabs = [];
         $hasActive = false;
-        foreach ($collectionNode->getChildren() as $child) {
+        foreach ($directiveNode->getChildren() as $child) {
             if ($child instanceof AbstractTabNode) {
                 if ($child->isActive()) {
                     if (!$hasActive) {
@@ -72,7 +61,7 @@ final class TabsDirective extends SubDirective
             } else {
                 $this->logger->warning(
                     'The "tabs" directive may only contain children of type "tab". The following node was found: ' . $child::class,
-                    $blockContext->getLoggerInformation(),
+                    $directiveNode->getLoggerInformation(),
                 );
             }
         }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/TestLoggerDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/TestLoggerDirective.php
@@ -13,11 +13,9 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Guides\RestructuredText\Directives;
 
-use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Nodes\ContainerNode;
-use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
-use phpDocumentor\Guides\RestructuredText\Parser\Directive;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
 use Psr\Log\LoggerInterface;
 
@@ -26,6 +24,7 @@ use Psr\Log\LoggerInterface;
  *
  * @link https://docutils.sourceforge.io/docs/ref/rst/directives.html#container
  */
+#[Attributes\Directive(name: 'testlogger')]
 final class TestLoggerDirective extends SubDirective
 {
     public function __construct(
@@ -35,22 +34,11 @@ final class TestLoggerDirective extends SubDirective
         parent::__construct($startingRule);
     }
 
-    public function getName(): string
+    public function createNode(DirectiveNode $directiveNode): Node
     {
-        return 'testlogger';
-    }
+        $this->logger->warning('Test logging in directives', $directiveNode->getLoggerInformation());
 
-    /** {@inheritDoc}
-     *
-     * @param Directive $directive
-     */
-    protected function processSub(
-        BlockContext $blockContext,
-        CollectionNode $collectionNode,
-        Directive $directive,
-    ): Node {
-        $this->logger->warning('Test logging in directives', $blockContext->getLoggerInformation());
-
-        return (new ContainerNode($collectionNode->getChildren()))->withOptions(['class' => $directive->getData()]);
+        return (new ContainerNode($directiveNode->getChildren()))
+            ->withOptions(['class' => $directiveNode->getDirective()->getData()]);
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/TestLoggerDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/TestLoggerDirective.php
@@ -36,7 +36,7 @@ final class TestLoggerDirective extends SubDirective
 
     public function createNode(DirectiveNode $directiveNode): Node
     {
-        $this->logger->warning('Test logging in directives', $directiveNode->getLoggerInformation());
+        $this->logger->warning('Test logging in directives', $directiveNode->getSourceLocation()->toLoggerInformation());
 
         return (new ContainerNode($directiveNode->getChildren()))
             ->withOptions(['class' => $directiveNode->getDirective()->getData()]);

--- a/packages/guides-restructured-text/src/RestructuredText/Nodes/DirectiveNode.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Nodes/DirectiveNode.php
@@ -20,6 +20,9 @@ use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 /** @extends CompoundNode<Node> */
 final class DirectiveNode extends CompoundNode
 {
+    /** @var array<string, int|string> */
+    private array $loggerInformation = [];
+
     /** @param Node[] $children */
     public function __construct(private readonly Directive $directive, array $children = [])
     {
@@ -29,5 +32,24 @@ final class DirectiveNode extends CompoundNode
     public function getDirective(): Directive
     {
         return $this->directive;
+    }
+
+    /**
+     * Source location info (file, line), set once the directive's content has
+     * been fully parsed -- available to createNode() for directives that need
+     * to log a warning about their own content, since createNode() itself has
+     * no access to BlockContext.
+     *
+     * @param array<string, int|string> $loggerInformation
+     */
+    public function setLoggerInformation(array $loggerInformation): void
+    {
+        $this->loggerInformation = $loggerInformation;
+    }
+
+    /** @return array<string, int|string> */
+    public function getLoggerInformation(): array
+    {
+        return $this->loggerInformation;
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Nodes/DirectiveNode.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Nodes/DirectiveNode.php
@@ -20,13 +20,14 @@ use phpDocumentor\Guides\RestructuredText\Parser\Directive;
 /** @extends CompoundNode<Node> */
 final class DirectiveNode extends CompoundNode
 {
-    /** @var array<string, int|string> */
-    private array $loggerInformation = [];
+    private DirectiveSourceLocation $sourceLocation;
 
     /** @param Node[] $children */
     public function __construct(private readonly Directive $directive, array $children = [])
     {
         parent::__construct($children);
+
+        $this->sourceLocation = new DirectiveSourceLocation();
     }
 
     public function getDirective(): Directive
@@ -35,21 +36,17 @@ final class DirectiveNode extends CompoundNode
     }
 
     /**
-     * Source location info (file, line), set once the directive's content has
-     * been fully parsed -- available to createNode() for directives that need
-     * to log a warning about their own content, since createNode() itself has
-     * no access to BlockContext.
-     *
-     * @param array<string, int|string> $loggerInformation
+     * Set once the directive's content has been fully parsed -- available to
+     * createNode() for directives that need to log a warning about their own
+     * content, since createNode() itself has no access to BlockContext.
      */
-    public function setLoggerInformation(array $loggerInformation): void
+    public function setSourceLocation(DirectiveSourceLocation $sourceLocation): void
     {
-        $this->loggerInformation = $loggerInformation;
+        $this->sourceLocation = $sourceLocation;
     }
 
-    /** @return array<string, int|string> */
-    public function getLoggerInformation(): array
+    public function getSourceLocation(): DirectiveSourceLocation
     {
-        return $this->loggerInformation;
+        return $this->sourceLocation;
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Nodes/DirectiveSourceLocation.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Nodes/DirectiveSourceLocation.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link https://phpdoc.org
+ */
+
+namespace phpDocumentor\Guides\RestructuredText\Nodes;
+
+use function is_int;
+use function is_string;
+
+/**
+ * Where in the source a directive was written, for logging. Built from the
+ * project-wide "logger information" convention (BlockContext,
+ * DocumentParserContext, ParserContext, DocumentNode, ...), which is a plain
+ * array by necessity -- it ultimately feeds PSR-3's LoggerInterface, whose
+ * $context parameter is a plain array -- but that leaves a directive with no
+ * indication of which keys actually exist. This narrows it to the three keys
+ * that convention ever actually sets.
+ */
+final class DirectiveSourceLocation
+{
+    public function __construct(
+        public readonly string|null $file = null,
+        public readonly int|null $lineNumber = null,
+        public readonly string|null $currentLine = null,
+    ) {
+    }
+
+    /** @param array<string, int|string> $loggerInformation */
+    public static function fromLoggerInformation(array $loggerInformation): self
+    {
+        $file = $loggerInformation['rst-file'] ?? null;
+        $lineNumber = $loggerInformation['currentLineNumber'] ?? null;
+        $currentLine = $loggerInformation['currentLine'] ?? null;
+
+        return new self(
+            is_string($file) ? $file : null,
+            is_int($lineNumber) ? $lineNumber : null,
+            is_string($currentLine) ? $currentLine : null,
+        );
+    }
+
+    /**
+     * The plain array PSR-3's LoggerInterface::warning()/error() expects as
+     * $context.
+     *
+     * @return array<string, int|string>
+     */
+    public function toLoggerInformation(): array
+    {
+        $info = [];
+        if ($this->file !== null) {
+            $info['rst-file'] = $this->file;
+        }
+
+        if ($this->lineNumber !== null) {
+            $info['currentLineNumber'] = $this->lineNumber;
+        }
+
+        if ($this->currentLine !== null) {
+            $info['currentLine'] = $this->currentLine;
+        }
+
+        return $info;
+    }
+}

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
@@ -95,10 +95,14 @@ final class DirectiveRule implements Rule
         $buffer = $this->collectDirectiveContents($documentIterator);
 
         if ($this->startingRule !== null && $directiveHandler->isUpgraded()) {
-            $node = $this->startingRule->apply(
-                new BlockContext($blockContext->getDocumentParserContext(), $buffer->getLinesString(), true, $documentIterator->key()),
-                new DirectiveNode($directive),
-            );
+            $subBlockContext = new BlockContext($blockContext->getDocumentParserContext(), $buffer->getLinesString(), true, $documentIterator->key());
+            $directiveNode = new DirectiveNode($directive);
+            $node = $this->startingRule->apply($subBlockContext, $directiveNode);
+            // Captured only after the sub-parse has fully consumed $subBlockContext's
+            // content, matching what a directive's own logging call would have seen
+            // under the old (non-upgraded) dispatch, where content is always parsed
+            // before the directive's own code runs.
+            $directiveNode->setLoggerInformation($subBlockContext->getLoggerInformation());
 
             if ($node === null) {
                 return null;

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
@@ -19,6 +19,7 @@ use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\RestructuredText\Directives\BaseDirective as DirectiveHandler;
 use phpDocumentor\Guides\RestructuredText\Directives\GeneralDirective;
 use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveSourceLocation;
 use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
 use phpDocumentor\Guides\RestructuredText\Parser\Buffer;
 use phpDocumentor\Guides\RestructuredText\Parser\Directive;
@@ -102,7 +103,7 @@ final class DirectiveRule implements Rule
             // content, matching what a directive's own logging call would have seen
             // under the old (non-upgraded) dispatch, where content is always parsed
             // before the directive's own code runs.
-            $directiveNode->setLoggerInformation($subBlockContext->getLoggerInformation());
+            $directiveNode->setSourceLocation(DirectiveSourceLocation::fromLoggerInformation($subBlockContext->getLoggerInformation()));
 
             if ($node === null) {
                 return null;


### PR DESCRIPTION
[FEATURE] Give DirectiveNode logger info, migrate logging directives

Part of the #1373 directive migration: TestLoggerDirective,
SectionauthorDirective, ConfigurationBlockDirective, and
TabsDirective/TabDirective couldn't move to the #[Directive] model
because they need live parser access to log a warning with file/line
context, which createNode() doesn't have -- one of the blockers found
in #1378. DirectiveNode now carries that context, captured once its
content is fully parsed (matching what the old dispatch would have
seen -- captured earlier gave a wrong line number), removing the
blocker for this class of directive.

TabsDirective and TabDirective are migrated together: migrating
TabDirective alone previously broke tabs_html, since TabsDirective
inspects its children's concrete type and only resolves correctly
once both are on the compile-time model together.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PP4LkejR5PSubbhNmF4RkT
Signed-off-by: lina.wolf