### PR TITLE
[TASK] Migrate directives unblocked by the logger-info fix

### DIFF
--- a/packages/guides-restructured-text/src/RestructuredText/Directives/LaTeXMain.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/LaTeXMain.php
@@ -15,24 +15,16 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 
 use phpDocumentor\Guides\Nodes\MainNode;
 use phpDocumentor\Guides\Nodes\Node;
-use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
-use phpDocumentor\Guides\RestructuredText\Parser\Directive;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 
 /**
  * Marks the document as LaTeX main
  */
+#[Attributes\Directive(name: 'latex-main')]
 final class LaTeXMain extends BaseDirective
 {
-    public function getName(): string
+    public function createNode(DirectiveNode $directiveNode): Node
     {
-        return 'latex-main';
-    }
-
-    /** {@inheritDoc} */
-    public function processNode(
-        BlockContext $blockContext,
-        Directive $directive,
-    ): Node {
-        return new MainNode($directive->getData());
+        return new MainNode($directiveNode->getDirective()->getData());
     }
 }

--- a/packages/guides-restructured-text/src/RestructuredText/Directives/TableDirective.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Directives/TableDirective.php
@@ -16,8 +16,7 @@ namespace phpDocumentor\Guides\RestructuredText\Directives;
 use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\Node;
 use phpDocumentor\Guides\Nodes\TableNode;
-use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
-use phpDocumentor\Guides\RestructuredText\Parser\Directive;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
 use Psr\Log\LoggerInterface;
 
@@ -43,6 +42,7 @@ use function strval;
  *     | Row 2, Column 1 | Row 2, Column 2 |
  *     +-----------------+-----------------+
  */
