### PR TITLE
[TASK] Ignore deptrac's local analysis cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /output/
 /build/
 /.phpdoc/
+/.deptrac.cache


### PR DESCRIPTION
PR #306 originally gitignored .deptrac.cache when it introduced
deptrac. PR #638 later consolidated dev-tool caches into /.cache but
dropped the deptrac-specific entry without actually moving deptrac's
cache there (it has no built-in support for that path) -- leaving
.deptrac.cache unignored ever since.

Signed-off-by: lina.wolf
Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>