+#[Attributes\Directive(name: 'table')]
 final class TableDirective extends SubDirective
 {
     public function __construct(
@@ -52,34 +52,28 @@ final class TableDirective extends SubDirective
         parent::__construct($startingRule);
     }
 
-    public function getName(): string
+    public function createNode(DirectiveNode $directiveNode): Node
     {
-        return 'table';
-    }
+        $directive = $directiveNode->getDirective();
+        $children = $directiveNode->getChildren();
 
-    /** {@inheritDoc} */
-    protected function processSub(
-        BlockContext $blockContext,
-        CollectionNode $collectionNode,
-        Directive $directive,
-    ): Node {
-        if (count($collectionNode->getChildren()) !== 1) {
+        if (count($children) !== 1) {
             $this->logger->warning(
-                sprintf('The table directive may contain exactly one table. %s children found', count($collectionNode->getChildren())),
-                $blockContext->getLoggerInformation(),
+                sprintf('The table directive may contain exactly one table. %s children found', count($children)),
+                $directiveNode->getSourceLocation()->toLoggerInformation(),
             );
 
-            return $collectionNode;
+            return new CollectionNode($children);
         }
 
-        $tableNode = $collectionNode->getChildren()[0];
+        $tableNode = $children[0];
         if (!$tableNode instanceof TableNode) {
             $this->logger->warning(
                 sprintf('The table directive may contain exactly one table. A node of type %s was found. ', $tableNode::class),
-                $blockContext->getLoggerInformation(),
+                $directiveNode->getSourceLocation()->toLoggerInformation(),
             );
 
-            return $collectionNode;
+            return new CollectionNode($children);
         }
 
         $options = $this->optionsToArray($directive->getOptions());

--- a/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
+++ b/packages/guides-restructured-text/src/RestructuredText/Parser/Productions/DirectiveRule.php
@@ -99,7 +99,11 @@ final class DirectiveRule implements Rule
             $rawContent = $buffer->getLinesString();
 
             if ($directiveHandler->usesRawContent()) {
-                $node = new DirectiveNode($directive, rawContent: $rawContent);
+                $directiveNode = new DirectiveNode($directive, rawContent: $rawContent);
+                $directiveNode->setSourceLocation(DirectiveSourceLocation::fromLoggerInformation(
+                    (new BlockContext($blockContext->getDocumentParserContext(), $rawContent, true, $documentIterator->key()))->getLoggerInformation(),
+                ));
+                $node = $directiveNode;
             } else {
                 $subBlockContext = new BlockContext($blockContext->getDocumentParserContext(), $rawContent, true, $documentIterator->key());
                 $directiveNode = new DirectiveNode($directive, rawContent: $rawContent);

--- a/packages/guides-theme-bootstrap/src/Bootstrap/Directives/AccordionDirective.php
+++ b/packages/guides-theme-bootstrap/src/Bootstrap/Directives/AccordionDirective.php
@@ -15,15 +15,15 @@ namespace phpDocumentor\Guides\Bootstrap\Directives;
 
 use phpDocumentor\Guides\Bootstrap\Nodes\AccordionItemNode;
 use phpDocumentor\Guides\Bootstrap\Nodes\AccordionNode;
-use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\InlineCompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Directives\Attributes\Directive;
 use phpDocumentor\Guides\RestructuredText\Directives\SubDirective;
-use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
-use phpDocumentor\Guides\RestructuredText\Parser\Directive;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
 use Psr\Log\LoggerInterface;
 
+#[Directive(name: 'accordion')]
 class AccordionDirective extends SubDirective
 {
     public const NAME = 'accordion';
@@ -35,30 +35,23 @@ class AccordionDirective extends SubDirective
         parent::__construct($startingRule);
     }
 
-    public function getName(): string
+    public function createNode(DirectiveNode $directiveNode): Node
     {
-        return self::NAME;
-    }
+        $directive = $directiveNode->getDirective();
 
-    protected function processSub(
-        BlockContext $blockContext,
-        CollectionNode $collectionNode,
-        Directive $directive,
-    ): Node|null {
-        $originalChildren = $collectionNode->getChildren();
         $children = [];
-        foreach ($originalChildren as $child) {
+        foreach ($directiveNode->getChildren() as $child) {
             if ($child instanceof AccordionItemNode) {
                 $children[] = $child;
             } else {
-                $this->logger->warning('An accordion may only accordion-items. ', $blockContext->getLoggerInformation());
+                $this->logger->warning('An accordion may only accordion-items. ', $directiveNode->getSourceLocation()->toLoggerInformation());
             }
         }
 
         $id = $directive->getOption('name')->toString();
         if ($id === '') {
             $id = 'accordion';
-            $this->logger->warning('An accordion must have a unique name as parameter. ', $blockContext->getLoggerInformation());
+            $this->logger->warning('An accordion must have a unique name as parameter. ', $directiveNode->getSourceLocation()->toLoggerInformation());
         }
 
         return new AccordionNode(

--- a/packages/guides-theme-bootstrap/src/Bootstrap/Directives/CardGridDirective.php
+++ b/packages/guides-theme-bootstrap/src/Bootstrap/Directives/CardGridDirective.php
@@ -15,17 +15,17 @@ namespace phpDocumentor\Guides\Bootstrap\Directives;
 
 use phpDocumentor\Guides\Bootstrap\Nodes\CardGridNode;
 use phpDocumentor\Guides\Bootstrap\Nodes\CardNode;
-use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\InlineCompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Directives\Attributes\Directive;
 use phpDocumentor\Guides\RestructuredText\Directives\SubDirective;
-use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
-use phpDocumentor\Guides\RestructuredText\Parser\Directive;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
 use Psr\Log\LoggerInterface;
 
 use function intval;
 
+#[Directive(name: 'card-grid')]
 class CardGridDirective extends SubDirective
 {
     public function __construct(
@@ -35,28 +35,20 @@ class CardGridDirective extends SubDirective
         parent::__construct($startingRule);
     }
 
-    public function getName(): string
+    public function createNode(DirectiveNode $directiveNode): Node
     {
-        return 'card-grid';
-    }
+        $directive = $directiveNode->getDirective();
 
-    protected function processSub(
-        BlockContext $blockContext,
-        CollectionNode $collectionNode,
-        Directive $directive,
-    ): Node|null {
-        $title = null;
-        $originalChildren = $collectionNode->getChildren();
         $children = [];
         $cardHeight = intval($directive->getOption('card-height')->getValue());
-        foreach ($originalChildren as $child) {
+        foreach ($directiveNode->getChildren() as $child) {
             if ($child instanceof CardNode) {
                 $children[] = $child;
                 if ($cardHeight > 0) {
                     $child->setCardHeight($cardHeight);
                 }
             } else {
-                $this->logger->warning('A card-grid may only contain cards. ', $blockContext->getLoggerInformation());
+                $this->logger->warning('A card-grid may only contain cards. ', $directiveNode->getSourceLocation()->toLoggerInformation());
             }
         }
 

--- a/packages/guides-theme-bootstrap/src/Bootstrap/Directives/CardGroupDirective.php
+++ b/packages/guides-theme-bootstrap/src/Bootstrap/Directives/CardGroupDirective.php
@@ -15,15 +15,15 @@ namespace phpDocumentor\Guides\Bootstrap\Directives;
 
 use phpDocumentor\Guides\Bootstrap\Nodes\CardGroupNode;
 use phpDocumentor\Guides\Bootstrap\Nodes\CardNode;
-use phpDocumentor\Guides\Nodes\CollectionNode;
 use phpDocumentor\Guides\Nodes\InlineCompoundNode;
 use phpDocumentor\Guides\Nodes\Node;
+use phpDocumentor\Guides\RestructuredText\Directives\Attributes\Directive;
 use phpDocumentor\Guides\RestructuredText\Directives\SubDirective;
-use phpDocumentor\Guides\RestructuredText\Parser\BlockContext;
-use phpDocumentor\Guides\RestructuredText\Parser\Directive;
+use phpDocumentor\Guides\RestructuredText\Nodes\DirectiveNode;
 use phpDocumentor\Guides\RestructuredText\Parser\Productions\Rule;
 use Psr\Log\LoggerInterface;
 
+#[Directive(name: 'card-group')]
 class CardGroupDirective extends SubDirective
 {
     public function __construct(
@@ -33,24 +33,16 @@ class CardGroupDirective extends SubDirective
         parent::__construct($startingRule);
     }
 
-    public function getName(): string
+    public function createNode(DirectiveNode $directiveNode): Node
     {
-        return 'card-group';
-    }
+        $directive = $directiveNode->getDirective();
 
-    protected function processSub(
-        BlockContext $blockContext,
-        CollectionNode $collectionNode,
-        Directive $directive,
-    ): Node|null {
-        $title = null;
-        $originalChildren = $collectionNode->getChildren();
         $children = [];
-        foreach ($originalChildren as $child) {
+        foreach ($directiveNode->getChildren() as $child) {
             if ($child instanceof CardNode) {
                 $children[] = $child;
             } else {
-                $this->logger->warning('A card-group may only contain cards. ', $blockContext->getLoggerInformation());
+                $this->logger->warning('A card-group may only contain cards. ', $directiveNode->getSourceLocation()->toLoggerInformation());
             }
         }
 


### PR DESCRIPTION
Continues the #1373 migration now that #1383 landed. Migrates the
directives that don't hit #1378's known ordering hazards -- Card
Group/Grid, Accordion, Table, LaTeXMain.

Card, AccordionItem, CardHeader/Image/Footer, and ListTable turned
out to be blocked by two ordering hazards #1378 didn't cover; filed
as a comment there rather than migrated.

Stacked on #1388: this batch needed a directive's `:class:` option
applied generically the way the old dispatch's postProcessNode()
always did, which #1388 fixes underneath this branch.

Signed-off-by: linawolf
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PP4LkejR5PSubbhNmF4RkT